### PR TITLE
Agent session backups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,21 @@
 node_modules/
 
+# Build output
+dist/
+coverage/
+.nyc_output/
+*.tsbuildinfo
+
+# Frontend tooling caches
+**/.vite/
+**/.vite-temp/
+.turbo/
+.cache/
+
+# Tauri / Rust build output
+**/src-tauri/target/
+**/src-tauri/gen/
+
 # Agent runtime dirs
 output/
 uploads/
@@ -8,8 +24,14 @@ uploads/
 # Env / misc
 .env
 .env.*
+!.env.example
+!.env.template
 *.log
 .DS_Store
 
 # Local editor / tool state
 .claude/
+.vscode/
+.idea/
+*.swp
+*~

--- a/docs/websocket-protocol.md
+++ b/docs/websocket-protocol.md
@@ -504,7 +504,7 @@ server  <- config_updated { config: { provider: "openai", model: "gpt-4-turbo", 
 ### Backup / Checkpoint Flow
 
 ```
-client  -> session_backup_get {}
+client  -> session_backup_get { sessionId: "..." }
 server  <- session_backup_state { reason: "requested", backup: {...} }
 
 client  -> user_message { text: "make changes" }

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -1,5 +1,6 @@
 import { isProviderName } from "../types";
 import type { AgentConfig, TodoItem } from "../types";
+import type { SessionBackupPublicState } from "./sessionBackup";
 
 export type ClientMessage =
   | { type: "client_hello"; client: "tui" | "cli" | string; version?: string }
@@ -9,6 +10,10 @@ export type ClientMessage =
   | { type: "connect_provider"; sessionId: string; provider: AgentConfig["provider"]; apiKey?: string }
   | { type: "set_model"; sessionId: string; model: string; provider?: AgentConfig["provider"] }
   | { type: "list_tools"; sessionId: string }
+  | { type: "session_backup_get"; sessionId: string }
+  | { type: "session_backup_checkpoint"; sessionId: string }
+  | { type: "session_backup_restore"; sessionId: string; checkpointId?: string }
+  | { type: "session_backup_delete_checkpoint"; sessionId: string; checkpointId: string }
   | { type: "reset"; sessionId: string };
 
 export type ServerEvent =
@@ -38,6 +43,12 @@ export type ServerEvent =
       config: Pick<AgentConfig, "provider" | "model" | "workingDirectory" | "outputDirectory">;
     }
   | { type: "tools"; sessionId: string; tools: string[] }
+  | {
+      type: "session_backup_state";
+      sessionId: string;
+      reason: "requested" | "auto_checkpoint" | "manual_checkpoint" | "restore" | "delete";
+      backup: SessionBackupPublicState;
+    }
   | { type: "error"; sessionId: string; message: string };
 
 export function safeParseClientMessage(raw: string): { ok: true; msg: ClientMessage } | { ok: false; error: string } {
@@ -61,6 +72,32 @@ export function safeParseClientMessage(raw: string): { ok: true; msg: ClientMess
     case "list_tools":
     case "reset":
       return { ok: true, msg: obj };
+    case "session_backup_get": {
+      if (typeof obj.sessionId !== "string") return { ok: false, error: "session_backup_get missing sessionId" };
+      return { ok: true, msg: obj as ClientMessage };
+    }
+    case "session_backup_checkpoint": {
+      if (typeof obj.sessionId !== "string") {
+        return { ok: false, error: "session_backup_checkpoint missing sessionId" };
+      }
+      return { ok: true, msg: obj as ClientMessage };
+    }
+    case "session_backup_restore": {
+      if (typeof obj.sessionId !== "string") return { ok: false, error: "session_backup_restore missing sessionId" };
+      if (obj.checkpointId !== undefined && typeof obj.checkpointId !== "string") {
+        return { ok: false, error: "session_backup_restore invalid checkpointId" };
+      }
+      return { ok: true, msg: obj as ClientMessage };
+    }
+    case "session_backup_delete_checkpoint": {
+      if (typeof obj.sessionId !== "string") {
+        return { ok: false, error: "session_backup_delete_checkpoint missing sessionId" };
+      }
+      if (typeof obj.checkpointId !== "string" || !obj.checkpointId) {
+        return { ok: false, error: "session_backup_delete_checkpoint missing checkpointId" };
+      }
+      return { ok: true, msg: obj as ClientMessage };
+    }
     case "connect_provider": {
       if (typeof obj.sessionId !== "string") return { ok: false, error: "connect_provider missing sessionId" };
       if (!isProviderName(obj.provider)) return { ok: false, error: "connect_provider missing/invalid provider" };

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -84,7 +84,10 @@ export function safeParseClientMessage(raw: string): { ok: true; msg: ClientMess
     }
     case "session_backup_restore": {
       if (typeof obj.sessionId !== "string") return { ok: false, error: "session_backup_restore missing sessionId" };
-      if (obj.checkpointId !== undefined && typeof obj.checkpointId !== "string") {
+      if (
+        obj.checkpointId !== undefined &&
+        (typeof obj.checkpointId !== "string" || obj.checkpointId.trim().length === 0)
+      ) {
         return { ok: false, error: "session_backup_restore invalid checkpointId" };
       }
       return { ok: true, msg: obj as ClientMessage };

--- a/src/server/sessionBackup.ts
+++ b/src/server/sessionBackup.ts
@@ -1,0 +1,446 @@
+import { spawn } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { gunzipSync, gzipSync } from "node:zlib";
+
+import { getAiCoworkerPaths } from "../connect";
+
+export type SessionBackupCheckpointTrigger = "auto" | "manual";
+
+export type SessionBackupPublicCheckpoint = {
+  id: string;
+  index: number;
+  createdAt: string;
+  trigger: SessionBackupCheckpointTrigger;
+  changed: boolean;
+  patchBytes: number;
+};
+
+export type SessionBackupPublicState = {
+  status: "initializing" | "ready" | "failed";
+  sessionId: string;
+  workingDirectory: string;
+  backupDirectory: string | null;
+  createdAt: string;
+  originalSnapshot: { kind: "pending" | "directory" | "tar_gz" };
+  checkpoints: SessionBackupPublicCheckpoint[];
+  failureReason?: string;
+};
+
+type SessionBackupMetadataCheckpoint = SessionBackupPublicCheckpoint & {
+  patchFile?: string;
+};
+
+type SessionBackupMetadata = {
+  version: 1;
+  sessionId: string;
+  workingDirectory: string;
+  createdAt: string;
+  state: "active" | "closed";
+  closedAt?: string;
+  compactedAt?: string;
+  originalSnapshot: { kind: "directory" | "tar_gz"; path: string };
+  checkpoints: SessionBackupMetadataCheckpoint[];
+};
+
+export type SessionBackupInitOptions = {
+  sessionId: string;
+  workingDirectory: string;
+  homedir?: string;
+};
+
+export interface SessionBackupHandle {
+  getPublicState(): SessionBackupPublicState;
+  createCheckpoint(trigger: SessionBackupCheckpointTrigger): Promise<SessionBackupPublicCheckpoint>;
+  restoreOriginal(): Promise<void>;
+  restoreCheckpoint(checkpointId: string): Promise<void>;
+  deleteCheckpoint(checkpointId: string): Promise<boolean>;
+  close(): Promise<void>;
+}
+
+const METADATA_FILE = "metadata.json";
+const ORIGINAL_DIR = "original";
+const ORIGINAL_ARCHIVE = "original.tar.gz";
+const CHECKPOINTS_DIR = "checkpoints";
+
+function makeCheckpointId(index: number): string {
+  return `cp-${String(index).padStart(4, "0")}`;
+}
+
+function toPatchPrefix(absPath: string): string {
+  const resolved = path.resolve(absPath).replace(/\\/g, "/").replace(/^\/+/, "");
+  return resolved.endsWith("/") ? resolved : `${resolved}/`;
+}
+
+function normalizeDiffPatchPaths(diffPatch: string, originalDir: string, workingDir: string): string {
+  if (!diffPatch.trim()) return "";
+
+  const originalPrefix = toPatchPrefix(originalDir);
+  const workingPrefix = toPatchPrefix(workingDir);
+
+  const replacePrefix = (line: string, prefix: string) =>
+    line.replace(`a/${prefix}`, "a/").replace(`b/${prefix}`, "b/");
+
+  return diffPatch
+    .split("\n")
+    .map((line) => {
+      if (!line.startsWith("diff --git ") && !line.startsWith("--- ") && !line.startsWith("+++ ")) {
+        return line;
+      }
+      return replacePrefix(replacePrefix(line, originalPrefix), workingPrefix);
+    })
+    .join("\n");
+}
+
+type CommandResult = { exitCode: number | null; stdout: string; stderr: string };
+
+async function runCommand(
+  command: string,
+  args: string[],
+  opts: { cwd?: string; stdin?: string } = {}
+): Promise<CommandResult> {
+  const child = spawn(command, args, {
+    cwd: opts.cwd,
+    env: process.env,
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+
+  const stdoutChunks: Uint8Array[] = [];
+  const stderrChunks: Uint8Array[] = [];
+
+  const stdoutPromise = (async () => {
+    if (!child.stdout) return;
+    for await (const chunk of child.stdout) stdoutChunks.push(chunk);
+  })();
+
+  const stderrPromise = (async () => {
+    if (!child.stderr) return;
+    for await (const chunk of child.stderr) stderrChunks.push(chunk);
+  })();
+
+  const closePromise = new Promise<number | null>((resolve, reject) => {
+    child.once("error", reject);
+    child.once("close", (exitCode) => resolve(exitCode));
+  });
+
+  if (opts.stdin !== undefined && child.stdin) {
+    child.stdin.write(opts.stdin);
+  }
+  child.stdin?.end();
+
+  const [exitCode] = await Promise.all([closePromise, stdoutPromise, stderrPromise]);
+
+  return {
+    exitCode,
+    stdout: Buffer.concat(stdoutChunks).toString("utf-8"),
+    stderr: Buffer.concat(stderrChunks).toString("utf-8"),
+  };
+}
+
+async function pathExists(p: string): Promise<boolean> {
+  try {
+    await fs.stat(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function ensureDirectory(p: string): Promise<void> {
+  await fs.mkdir(p, { recursive: true });
+}
+
+async function ensureWorkingDirectory(workingDirectory: string): Promise<void> {
+  try {
+    const st = await fs.stat(workingDirectory);
+    if (!st.isDirectory()) throw new Error(`Working directory is not a directory: ${workingDirectory}`);
+  } catch {
+    await fs.mkdir(workingDirectory, { recursive: true });
+  }
+}
+
+async function copyDirectory(sourceDir: string, destinationDir: string): Promise<void> {
+  await fs.rm(destinationDir, { recursive: true, force: true });
+  await fs.cp(sourceDir, destinationDir, { recursive: true, force: true, errorOnExist: false });
+}
+
+async function emptyDirectory(dir: string): Promise<void> {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    await fs.rm(path.join(dir, entry.name), { recursive: true, force: true });
+  }
+}
+
+async function copyDirectoryContents(sourceDir: string, destinationDir: string): Promise<void> {
+  await ensureDirectory(destinationDir);
+  const entries = await fs.readdir(sourceDir, { withFileTypes: true });
+  for (const entry of entries) {
+    const sourcePath = path.join(sourceDir, entry.name);
+    const destinationPath = path.join(destinationDir, entry.name);
+    await fs.cp(sourcePath, destinationPath, { recursive: true, force: true, errorOnExist: false });
+  }
+}
+
+async function writeJson(filePath: string, value: unknown): Promise<void> {
+  await fs.writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf-8");
+}
+
+async function readMetadata(filePath: string): Promise<SessionBackupMetadata | null> {
+  try {
+    const raw = await fs.readFile(filePath, "utf-8");
+    const parsed = JSON.parse(raw) as SessionBackupMetadata;
+    if (parsed && parsed.version === 1 && typeof parsed.sessionId === "string") return parsed;
+  } catch {
+    // ignore malformed files; compaction should continue best-effort
+  }
+  return null;
+}
+
+async function createTarGzFromDirectory(sourceDir: string, targetArchive: string): Promise<void> {
+  await ensureDirectory(path.dirname(targetArchive));
+  const parentDir = path.dirname(sourceDir);
+  const dirName = path.basename(sourceDir);
+  const res = await runCommand("tar", ["-czf", targetArchive, "-C", parentDir, dirName]);
+  if (res.exitCode !== 0) {
+    throw new Error(`tar create failed: ${res.stderr || res.stdout || `exit=${String(res.exitCode)}`}`);
+  }
+}
+
+async function extractTarGzIntoDirectory(archivePath: string, targetDir: string): Promise<void> {
+  await ensureDirectory(targetDir);
+  const res = await runCommand("tar", ["-xzf", archivePath, "-C", targetDir]);
+  if (res.exitCode !== 0) {
+    throw new Error(`tar extract failed: ${res.stderr || res.stdout || `exit=${String(res.exitCode)}`}`);
+  }
+}
+
+async function createDiffPatch(originalDir: string, workingDir: string): Promise<string> {
+  const res = await runCommand("git", ["diff", "--no-index", "--binary", originalDir, workingDir]);
+  if (res.exitCode === 0) return "";
+  if (res.exitCode === 1) return normalizeDiffPatchPaths(res.stdout, originalDir, workingDir);
+  throw new Error(res.stderr || res.stdout || `git diff failed (exit=${String(res.exitCode)})`);
+}
+
+async function applyDiffPatch(workingDir: string, patchText: string): Promise<void> {
+  if (!patchText.trim()) return;
+  const res = await runCommand("git", ["apply", "--binary", "--whitespace=nowarn"], {
+    cwd: workingDir,
+    stdin: patchText,
+  });
+  if (res.exitCode !== 0) {
+    throw new Error(res.stderr || res.stdout || `git apply failed (exit=${String(res.exitCode)})`);
+  }
+}
+
+export class SessionBackupManager implements SessionBackupHandle {
+  static async compactClosedSessions(backupsRootDir: string, skipSessionId?: string): Promise<void> {
+    await ensureDirectory(backupsRootDir);
+    const entries = await fs.readdir(backupsRootDir, { withFileTypes: true });
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      if (skipSessionId && entry.name === skipSessionId) continue;
+
+      const sessionDir = path.join(backupsRootDir, entry.name);
+      const metadataPath = path.join(sessionDir, METADATA_FILE);
+      const metadata = await readMetadata(metadataPath);
+      if (!metadata) continue;
+      if (metadata.state !== "closed") continue;
+      if (metadata.originalSnapshot.kind !== "directory") continue;
+
+      const originalDir = path.join(sessionDir, metadata.originalSnapshot.path);
+      if (!(await pathExists(originalDir))) continue;
+
+      try {
+        const archivePath = path.join(sessionDir, ORIGINAL_ARCHIVE);
+        await createTarGzFromDirectory(originalDir, archivePath);
+        await fs.rm(originalDir, { recursive: true, force: true });
+        metadata.originalSnapshot = { kind: "tar_gz", path: ORIGINAL_ARCHIVE };
+        metadata.compactedAt = new Date().toISOString();
+        await writeJson(metadataPath, metadata);
+      } catch {
+        // best-effort compaction; leave uncompressed if tar is unavailable/fails
+      }
+    }
+  }
+
+  static async create(opts: SessionBackupInitOptions): Promise<SessionBackupManager> {
+    const paths = getAiCoworkerPaths({ homedir: opts.homedir });
+    const backupsRootDir = path.join(paths.rootDir, "session-backups");
+    const sessionDir = path.join(backupsRootDir, opts.sessionId);
+    const originalDir = path.join(sessionDir, ORIGINAL_DIR);
+    const metadataPath = path.join(sessionDir, METADATA_FILE);
+
+    await ensureDirectory(backupsRootDir);
+    await SessionBackupManager.compactClosedSessions(backupsRootDir, opts.sessionId);
+
+    await ensureDirectory(sessionDir);
+    await ensureDirectory(path.join(sessionDir, CHECKPOINTS_DIR));
+    await ensureWorkingDirectory(opts.workingDirectory);
+    await copyDirectory(opts.workingDirectory, originalDir);
+
+    const metadata: SessionBackupMetadata = {
+      version: 1,
+      sessionId: opts.sessionId,
+      workingDirectory: path.resolve(opts.workingDirectory),
+      createdAt: new Date().toISOString(),
+      state: "active",
+      originalSnapshot: { kind: "directory", path: ORIGINAL_DIR },
+      checkpoints: [],
+    };
+    await writeJson(metadataPath, metadata);
+
+    return new SessionBackupManager({
+      metadata,
+      sessionDir,
+      metadataPath,
+    });
+  }
+
+  private metadata: SessionBackupMetadata;
+  private readonly sessionDir: string;
+  private readonly metadataPath: string;
+
+  private constructor(opts: {
+    metadata: SessionBackupMetadata;
+    sessionDir: string;
+    metadataPath: string;
+  }) {
+    this.metadata = opts.metadata;
+    this.sessionDir = opts.sessionDir;
+    this.metadataPath = opts.metadataPath;
+  }
+
+  getPublicState(): SessionBackupPublicState {
+    return {
+      status: "ready",
+      sessionId: this.metadata.sessionId,
+      workingDirectory: this.metadata.workingDirectory,
+      backupDirectory: this.sessionDir,
+      createdAt: this.metadata.createdAt,
+      originalSnapshot: { kind: this.metadata.originalSnapshot.kind },
+      checkpoints: this.metadata.checkpoints.map((cp) => ({
+        id: cp.id,
+        index: cp.index,
+        createdAt: cp.createdAt,
+        trigger: cp.trigger,
+        changed: cp.changed,
+        patchBytes: cp.patchBytes,
+      })),
+    };
+  }
+
+  async createCheckpoint(trigger: SessionBackupCheckpointTrigger): Promise<SessionBackupPublicCheckpoint> {
+    const originalDir = await this.ensureOriginalDirectory();
+    const diffPatch = await createDiffPatch(originalDir, this.metadata.workingDirectory);
+    const changed = diffPatch.trim().length > 0;
+
+    const index = this.metadata.checkpoints.length + 1;
+    const id = makeCheckpointId(index);
+    const createdAt = new Date().toISOString();
+
+    let patchBytes = 0;
+    let patchFile: string | undefined;
+
+    if (changed) {
+      const patchAbsPath = path.join(this.sessionDir, CHECKPOINTS_DIR, `${id}.patch.gz`);
+      const compressed = gzipSync(Buffer.from(diffPatch, "utf-8"));
+      patchBytes = compressed.byteLength;
+      await fs.writeFile(patchAbsPath, compressed);
+      patchFile = path.join(CHECKPOINTS_DIR, `${id}.patch.gz`);
+    }
+
+    const checkpoint: SessionBackupMetadataCheckpoint = {
+      id,
+      index,
+      createdAt,
+      trigger,
+      changed,
+      patchBytes,
+      patchFile,
+    };
+
+    this.metadata.checkpoints.push(checkpoint);
+    await this.persistMetadata();
+
+    return {
+      id: checkpoint.id,
+      index: checkpoint.index,
+      createdAt: checkpoint.createdAt,
+      trigger: checkpoint.trigger,
+      changed: checkpoint.changed,
+      patchBytes: checkpoint.patchBytes,
+    };
+  }
+
+  async restoreOriginal(): Promise<void> {
+    const originalDir = await this.ensureOriginalDirectory();
+    await ensureWorkingDirectory(this.metadata.workingDirectory);
+    await emptyDirectory(this.metadata.workingDirectory);
+    await copyDirectoryContents(originalDir, this.metadata.workingDirectory);
+  }
+
+  async restoreCheckpoint(checkpointId: string): Promise<void> {
+    const checkpoint = this.metadata.checkpoints.find((cp) => cp.id === checkpointId);
+    if (!checkpoint) throw new Error(`Unknown checkpoint: ${checkpointId}`);
+
+    await this.restoreOriginal();
+    if (!checkpoint.changed) return;
+    if (!checkpoint.patchFile) {
+      throw new Error(`Checkpoint ${checkpointId} is marked changed but has no patch file`);
+    }
+
+    const patchAbsPath = path.join(this.sessionDir, checkpoint.patchFile);
+    const compressed = await fs.readFile(patchAbsPath);
+    const patchText = gunzipSync(compressed).toString("utf-8");
+    await applyDiffPatch(this.metadata.workingDirectory, patchText);
+  }
+
+  async deleteCheckpoint(checkpointId: string): Promise<boolean> {
+    const idx = this.metadata.checkpoints.findIndex((cp) => cp.id === checkpointId);
+    if (idx < 0) return false;
+
+    const checkpoint = this.metadata.checkpoints[idx];
+    this.metadata.checkpoints.splice(idx, 1);
+
+    if (checkpoint.patchFile) {
+      const patchAbsPath = path.join(this.sessionDir, checkpoint.patchFile);
+      await fs.rm(patchAbsPath, { force: true });
+    }
+
+    await this.persistMetadata();
+    return true;
+  }
+
+  async close(): Promise<void> {
+    if (this.metadata.state === "closed") return;
+    this.metadata.state = "closed";
+    this.metadata.closedAt = new Date().toISOString();
+    await this.persistMetadata();
+  }
+
+  private async ensureOriginalDirectory(): Promise<string> {
+    if (this.metadata.originalSnapshot.kind === "directory") {
+      const originalDir = path.join(this.sessionDir, this.metadata.originalSnapshot.path);
+      if (await pathExists(originalDir)) return originalDir;
+    }
+
+    if (this.metadata.originalSnapshot.kind === "tar_gz") {
+      const archivePath = path.join(this.sessionDir, this.metadata.originalSnapshot.path);
+      await extractTarGzIntoDirectory(archivePath, this.sessionDir);
+      this.metadata.originalSnapshot = { kind: "directory", path: ORIGINAL_DIR };
+      await this.persistMetadata();
+      return path.join(this.sessionDir, ORIGINAL_DIR);
+    }
+
+    const originalDir = path.join(this.sessionDir, ORIGINAL_DIR);
+    if (!(await pathExists(originalDir))) {
+      throw new Error("Original backup snapshot is unavailable");
+    }
+    return originalDir;
+  }
+
+  private async persistMetadata(): Promise<void> {
+    await writeJson(this.metadataPath, this.metadata);
+  }
+}

--- a/src/server/startServer.ts
+++ b/src/server/startServer.ts
@@ -145,6 +145,26 @@ export async function startAgentServer(
             session.listTools();
             return;
           }
+
+          if (msg.type === "session_backup_get") {
+            void session.getSessionBackupState();
+            return;
+          }
+
+          if (msg.type === "session_backup_checkpoint") {
+            void session.createManualSessionCheckpoint();
+            return;
+          }
+
+          if (msg.type === "session_backup_restore") {
+            void session.restoreSessionBackup(msg.checkpointId);
+            return;
+          }
+
+          if (msg.type === "session_backup_delete_checkpoint") {
+            void session.deleteSessionCheckpoint(msg.checkpointId);
+            return;
+          }
         },
         close(ws) {
           ws.data.session?.dispose("websocket closed");

--- a/test/protocol.test.ts
+++ b/test/protocol.test.ts
@@ -343,6 +343,91 @@ describe("safeParseClientMessage", () => {
     });
   });
 
+  describe("session backup messages", () => {
+    test("session_backup_get parses", () => {
+      const msg = expectOk(JSON.stringify({ type: "session_backup_get", sessionId: "s1" }));
+      expect(msg.type).toBe("session_backup_get");
+      if (msg.type === "session_backup_get") {
+        expect(msg.sessionId).toBe("s1");
+      }
+    });
+
+    test("session_backup_get missing sessionId fails", () => {
+      const err = expectErr(JSON.stringify({ type: "session_backup_get" }));
+      expect(err).toContain("session_backup_get missing sessionId");
+    });
+
+    test("session_backup_checkpoint parses", () => {
+      const msg = expectOk(JSON.stringify({ type: "session_backup_checkpoint", sessionId: "s1" }));
+      expect(msg.type).toBe("session_backup_checkpoint");
+      if (msg.type === "session_backup_checkpoint") {
+        expect(msg.sessionId).toBe("s1");
+      }
+    });
+
+    test("session_backup_checkpoint missing sessionId fails", () => {
+      const err = expectErr(JSON.stringify({ type: "session_backup_checkpoint" }));
+      expect(err).toContain("session_backup_checkpoint missing sessionId");
+    });
+
+    test("session_backup_restore parses original target (no checkpointId)", () => {
+      const msg = expectOk(JSON.stringify({ type: "session_backup_restore", sessionId: "s1" }));
+      expect(msg.type).toBe("session_backup_restore");
+      if (msg.type === "session_backup_restore") {
+        expect(msg.sessionId).toBe("s1");
+        expect(msg.checkpointId).toBeUndefined();
+      }
+    });
+
+    test("session_backup_restore parses checkpoint target", () => {
+      const msg = expectOk(
+        JSON.stringify({ type: "session_backup_restore", sessionId: "s1", checkpointId: "cp-0001" })
+      );
+      expect(msg.type).toBe("session_backup_restore");
+      if (msg.type === "session_backup_restore") {
+        expect(msg.sessionId).toBe("s1");
+        expect(msg.checkpointId).toBe("cp-0001");
+      }
+    });
+
+    test("session_backup_restore missing sessionId fails", () => {
+      const err = expectErr(JSON.stringify({ type: "session_backup_restore" }));
+      expect(err).toContain("session_backup_restore missing sessionId");
+    });
+
+    test("session_backup_restore non-string checkpointId fails", () => {
+      const err = expectErr(
+        JSON.stringify({ type: "session_backup_restore", sessionId: "s1", checkpointId: 42 })
+      );
+      expect(err).toContain("session_backup_restore invalid checkpointId");
+    });
+
+    test("session_backup_delete_checkpoint parses", () => {
+      const msg = expectOk(
+        JSON.stringify({
+          type: "session_backup_delete_checkpoint",
+          sessionId: "s1",
+          checkpointId: "cp-0003",
+        })
+      );
+      expect(msg.type).toBe("session_backup_delete_checkpoint");
+      if (msg.type === "session_backup_delete_checkpoint") {
+        expect(msg.sessionId).toBe("s1");
+        expect(msg.checkpointId).toBe("cp-0003");
+      }
+    });
+
+    test("session_backup_delete_checkpoint missing sessionId fails", () => {
+      const err = expectErr(JSON.stringify({ type: "session_backup_delete_checkpoint", checkpointId: "cp-1" }));
+      expect(err).toContain("session_backup_delete_checkpoint missing sessionId");
+    });
+
+    test("session_backup_delete_checkpoint missing checkpointId fails", () => {
+      const err = expectErr(JSON.stringify({ type: "session_backup_delete_checkpoint", sessionId: "s1" }));
+      expect(err).toContain("session_backup_delete_checkpoint missing checkpointId");
+    });
+  });
+
   describe("return shape", () => {
     test("ok result has ok: true and msg", () => {
       const result = safeParseClientMessage(

--- a/test/protocol.test.ts
+++ b/test/protocol.test.ts
@@ -402,6 +402,11 @@ describe("safeParseClientMessage", () => {
       expect(err).toContain("session_backup_restore invalid checkpointId");
     });
 
+    test("session_backup_restore empty checkpointId fails", () => {
+      const err = expectErr(JSON.stringify({ type: "session_backup_restore", sessionId: "s1", checkpointId: "" }));
+      expect(err).toContain("session_backup_restore invalid checkpointId");
+    });
+
     test("session_backup_delete_checkpoint parses", () => {
       const msg = expectOk(
         JSON.stringify({

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -464,6 +464,27 @@ describe("WebSocket Lifecycle", () => {
     }
   });
 
+  test("sending session_backup_get returns session_backup_state", async () => {
+    const tmpDir = await makeTmpProject();
+    const { server, url } = await startAgentServer(serverOpts(tmpDir));
+    try {
+      const { responses } = await sendAndCollect(
+        url,
+        (sessionId) => ({ type: "session_backup_get", sessionId }),
+        1,
+        3000
+      );
+
+      const backupEvt = responses[0];
+      expect(backupEvt.type).toBe("session_backup_state");
+      expect(backupEvt.backup).toBeDefined();
+      expect(typeof backupEvt.backup.status).toBe("string");
+      expect(backupEvt.sessionId).toBeDefined();
+    } finally {
+      server.stop();
+    }
+  });
+
   test("sending a non-object JSON value receives error", async () => {
     const tmpDir = await makeTmpProject();
     const { server, url } = await startAgentServer(serverOpts(tmpDir));

--- a/test/session-backup.test.ts
+++ b/test/session-backup.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "bun:test";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { SessionBackupManager } from "../src/server/sessionBackup";
+
+async function makeTmpWorkspace() {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "session-backup-test-"));
+  const home = path.join(root, "home");
+  const workspace = path.join(root, "workspace");
+  await fs.mkdir(home, { recursive: true });
+  await fs.mkdir(workspace, { recursive: true });
+  return { root, home, workspace };
+}
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.stat(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe("SessionBackupManager", () => {
+  test("creates original snapshot and restores original/checkpoint states", async () => {
+    const { home, workspace } = await makeTmpWorkspace();
+    await fs.mkdir(path.join(workspace, "sub"), { recursive: true });
+    await fs.writeFile(path.join(workspace, "a.txt"), "one\n", "utf-8");
+    await fs.writeFile(path.join(workspace, "sub", "b.txt"), "orig\n", "utf-8");
+
+    const manager = await SessionBackupManager.create({
+      sessionId: crypto.randomUUID(),
+      workingDirectory: workspace,
+      homedir: home,
+    });
+
+    await fs.writeFile(path.join(workspace, "a.txt"), "two\n", "utf-8");
+    await fs.writeFile(path.join(workspace, "new.txt"), "new\n", "utf-8");
+    await fs.rm(path.join(workspace, "sub", "b.txt"), { force: true });
+
+    const checkpoint = await manager.createCheckpoint("auto");
+    expect(checkpoint.changed).toBe(true);
+
+    await fs.writeFile(path.join(workspace, "a.txt"), "three\n", "utf-8");
+    await fs.rm(path.join(workspace, "new.txt"), { force: true });
+    await fs.writeFile(path.join(workspace, "sub", "b.txt"), "different\n", "utf-8");
+
+    await manager.restoreCheckpoint(checkpoint.id);
+    expect(await fs.readFile(path.join(workspace, "a.txt"), "utf-8")).toBe("two\n");
+    expect(await fs.readFile(path.join(workspace, "new.txt"), "utf-8")).toBe("new\n");
+    expect(await fileExists(path.join(workspace, "sub", "b.txt"))).toBe(false);
+
+    await manager.restoreOriginal();
+    expect(await fs.readFile(path.join(workspace, "a.txt"), "utf-8")).toBe("one\n");
+    expect(await fs.readFile(path.join(workspace, "sub", "b.txt"), "utf-8")).toBe("orig\n");
+    expect(await fileExists(path.join(workspace, "new.txt"))).toBe(false);
+  });
+
+  test("deleteCheckpoint removes stored checkpoint", async () => {
+    const { home, workspace } = await makeTmpWorkspace();
+    await fs.writeFile(path.join(workspace, "a.txt"), "one\n", "utf-8");
+
+    const manager = await SessionBackupManager.create({
+      sessionId: crypto.randomUUID(),
+      workingDirectory: workspace,
+      homedir: home,
+    });
+
+    await fs.writeFile(path.join(workspace, "a.txt"), "two\n", "utf-8");
+    const checkpoint = await manager.createCheckpoint("manual");
+    expect(manager.getPublicState().checkpoints).toHaveLength(1);
+
+    const removed = await manager.deleteCheckpoint(checkpoint.id);
+    expect(removed).toBe(true);
+    expect(manager.getPublicState().checkpoints).toHaveLength(0);
+
+    const removedAgain = await manager.deleteCheckpoint(checkpoint.id);
+    expect(removedAgain).toBe(false);
+  });
+
+  test("compactClosedSessions compresses closed originals", async () => {
+    const { home, workspace } = await makeTmpWorkspace();
+    await fs.writeFile(path.join(workspace, "a.txt"), "one\n", "utf-8");
+
+    const sessionId = crypto.randomUUID();
+    const manager = await SessionBackupManager.create({
+      sessionId,
+      workingDirectory: workspace,
+      homedir: home,
+    });
+    await manager.close();
+
+    const backupsRoot = path.join(home, ".cowork", "session-backups");
+    const sessionDir = path.join(backupsRoot, sessionId);
+    const originalDir = path.join(sessionDir, "original");
+    const originalArchive = path.join(sessionDir, "original.tar.gz");
+
+    expect(await fileExists(originalDir)).toBe(true);
+    await SessionBackupManager.compactClosedSessions(backupsRoot);
+    expect(await fileExists(originalArchive)).toBe(true);
+    expect(await fileExists(originalDir)).toBe(false);
+  });
+});


### PR DESCRIPTION
Add automatic session backups and WebSocket-controlled checkpoints to enable users to revert agent workspace changes and recover from mistakes without agent awareness.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-53cd4fad-2c50-4853-ba4d-002c18117d09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-53cd4fad-2c50-4853-ba4d-002c18117d09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

