### PR TITLE
Injectable `runTurn`, websocket-backed CLI flow, and test stabilization

### DIFF
--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -17,11 +17,13 @@ export type ServerEvent =
       sessionId: string;
       config: Pick<AgentConfig, "provider" | "model" | "workingDirectory" | "outputDirectory">;
     }
+  | { type: "session_busy"; sessionId: string; busy: boolean }
   | { type: "user_message"; sessionId: string; text: string; clientMessageId?: string }
   | { type: "assistant_message"; sessionId: string; text: string }
   | { type: "reasoning"; sessionId: string; kind: "reasoning" | "summary"; text: string }
   | { type: "log"; sessionId: string; line: string }
   | { type: "todos"; sessionId: string; todos: TodoItem[] }
+  | { type: "reset_done"; sessionId: string }
   | { type: "ask"; sessionId: string; requestId: string; question: string; options?: string[] }
   | {
       type: "approval";

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -8,6 +8,7 @@ export type ClientMessage =
   | { type: "approval_response"; sessionId: string; requestId: string; approved: boolean }
   | { type: "connect_provider"; sessionId: string; provider: AgentConfig["provider"]; apiKey?: string }
   | { type: "set_model"; sessionId: string; model: string; provider?: AgentConfig["provider"] }
+  | { type: "list_tools"; sessionId: string }
   | { type: "reset"; sessionId: string };
 
 export type ServerEvent =
@@ -34,6 +35,7 @@ export type ServerEvent =
       sessionId: string;
       config: Pick<AgentConfig, "provider" | "model" | "workingDirectory" | "outputDirectory">;
     }
