### PR TITLE
🧪 Improve extractTriggers robustness and testing

### DIFF
--- a/src/skills/index.ts
+++ b/src/skills/index.ts
@@ -3,8 +3,8 @@ import path from "node:path";
 
 import type { SkillEntry } from "../types";
 
-function extractTriggers(name: string, content: string): string[] {
-  const triggerMatch = content.match(/^TRIGGERS?:\s*(.+)$/im);
+export function extractTriggers(name: string, content: string): string[] {
+  const triggerMatch = content.match(/^\s*TRIGGERS?\s*:\s*(.+)$/im);
   if (triggerMatch) {
     return triggerMatch[1]
       .split(",")

--- a/test/skills.extractTriggers.test.ts
+++ b/test/skills.extractTriggers.test.ts
@@ -1,0 +1,44 @@
+import { extractTriggers } from "../src/skills/index";
+import { describe, test, expect } from "bun:test";
+
+describe("extractTriggers", () => {
+  test("extracts triggers with standard formatting", () => {
+    const content = "TRIGGERS: a, b";
+    expect(extractTriggers("test", content)).toEqual(["a", "b"]);
+  });
+
+  test("extracts triggers with leading whitespace", () => {
+    const content = "  TRIGGERS: a, b";
+    expect(extractTriggers("test", content)).toEqual(["a", "b"]);
+  });
+
+  test("extracts triggers with spaces around colon", () => {
+    const content = "TRIGGERS : a, b";
+    expect(extractTriggers("test", content)).toEqual(["a", "b"]);
+  });
+
+  test("extracts triggers with case insensitivity", () => {
+    const content = "triggers: a, b";
+    expect(extractTriggers("test", content)).toEqual(["a", "b"]);
+  });
+
+  test("extracts triggers with special characters", () => {
+    const content = "TRIGGERS: @home, #work, c++, node.js";
+    expect(extractTriggers("test", content)).toEqual(["@home", "#work", "c++", "node.js"]);
+  });
+
+  test("handles empty values and trailing commas", () => {
+    const content = "TRIGGERS: a,, b,";
+    expect(extractTriggers("test", content)).toEqual(["a", "b"]);
+  });
+
+  test("returns defaults if no match found (known skill)", () => {
+    const content = "No triggers here";
+    expect(extractTriggers("pdf", content)).toEqual(["pdf", ".pdf", "form", "merge", "split"]);
+  });
+
+  test("returns name as default if no match found (unknown skill)", () => {
+    const content = "No triggers here";
+    expect(extractTriggers("unknown-skill", content)).toEqual(["unknown-skill"]);
+  });
+});


### PR DESCRIPTION
🧪 Improve extractTriggers robustness and testing

🎯 **What:** The `extractTriggers` function in `src/skills/index.ts` was using a regex that was fragile to unexpected formatting (e.g., indentation, spacing around colon). This was causing valid triggers to be missed if the formatting wasn't exactly `TRIGGER: value`.

📊 **Coverage:** Added a new test file `test/skills.extractTriggers.test.ts` that specifically targets `extractTriggers`. This covers:
- Leading whitespace (`  TRIGGERS:`)
- Spacing around colon (`TRIGGERS :`)
- Case insensitivity (`triggers:`)
- Special characters
- Empty values
- No match scenarios

✨ **Result:**
- Exported `extractTriggers` for easier unit testing.
- Updated the regex to `^\s*TRIGGERS?\s*:\s*(.+)$/im` to be more robust.
- Verified that all new edge cases now pass, and existing tests in `test/skills.test.ts` still pass (no regressions).

---
*PR created automatically by Jules for task [4952337908020557587](https://jules.google.com/task/4952337908020557587) started by @mweinbach*