### PR TITLE
🧪 Improve test coverage for providers

### DIFF
--- a/test/providers/index.test.ts
+++ b/test/providers/index.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, spyOn, test } from "bun:test";
+import {
+  defaultModelForProvider,
+  getModelForProvider,
+  getProviderKeyCandidates,
+  PROVIDERS,
+} from "../../src/providers";
+import { makeConfig } from "./helpers";
+
+describe("src/providers/index.ts", () => {
+  describe("getModelForProvider", () => {
+    test("calls createModel on the correct provider with correct arguments", () => {
+      const config = makeConfig({ provider: "google" });
+      const modelId = "gemini-pro";
+      const savedKey = "test-key";
+
+      // Spy on the provider's createModel method
+      const createModelSpy = spyOn(PROVIDERS.google, "createModel");
+
+      // Call the function
+      getModelForProvider(config, modelId, savedKey);
+
+      // Verify the spy was called with correct arguments
+      expect(createModelSpy).toHaveBeenCalledTimes(1);
+      expect(createModelSpy).toHaveBeenCalledWith({
+        config,
+        modelId,
+        savedKey,
+      });
+
+      // Restore the spy
+      createModelSpy.mockRestore();
+    });
+
+    test("works with different provider", () => {
+      const config = makeConfig({ provider: "openai" });
+      const modelId = "gpt-4";
+
+      const createModelSpy = spyOn(PROVIDERS.openai, "createModel");
+
+      getModelForProvider(config, modelId);
+
+      expect(createModelSpy).toHaveBeenCalledTimes(1);
+      expect(createModelSpy).toHaveBeenCalledWith({
+        config,
+        modelId,
+        savedKey: undefined,
+      });
+
+      createModelSpy.mockRestore();
+    });
+  });
+
+  describe("defaultModelForProvider", () => {
+    test("returns correct default model for google", () => {
+      expect(defaultModelForProvider("google")).toBe(PROVIDERS.google.defaultModel);
+    });
+
+    test("returns correct default model for openai", () => {
+      expect(defaultModelForProvider("openai")).toBe(PROVIDERS.openai.defaultModel);
+    });
+  });
+
+  describe("getProviderKeyCandidates", () => {
+    test("returns correct key candidates for google", () => {
+      expect(getProviderKeyCandidates("google")).toBe(PROVIDERS.google.keyCandidates);
+    });
+
+    test("returns correct key candidates for openai", () => {
+      expect(getProviderKeyCandidates("openai")).toBe(PROVIDERS.openai.keyCandidates);
+    });
+  });
+});


### PR DESCRIPTION
🎯 **What:** Added unit tests for `src/providers/index.ts`.
📊 **Coverage:** Covered `getModelForProvider`, `defaultModelForProvider`, and `getProviderKeyCandidates`.
✨ **Result:** Verified that `getModelForProvider` correctly delegates to the provider implementation.

---
*PR created automatically by Jules for task [16862802627113875555](https://jules.google.com/task/16862802627113875555) started by @mweinbach*