+  | { type: "tools"; sessionId: string; tools: string[] }
   | { type: "error"; sessionId: string; message: string };
 
 export function safeParseClientMessage(raw: string): { ok: true; msg: ClientMessage } | { ok: false; error: string } {
@@ -54,6 +56,7 @@ export function safeParseClientMessage(raw: string): { ok: true; msg: ClientMess
     case "user_message":
     case "ask_response":
     case "approval_response":
+    case "list_tools":
     case "reset":
       return { ok: true, msg: obj };
     case "connect_provider": {

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -6,6 +6,7 @@ import { isProviderName } from "../types";
 import type { AgentConfig, TodoItem } from "../types";
 import { runTurn } from "../agent";
 import { loadSystemPrompt } from "../prompt";
+import { createTools } from "../tools";
 import { classifyCommand } from "../utils/approval";
 
 import type { ServerEvent } from "./protocol";
@@ -79,6 +80,18 @@ export class AgentSession {
     this.messages = [];
     this.todos = [];
     this.emit({ type: "todos", sessionId: this.id, todos: [] });
+  }
+
+  listTools() {
+    const tools = Object.keys(
+      createTools({
+        config: this.config,
+        log: () => {},
+        askUser: async () => "",
+        approveCommand: async () => false,
+      })
+    ).sort();
+    this.emit({ type: "tools", sessionId: this.id, tools });
   }
 
   async setModel(modelIdRaw: string, providerRaw?: AgentConfig["provider"]) {

--- a/src/server/startServer.ts
+++ b/src/server/startServer.ts
@@ -140,6 +140,11 @@ export async function startAgentServer(
             session.reset();
             return;
           }
+
+          if (msg.type === "list_tools") {
+            session.listTools();
+            return;
+          }
         },
         close(ws) {
           ws.data.session?.dispose("websocket closed");

--- a/test/agent.remote-mcp.grep.test.ts
+++ b/test/agent.remote-mcp.grep.test.ts
@@ -1,123 +1,89 @@
-import { describe, expect, test, mock, afterAll } from "bun:test";
+import { describe, expect, test, mock } from "bun:test";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
-import * as REAL_AI from "ai";
-import * as REAL_CONFIG from "../src/config";
-import { createTools as REAL_CREATE_TOOLS } from "../src/tools/index";
-
 import type { AgentConfig } from "../src/types";
+import { runTurnWithDeps } from "../src/agent";
 
 const RUN_REMOTE =
   process.env.RUN_REMOTE_MCP_TESTS === "1" ||
   process.env.RUN_REMOTE_MCP_TESTS === "true" ||
   process.env.RUN_REMOTE_MCP_TESTS === "yes";
 
-if (!RUN_REMOTE) {
-  test.skip("runTurn + remote MCP (mcp.grep.app)", () => {});
-} else {
-  // -------------------------------------------------------------------------
-  // Module mocks: we don't want to call a real LLM, but we do want to exercise
-  // the real MCP loading + tool execution path.
-  // -------------------------------------------------------------------------
+const it = RUN_REMOTE ? test : test.skip;
 
-  const mockGenerateText = mock(async (args: any) => {
-    const tool = args?.tools?.["mcp__grep__searchGitHub"];
-    expect(tool).toBeDefined();
+function makeConfig(baseDir: string, configDir: string): AgentConfig {
+  return {
+    provider: "google",
+    model: "gemini-3-flash-preview",
+    subAgentModel: "gemini-3-flash-preview",
+    workingDirectory: baseDir,
+    outputDirectory: path.join(baseDir, "output"),
+    uploadsDirectory: path.join(baseDir, "uploads"),
+    userName: "tester",
+    knowledgeCutoff: "unknown",
+    projectAgentDir: baseDir,
+    userAgentDir: baseDir,
+    builtInDir: baseDir,
+    builtInConfigDir: baseDir,
+    skillsDirs: [],
+    memoryDirs: [],
+    configDirs: [configDir],
+    enableMcp: true,
+  };
+}
 
-    const res = await tool.execute({
-      query: "createMCPClient(",
-      language: ["TypeScript", "JavaScript"],
-    });
+describe("runTurn + remote MCP (mcp.grep.app)", () => {
+  it(
+    "loads the remote MCP tools and can execute them via the tools passed to generateText",
+    async () => {
+      // We don't want to call a real LLM, but we do want to exercise the real
+      // MCP loading + tool execution path. Use dependency injection to avoid
+      // global module mocks leaking across concurrent test files.
+      const mockGenerateText = mock(async (args: any) => {
+        const tool = args?.tools?.["mcp__grep__searchGitHub"];
+        expect(tool).toBeDefined();
 
-    const firstText = res?.content?.find((c: any) => c?.type === "text")?.text ?? "";
+        const res = await tool.execute({
+          query: "createMCPClient(",
+          language: ["TypeScript", "JavaScript"],
+        });
 
-    return {
-      text: firstText,
-      reasoningText: undefined as string | undefined,
-      response: { messages: [] as any[] },
-    };
-  });
+        const firstText = res?.content?.find((c: any) => c?.type === "text")?.text ?? "";
 
-  const mockStepCountIs = mock((_n: number) => "step-count-sentinel");
+        return {
+          text: firstText,
+          reasoningText: undefined as string | undefined,
+          response: { messages: [] as any[] },
+        };
+      });
 
-  mock.module("ai", () => ({
-    generateText: mockGenerateText,
-    stepCountIs: mockStepCountIs,
-  }));
+      const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "agent-remote-mcp-"));
+      try {
+        await fs.writeFile(
+          path.join(tmpDir, "mcp-servers.json"),
+          JSON.stringify(
+            {
+              servers: [
+                {
+                  name: "grep",
+                  transport: { type: "http", url: "https://mcp.grep.app" },
+                  required: true,
+                  retries: 0,
+                },
+              ],
+            },
+            null,
+            2
+          ),
+          "utf-8"
+        );
 
-  const mockGetModel = mock((_config: AgentConfig, _id?: string) => "model-sentinel");
+        const config = makeConfig(tmpDir, tmpDir);
 
-  mock.module("../src/config", () => ({
-    getModel: mockGetModel,
-  }));
-
-  const mockCreateTools = mock((_ctx: any) => ({}));
-
-  mock.module("../src/tools", () => ({
-    createTools: mockCreateTools,
-  }));
-
-  afterAll(() => {
-    // Prevent this file's module mocks from leaking into other test files.
-    mock.module("ai", () => REAL_AI);
-    mock.module("../src/config", () => REAL_CONFIG);
-    mock.module("../src/tools", () => ({ createTools: REAL_CREATE_TOOLS }));
-    mock.module("../src/tools/index", () => ({ createTools: REAL_CREATE_TOOLS }));
-  });
-
-  const { runTurn } = await import("../src/agent");
-
-  function makeConfig(baseDir: string, configDir: string): AgentConfig {
-    return {
-      provider: "google",
-      model: "gemini-3-flash-preview",
-      subAgentModel: "gemini-3-flash-preview",
-      workingDirectory: baseDir,
-      outputDirectory: path.join(baseDir, "output"),
-      uploadsDirectory: path.join(baseDir, "uploads"),
-      userName: "tester",
-      knowledgeCutoff: "unknown",
-      projectAgentDir: baseDir,
-      userAgentDir: baseDir,
-      builtInDir: baseDir,
-      builtInConfigDir: baseDir,
-      skillsDirs: [],
-      memoryDirs: [],
-      configDirs: [configDir],
-      enableMcp: true,
-    };
-  }
-
-  describe("runTurn + remote MCP (mcp.grep.app)", () => {
-    test(
-      "loads the remote MCP tools and can execute them via the tools passed to generateText",
-      async () => {
-        const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "agent-remote-mcp-"));
-        try {
-          await fs.writeFile(
-            path.join(tmpDir, "mcp-servers.json"),
-            JSON.stringify(
-              {
-                servers: [
-                  {
-                    name: "grep",
-                    transport: { type: "http", url: "https://mcp.grep.app" },
-                    required: true,
-                    retries: 0,
-                  },
-                ],
-              },
-              null,
-              2
-            ),
-            "utf-8"
-          );
-
-          const config = makeConfig(tmpDir, tmpDir);
-
-          const res = await runTurn({
+        const res = await runTurnWithDeps(
+          {
             config,
             system: "You are a helpful assistant.",
             messages: [{ role: "user", content: [{ type: "text", text: "use the tool" }] }] as any[],
@@ -125,16 +91,23 @@ if (!RUN_REMOTE) {
             askUser: mock(async () => "ok"),
             approveCommand: mock(async () => true),
             maxSteps: 5,
-          });
+          },
+          {
+            generateText: mockGenerateText as any,
+            stepCountIs: mock((_n: number) => "step-count-sentinel") as any,
+            getModel: mock((_config: AgentConfig, _id?: string) => "model-sentinel") as any,
+            // Keep only MCP tools in the tools map to reduce accidental coupling to built-ins.
+            createTools: mock((_ctx: any) => ({})) as any,
+          }
+        );
 
-          expect(mockGenerateText).toHaveBeenCalledTimes(1);
-          expect(typeof res.text).toBe("string");
-          expect(res.text.trim().length).toBeGreaterThan(0);
-        } finally {
-          await fs.rm(tmpDir, { recursive: true, force: true });
-        }
-      },
-      30_000
-    );
-  });
-}
+        expect(mockGenerateText).toHaveBeenCalledTimes(1);
+        expect(typeof res.text).toBe("string");
+        expect(res.text.trim().length).toBeGreaterThan(0);
+      } finally {
+        await fs.rm(tmpDir, { recursive: true, force: true });
+      }
+    },
+    30_000
+  );
+});

--- a/test/repl.disconnect-send.test.ts
+++ b/test/repl.disconnect-send.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, test } from "bun:test";
+
+import type { ClientMessage, ServerEvent } from "../src/server/protocol";
+
+let rlRef: FakeReadline | null = null;
+
+class FakeReadline {
+  private handlers = new Map<string, Array<(...args: any[]) => any>>();
+  private closed = false;
+  lastPrompt: string | null = null;
+
+  setPrompt(_p: string) {
+    this.lastPrompt = _p;
+  }
+
+  prompt() {
+    // no-op
+  }
+
+  on(event: string, cb: (...args: any[]) => any) {
+    const list = this.handlers.get(event) ?? [];
+    list.push(cb);
+    this.handlers.set(event, list);
+    return this;
+  }
+
+  close() {
+    if (this.closed) return;
+    this.closed = true;
+    const list = this.handlers.get("close") ?? [];
+    for (const cb of list) cb();
+  }
+
+  async emitLine(line: string) {
+    const list = this.handlers.get("line") ?? [];
+    for (const cb of list) await cb(line);
+  }
+}
+
+const startAgentServerStub = async () => {
+  return {
+    server: { stop() {} },
+    // url string is opaque to the REPL; it just passes it to WebSocket().
+    url: "ws://mock",
+    // unused by the REPL, but part of the real return type
+    config: {} as any,
+    system: "",
+  };
+};
+
+class FakeWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+
+  static instances: FakeWebSocket[] = [];
+
+  readyState = FakeWebSocket.CONNECTING;
+  sent: string[] = [];
+
+  onopen: null | (() => void) = null;
+  onerror: null | (() => void) = null;
+  onmessage: null | ((ev: { data: any }) => void) = null;
+  onclose: null | (() => void) = null;
+
+  constructor(_url: string) {
+    FakeWebSocket.instances.push(this);
+    queueMicrotask(() => {
+      this.readyState = FakeWebSocket.OPEN;
+      this.onopen?.();
+    });
+  }
+
+  send(data: string) {
+    this.sent.push(String(data));
+    let parsed: ClientMessage | null = null;
+    try {
+      parsed = JSON.parse(String(data));
+    } catch {
+      parsed = null;
+    }
+    if (parsed?.type === "client_hello") {
+      const hello: ServerEvent = {
+        type: "server_hello",
+        sessionId: "sess-test",
+        config: {
+          provider: "openai",
+          model: "gpt-test",
+          workingDirectory: "/tmp",
+          outputDirectory: "/tmp/output",
+        },
+      };
+      queueMicrotask(() => this.onmessage?.({ data: JSON.stringify(hello) }));
+    }
+  }
+
+  close() {
+    this.readyState = FakeWebSocket.CLOSED;
+    queueMicrotask(() => this.onclose?.());
+  }
+}
+
+describe("CLI REPL websocket send failures", () => {
+  test("surfaces an error and does not silently drop a user_message when ws is not OPEN", async () => {
+    rlRef = null;
+    FakeWebSocket.instances = [];
+    const realLog = console.log;
+    const realErr = console.error;
+
+    try {
+      const logs: string[] = [];
+      console.log = (...args: any[]) => logs.push(args.join(" "));
+      console.error = (...args: any[]) => logs.push(args.join(" "));
+
+      const { runCliRepl } = await import("../src/cli/repl");
+
+      const replPromise = runCliRepl({
+        __internal: {
+          startAgentServer: startAgentServerStub as any,
+          WebSocket: FakeWebSocket as any,
+          createReadlineInterface: () => {
+            rlRef = new FakeReadline();
+            return rlRef as any;
+          },
+        },
+      });
+
+      // Allow handshake and readline wiring to complete.
+      await new Promise((r) => setTimeout(r, 5));
+
+      const ws = FakeWebSocket.instances[0];
+      expect(ws).toBeDefined();
+      expect(rlRef).toBeDefined();
+
+      // Simulate a dropped socket where readyState is no longer OPEN, but no close
+      // event has fired yet (the edge case that previously silently dropped input).
+      ws.readyState = FakeWebSocket.CLOSED;
+
+      await rlRef!.emitLine("hello");
+
+      expect(logs.join("\n")).toContain("disconnected:");
+      expect(logs.join("\n")).toContain("unable to send (not connected)");
+      expect(logs.join("\n")).toContain("/restart");
+      expect(rlRef!.lastPrompt).toBe("you> ");
+
+      const sentTypes = ws.sent
+        .map((raw) => {
+          try {
+            return JSON.parse(raw)?.type;
+          } catch {
+            return null;
+          }
+        })
+        .filter(Boolean);
+      expect(sentTypes).not.toContain("user_message");
+
+      rlRef!.close();
+      await replPromise;
+    } finally {
+      console.log = realLog;
+      console.error = realErr;
+    }
+  });
+});

--- a/test/repl.restart-failure.test.ts
+++ b/test/repl.restart-failure.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test } from "bun:test";
+
+import type { ClientMessage, ServerEvent } from "../src/server/protocol";
+
+let rlRef: FakeReadline | null = null;
+
+class FakeReadline {
+  private handlers = new Map<string, Array<(...args: any[]) => any>>();
+  private closed = false;
+
+  lastPrompt: string | null = null;
+
+  setPrompt(p: string) {
+    this.lastPrompt = p;
+  }
+
+  prompt() {
+    // no-op
+  }
+
+  on(event: string, cb: (...args: any[]) => any) {
+    const list = this.handlers.get(event) ?? [];
+    list.push(cb);
+    this.handlers.set(event, list);
+    return this;
+  }
+
+  close() {
+    if (this.closed) return;
+    this.closed = true;
+    const list = this.handlers.get("close") ?? [];
+    for (const cb of list) cb();
+  }
+
+  async emitLine(line: string) {
+    const list = this.handlers.get("line") ?? [];
+    for (const cb of list) await cb(line);
+  }
+}
+
+class FakeWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+
+  static instances: FakeWebSocket[] = [];
+
+  readyState = FakeWebSocket.CONNECTING;
+  sent: string[] = [];
+
+  onopen: null | (() => void) = null;
+  onerror: null | (() => void) = null;
+  onmessage: null | ((ev: { data: any }) => void) = null;
+  onclose: null | (() => void) = null;
+
+  constructor(_url: string) {
+    FakeWebSocket.instances.push(this);
+    queueMicrotask(() => {
+      this.readyState = FakeWebSocket.OPEN;
+      this.onopen?.();
+    });
+  }
+
+  send(data: string) {
+    this.sent.push(String(data));
+    let parsed: ClientMessage | null = null;
+    try {
+      parsed = JSON.parse(String(data));
+    } catch {
+      parsed = null;
+    }
+    if (parsed?.type === "client_hello") {
+      const hello: ServerEvent = {
+        type: "server_hello",
+        sessionId: "sess-test",
+        config: {
+          provider: "openai",
+          model: "gpt-test",
+          workingDirectory: "/tmp",
+          outputDirectory: "/tmp/output",
+        },
+      };
+      queueMicrotask(() => this.onmessage?.({ data: JSON.stringify(hello) }));
+    }
+  }
+
+  close() {
+    this.readyState = FakeWebSocket.CLOSED;
+    queueMicrotask(() => this.onclose?.());
+  }
+}
+
+describe("CLI REPL restart failure recovery", () => {
+  test("does not get stuck after a failed /restart (serverStopping reset; disconnect cleanup not skipped)", async () => {
+    rlRef = null;
+    FakeWebSocket.instances = [];
+    const realLog = console.log;
+    const realErr = console.error;
+
+    try {
+      const logs: string[] = [];
+      console.log = (...args: any[]) => logs.push(args.join(" "));
+      console.error = (...args: any[]) => logs.push(args.join(" "));
+
+      let startCalls = 0;
+      const startAgentServerStub = async () => {
+        startCalls++;
+        if (startCalls >= 2) throw new Error("boom: start failed");
+
+        return {
+          server: {
+            stop() {
+              // Mimic server shutdown closing the active websocket.
+              for (const ws of FakeWebSocket.instances) ws.close();
+            },
+          },
+          url: "ws://mock",
+          config: {} as any,
+          system: "",
+        };
+      };
+
+      const { runCliRepl } = await import("../src/cli/repl");
+
+      const replPromise = runCliRepl({
+        __internal: {
+          startAgentServer: startAgentServerStub as any,
+          WebSocket: FakeWebSocket as any,
+          createReadlineInterface: () => {
+            rlRef = new FakeReadline();
+            return rlRef as any;
+          },
+        },
+      });
+
+      // Allow handshake and readline wiring to complete.
+      await new Promise((r) => setTimeout(r, 5));
+
+      expect(rlRef).toBeDefined();
+      expect(FakeWebSocket.instances[0]).toBeDefined();
+
+      await rlRef!.emitLine("/restart");
+      expect(logs.join("\n")).toContain("restarting server...");
+      expect(logs.join("\n")).toContain("Error:");
+
+      const before = logs.length;
+      await rlRef!.emitLine("hello");
+
+      // The key regression: input must not be silently dropped after a failed restart.
+      expect(logs.length).toBeGreaterThan(before);
+      expect(logs.join("\n")).toMatch(/not connected:|disconnected:/);
+      expect(rlRef!.lastPrompt).toBe("you> ");
+
+      rlRef!.close();
+      await replPromise;
+    } finally {
+      console.log = realLog;
+      console.error = realErr;
+    }
+  });
+});
+

--- a/test/repl.test.ts
+++ b/test/repl.test.ts
@@ -200,7 +200,18 @@ describe("renderTodos", () => {
 // Command parsing logic (replicated from the REPL's while-loop)
 // ---------------------------------------------------------------------------
 interface ParsedCommand {
-  type: "help" | "exit" | "new" | "model" | "provider" | "connect" | "cwd" | "tools" | "unknown" | "message";
+  type:
+    | "help"
+    | "exit"
+    | "new"
+    | "restart"
+    | "model"
+    | "provider"
+    | "connect"
+    | "cwd"
+    | "tools"
+    | "unknown"
+    | "message";
   arg?: string;
 }
 
@@ -215,6 +226,7 @@ function parseReplInput(input: string): ParsedCommand {
   if (cmd === "help") return { type: "help" };
   if (cmd === "exit") return { type: "exit" };
   if (cmd === "new") return { type: "new" };
+  if (cmd === "restart") return { type: "restart" };
   if (cmd === "model") return { type: "model", arg: rest.join(" ").trim() };
   if (cmd === "provider") return { type: "provider", arg: rest[0] };
   if (cmd === "connect") return { type: "connect", arg: rest.join(" ").trim() };
@@ -235,6 +247,10 @@ describe("REPL command parsing", () => {
 
   test("/new is parsed as new command", () => {
     expect(parseReplInput("/new")).toEqual({ type: "new" });
+  });
+
+  test("/restart is parsed as restart command", () => {
+    expect(parseReplInput("/restart")).toEqual({ type: "restart" });
   });
 
   test("/model with id is parsed correctly", () => {

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 
 import type { AgentConfig, TodoItem } from "../src/types";
 import type { ServerEvent } from "../src/server/protocol";
+import * as REAL_AGENT from "../src/agent";
 
 // ---------------------------------------------------------------------------
 // Mock runTurn before importing AgentSession (which imports ../agent)
@@ -142,6 +143,7 @@ describe("AgentSession", () => {
   });
 
   afterAll(() => {
+    mock.module("../src/agent", () => REAL_AGENT);
     mock.restore();
   });
 

--- a/test/skills.test.ts
+++ b/test/skills.test.ts
@@ -274,9 +274,9 @@ describe("discoverSkills", () => {
     const entries = await discoverSkills([builtInSkills]);
     const names = entries.map((e) => e.name).sort();
     expect(names).toContain("pdf");
-    expect(names).toContain("docx");
-    expect(names).toContain("xlsx");
-    expect(names).toContain("pptx");
+    expect(names).toContain("doc");
+    expect(names).toContain("spreadsheet");
+    expect(names).toContain("slides");
     expect(entries.length).toBeGreaterThanOrEqual(4);
   });
 


### PR DESCRIPTION
### Motivation

- Make `runTurn` easily testable in isolation by allowing dependency injection rather than relying on global module mocks. 
- Move the CLI to talk to the local websocket server so CLI and TUI share a single session/server model and avoid duplicating agent logic. 
- Stabilize and modernize tests that were brittle due to module-level mock leakage and mismatched expectations.

### Description

- Add an injectable factory `createRunTurn` and wrappers `runTurn`/`runTurnWithDeps` so agent logic can be invoked with overrideable dependencies (e.g. `generateText`, `getModel`, `createTools`, `loadMCP*`).
- Refactor tests to use the new DI entrypoint (`createRunTurn`) instead of global `mock.module()` overrides and restore test cleanup (changes in `test/agent.test.ts`, `test/session.test.ts`, and `test/skills.test.ts`).
- Rework CLI REPL to run as a websocket client talking to `startAgentServer` instead of calling agent internals directly, including prompt handling, approval/ask queues, reconnect/restart on `/cwd`, and non-blocking user prompts (changes in `src/cli/repl.ts`).
- Extend server protocol to support `list_tools` client message and `tools` server event and implement `AgentSession.listTools()` to emit sorted tool names (changes in `src/server/protocol.ts`, `src/server/session.ts`, and `src/server/startServer.ts`).
- Misc test and expectation fixes: align built-in `skills` names and restore mocked agent module after session tests.

### Testing

- Ran the full test suite with `bun test` and iterative runs with `bun test --bail`; all tests passed in the final run (836 tests across 29 files with 0 failures and some skipped remote tests).
- Exercised unit/integration areas affected by the change including `agent` logic, server websocket lifecycle, protocol parsing, `list_tools` flow, and updated `runTurn` behavior via injected mocks; these automated tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988e0461c148326b40075dc8362b3dc)