### PR TITLE
Add harness observability stack, realtime portal, and testing CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  checks:
+    name: Docs + Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Docs consistency check
+        run: bun run docs:check
+
+      - name: Unit tests
+        run: bun test
+
+  harness_smoke:
+    name: Harness Smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    needs:
+      - checks
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Docker info
+        run: docker version
+
+      - name: Harness smoke
+        run: bun run harness:smoke -- --run-id ci-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,16 @@ on:
   push:
     branches:
       - main
+      - testing
   pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   checks:
@@ -27,6 +36,9 @@ jobs:
       - name: Unit tests
         run: bun test
 
+      - name: Portal build
+        run: bun run portal:build
+
   harness_smoke:
     name: Harness Smoke
     runs-on: ubuntu-latest
@@ -48,3 +60,55 @@ jobs:
 
       - name: Harness smoke
         run: bun run harness:smoke -- --run-id ci-${{ github.run_id }}-${{ github.run_attempt }}
+
+  harness_full_testing:
+    name: Harness Full (Testing Env)
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    needs:
+      - harness_smoke
+    if: ${{ github.event_name != 'pull_request' }}
+    environment:
+      name: Testing
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}
+      GEMINI_API_KEY: ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Docker info
+        run: docker version
+
+      - name: Validate required provider secrets
+        run: |
+          missing=0
+          for k in OPENAI_API_KEY GOOGLE_GENERATIVE_AI_API_KEY ANTHROPIC_API_KEY; do
+            if [ -z "${!k}" ]; then
+              echo "Missing required secret: $k"
+              missing=1
+            fi
+          done
+          if [ "$missing" -ne 0 ]; then
+            exit 1
+          fi
+
+      - name: Full harness run (observability/report-only)
+        run: bun run harness:run
+
+      - name: Upload harness artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: harness-output-${{ github.run_id }}-${{ github.run_attempt }}
+          path: output/raw-agent-loop_mixed_*
+          if-no-files-found: warn
+          retention-days: 14

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,10 @@ agent-coworker is a terminal-first coworker agent built on Bun + TypeScript (ESM
 - `src/tools/`: built-in tools (`bash`, `read`, `write`, `webSearch`, etc.)
 - `test/`: Bun tests (`*.test.ts`)
 - `config/`: built-in defaults and MCP server defaults
+- `config/observability/`: local observability stack definitions (Vector + Victoria)
 - `prompts/`: system + sub-agent prompts
 - `skills/`: bundled skill docs/assets used by the agent
+- `docs/harness/index.md`: harness context/observability/SLO system-of-record map
 
 ## Build, Test, and Development Commands
 

--- a/README.md
+++ b/README.md
@@ -132,3 +132,4 @@ Full operational runbook:
 - `docs/harness/runbook.md`
 - `docs/harness/runbook.md` section `9.4 End-to-end: run in a target directory + watch live traces`
 - `docs/harness/runbook.md` section `17. Next.js Web Portal (Realtime)`
+- `docs/harness/runbook.md` section `18. GitHub CI In Testing Environment`

--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ Environment variables:
 - `AGENT_OUTPUT_DIR`, `AGENT_UPLOADS_DIR`
 - `AGENT_USER_NAME`
 - `AGENT_ENABLE_MCP` (`true|false`, defaults to `true`)
+- `AGENT_OBSERVABILITY_ENABLED` (`true|false`, defaults to `false`)
+- `AGENT_OBS_OTLP_HTTP` (OTLP HTTP endpoint)
+- `AGENT_OBS_LOGS_URL`, `AGENT_OBS_METRICS_URL`, `AGENT_OBS_TRACES_URL` (query API base URLs)
+- `AGENT_HARNESS_REPORT_ONLY` (`true|false`, defaults to `true`)
+- `AGENT_HARNESS_STRICT_MODE` (`true|false`, defaults to `false`)
 
 Config files (optional):
 - `./.agent/config.json` (project)
@@ -105,3 +110,25 @@ Watch mode:
 ```bash
 bun run dev
 ```
+
+Harness + observability helpers:
+```bash
+bun run obs:up
+bun run obs:status
+bun run harness:smoke
+bun run harness:run
+bun run obs:down
+```
+
+Harness web portal (Next.js realtime dashboard):
+```bash
+bun run portal:dev
+# build/start:
+bun run portal:build
+bun run portal:start
+```
+
+Full operational runbook:
+- `docs/harness/runbook.md`
+- `docs/harness/runbook.md` section `9.4 End-to-end: run in a target directory + watch live traces`
+- `docs/harness/runbook.md` section `17. Next.js Web Portal (Realtime)`

--- a/apps/desktop/src/app/types.ts
+++ b/apps/desktop/src/app/types.ts
@@ -42,6 +42,10 @@ export type FeedItem =
   | { id: string; kind: "message"; role: "user" | "assistant"; ts: string; text: string }
   | { id: string; kind: "reasoning"; mode: "reasoning" | "summary"; ts: string; text: string }
   | { id: string; kind: "todos"; ts: string; todos: TodoItem[] }
+  | { id: string; kind: "observabilityStatus"; ts: string; enabled: boolean; summary: string }
+  | { id: string; kind: "harnessContext"; ts: string; context: HarnessContextPayload | null }
+  | { id: string; kind: "observabilityQueryResult"; ts: string; result: ObservabilityQueryResultPayload }
+  | { id: string; kind: "harnessSloResult"; ts: string; result: HarnessSloResultPayload }
   | { id: string; kind: "log"; ts: string; line: string }
   | { id: string; kind: "error"; ts: string; message: string }
   | { id: string; kind: "system"; ts: string; line: string };
@@ -88,6 +92,15 @@ export type SessionBackupPublicState = SessionBackupStateEvent["backup"];
 export type SessionBackupReason = SessionBackupStateEvent["reason"];
 export type SessionBackupCheckpoint = SessionBackupPublicState["checkpoints"][number];
 
+export type ObservabilityStatusEvent = Extract<ServerEvent, { type: "observability_status" }>;
+export type HarnessContextEvent = Extract<ServerEvent, { type: "harness_context" }>;
+export type ObservabilityQueryResultEvent = Extract<ServerEvent, { type: "observability_query_result" }>;
+export type HarnessSloResultEvent = Extract<ServerEvent, { type: "harness_slo_result" }>;
+
+export type HarnessContextPayload = HarnessContextEvent["context"];
+export type ObservabilityQueryResultPayload = ObservabilityQueryResultEvent["result"];
+export type HarnessSloResultPayload = HarnessSloResultEvent["result"];
+
 export type ConnectDraft = {
   provider: ProviderName;
   apiKey: string;
@@ -120,5 +133,18 @@ export type Notification = {
 
 export type ThreadEvent = Extract<
   ServerEvent,
-  { type: "assistant_message" | "reasoning" | "todos" | "log" | "error" | "user_message" | "session_busy" }
+  {
+    type:
+      | "assistant_message"
+      | "reasoning"
+      | "todos"
+      | "log"
+      | "error"
+      | "user_message"
+      | "session_busy"
+      | "observability_status"
+      | "harness_context"
+      | "observability_query_result"
+      | "harness_slo_result";
+  }
 >;

--- a/apps/portal/.gitignore
+++ b/apps/portal/.gitignore
@@ -1,0 +1,2 @@
+.next
+node_modules

--- a/apps/portal/app/api/observability/query/route.ts
+++ b/apps/portal/app/api/observability/query/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+
+import { runObservabilityQuery, type ObservabilityQueryRequest } from "@/lib/observability";
+
+export const dynamic = "force-dynamic";
+
+function isQueryType(v: unknown): v is ObservabilityQueryRequest["queryType"] {
+  return v === "logql" || v === "promql" || v === "traceql";
+}
+
+export async function POST(request: Request) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const payload = typeof body === "object" && body !== null ? (body as Record<string, unknown>) : null;
+  if (!payload) return NextResponse.json({ error: "Expected object body" }, { status: 400 });
+
+  if (!isQueryType(payload.queryType)) {
+    return NextResponse.json({ error: "Invalid queryType" }, { status: 400 });
+  }
+  if (typeof payload.query !== "string") {
+    return NextResponse.json({ error: "Invalid query" }, { status: 400 });
+  }
+
+  const reqPayload: ObservabilityQueryRequest = {
+    queryType: payload.queryType,
+    query: payload.query,
+    fromMs: typeof payload.fromMs === "number" ? payload.fromMs : undefined,
+    toMs: typeof payload.toMs === "number" ? payload.toMs : undefined,
+    limit: typeof payload.limit === "number" ? payload.limit : undefined,
+  };
+
+  const result = await runObservabilityQuery(reqPayload);
+  return NextResponse.json(result);
+}

--- a/apps/portal/app/api/observability/snapshot/route.ts
+++ b/apps/portal/app/api/observability/snapshot/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from "next/server";
+
+import { getObservabilitySnapshot } from "@/lib/observability";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const snapshot = await getObservabilitySnapshot();
+  return NextResponse.json(snapshot);
+}

--- a/apps/portal/app/api/runs/detail/route.ts
+++ b/apps/portal/app/api/runs/detail/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+
+import { getHarnessRunDetail } from "@/lib/harness";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const runRoot = searchParams.get("runRoot") ?? "";
+  const runDir = searchParams.get("runDir") ?? "";
+
+  if (!runRoot || !runDir) {
+    return NextResponse.json({ error: "Missing runRoot or runDir" }, { status: 400 });
+  }
+
+  const detail = await getHarnessRunDetail(runRoot, runDir);
+  if (!detail) {
+    return NextResponse.json({ error: "Run not found" }, { status: 404 });
+  }
+
+  return NextResponse.json(detail);
+}

--- a/apps/portal/app/api/runs/route.ts
+++ b/apps/portal/app/api/runs/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+
+import { getHarnessRunsSnapshot } from "@/lib/harness";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const limitRaw = Number(searchParams.get("limitRoots") ?? "30");
+  const limitRoots = Number.isFinite(limitRaw) ? limitRaw : 30;
+
+  const snapshot = await getHarnessRunsSnapshot({ limitRoots });
+  return NextResponse.json(snapshot);
+}

--- a/apps/portal/app/api/stream/runs/route.ts
+++ b/apps/portal/app/api/stream/runs/route.ts
@@ -1,0 +1,79 @@
+import { getHarnessRunsSnapshot } from "@/lib/harness";
+
+export const dynamic = "force-dynamic";
+
+function encodeData(payload: unknown): Uint8Array {
+  return new TextEncoder().encode(`data: ${JSON.stringify(payload)}\n\n`);
+}
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const intervalMsRaw = Number(searchParams.get("intervalMs") ?? "2000");
+  const limitRaw = Number(searchParams.get("limitRoots") ?? "30");
+
+  const intervalMs = Math.max(500, Math.min(15_000, Number.isFinite(intervalMsRaw) ? intervalMsRaw : 2000));
+  const limitRoots = Math.max(1, Math.min(100, Number.isFinite(limitRaw) ? limitRaw : 30));
+
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      let closed = false;
+      let lastDigest = "";
+
+      const cleanup = () => {
+        if (closed) return;
+        closed = true;
+        clearInterval(intervalTimer);
+        clearInterval(heartbeatTimer);
+        try {
+          controller.close();
+        } catch {
+          // ignore double-close races
+        }
+      };
+
+      const sendSnapshot = async () => {
+        if (closed) return;
+        try {
+          const snapshot = await getHarnessRunsSnapshot({ limitRoots });
+          const digest = JSON.stringify(
+            snapshot.roots.map((root) => ({
+              runRootName: root.runRootName,
+              updatedAtMs: root.updatedAtMs,
+              runs: root.runs.map((run) => ({ runDirName: run.runDirName, updatedAtMs: run.updatedAtMs, status: run.status })),
+            }))
+          );
+
+          if (digest === lastDigest) return;
+          lastDigest = digest;
+          controller.enqueue(encodeData(snapshot));
+        } catch (err) {
+          controller.enqueue(
+            encodeData({ type: "stream_error", message: String(err), at: new Date().toISOString() })
+          );
+        }
+      };
+
+      await sendSnapshot();
+
+      const intervalTimer = setInterval(() => {
+        void sendSnapshot();
+      }, intervalMs);
+
+      const heartbeatTimer = setInterval(() => {
+        if (closed) return;
+        controller.enqueue(new TextEncoder().encode(`: heartbeat ${Date.now()}\n\n`));
+      }, 12_000);
+
+      request.signal.addEventListener("abort", cleanup);
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+      "X-Accel-Buffering": "no",
+    },
+  });
+}

--- a/apps/portal/app/globals.css
+++ b/apps/portal/app/globals.css
@@ -1,0 +1,508 @@
+:root {
+  --bg: #060811;
+  --bg-alt: #0f1322;
+  --panel: #12182a;
+  --panel-2: #1a2238;
+  --ink: #f4f7ff;
+  --ink-soft: #b8c2de;
+  --muted: #8b99bf;
+  --border: #2a3555;
+  --good: #2cd08f;
+  --warn: #ffbb4d;
+  --bad: #ff6b7d;
+  --pending: #7aa5ff;
+  --accent: #7ad7ff;
+  --shadow: 0 12px 32px rgba(4, 6, 18, 0.45);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  min-height: 100%;
+  font-family: "IBM Plex Sans", "Avenir Next", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(circle at 80% -10%, rgba(122, 215, 255, 0.14), transparent 45%),
+    radial-gradient(circle at -5% 0%, rgba(255, 107, 125, 0.1), transparent 40%),
+    linear-gradient(135deg, #05070f 0%, #090d18 40%, #0b1220 100%);
+  color: var(--ink);
+}
+
+pre,
+code,
+textarea,
+input,
+select,
+button {
+  font-family: "JetBrains Mono", "SFMono-Regular", Menlo, monospace;
+}
+
+.portal-shell {
+  width: 100%;
+  max-width: 1760px;
+  margin: 0 auto;
+  padding: 24px;
+  display: grid;
+  gap: 16px;
+}
+
+.portal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 20px;
+  background: linear-gradient(120deg, rgba(26, 34, 56, 0.9), rgba(12, 18, 32, 0.92));
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 18px 20px;
+  box-shadow: var(--shadow);
+}
+
+.portal-header h1 {
+  margin: 0;
+  font-size: 1.7rem;
+  letter-spacing: 0.01em;
+}
+
+.eyebrow {
+  margin: 0 0 6px 0;
+  color: var(--accent);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 0.74rem;
+  font-weight: 700;
+}
+
+.subtle {
+  margin: 6px 0 0 0;
+  color: var(--muted);
+  font-size: 0.86rem;
+}
+
+.status-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: flex-end;
+}
+
+.kpi-grid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.kpi-card {
+  background: linear-gradient(165deg, rgba(18, 24, 42, 0.94), rgba(14, 21, 36, 0.94));
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 12px 14px;
+  box-shadow: var(--shadow);
+}
+
+.kpi-card h2 {
+  margin: 0;
+  color: var(--ink-soft);
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.kpi-card strong {
+  display: block;
+  margin-top: 8px;
+  font-size: 1.6rem;
+  line-height: 1;
+}
+
+.layout-grid {
+  display: grid;
+  grid-template-columns: 330px 1fr 420px;
+  gap: 14px;
+  min-height: 68vh;
+}
+
+.panel {
+  background: linear-gradient(170deg, rgba(18, 24, 42, 0.96), rgba(10, 14, 26, 0.96));
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 14px;
+  box-shadow: var(--shadow);
+  overflow: hidden;
+}
+
+.panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.panel-header h2 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.run-list-panel {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.run-root-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  overflow: auto;
+  padding-right: 4px;
+}
+
+.run-root-card {
+  border: 1px solid #27355a;
+  border-radius: 10px;
+  padding: 10px;
+  background: linear-gradient(180deg, rgba(21, 28, 47, 0.8), rgba(15, 20, 36, 0.8));
+}
+
+.run-root-card h3 {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--ink);
+  overflow-wrap: anywhere;
+}
+
+.micro {
+  margin: 5px 0 0 0;
+  font-size: 0.74rem;
+  color: var(--ink-soft);
+}
+
+.run-item-list {
+  margin-top: 8px;
+  display: grid;
+  gap: 8px;
+}
+
+.run-item {
+  width: 100%;
+  border: 1px solid #2b3a62;
+  border-radius: 9px;
+  background: linear-gradient(180deg, rgba(16, 22, 38, 0.9), rgba(11, 16, 30, 0.9));
+  color: var(--ink);
+  text-align: left;
+  padding: 8px;
+  cursor: pointer;
+  transition: border-color 120ms ease, transform 120ms ease;
+}
+
+.run-item:hover {
+  border-color: #4d79db;
+  transform: translateY(-1px);
+}
+
+.run-item.selected {
+  border-color: #82d7ff;
+  box-shadow: 0 0 0 1px rgba(130, 215, 255, 0.4);
+}
+
+.run-item-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.run-item-head strong {
+  font-size: 0.84rem;
+  overflow-wrap: anywhere;
+}
+
+.run-preview {
+  margin: 6px 0 0 0;
+  color: var(--muted);
+  font-size: 0.76rem;
+  line-height: 1.3;
+}
+
+.details-panel {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.detail-grid {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  overflow: auto;
+  padding-right: 4px;
+}
+
+.detail-card {
+  border: 1px solid #2a3555;
+  border-radius: 10px;
+  padding: 10px;
+  background: linear-gradient(180deg, rgba(20, 26, 44, 0.84), rgba(12, 18, 30, 0.9));
+}
+
+.detail-card.wide {
+  grid-column: 1 / -1;
+}
+
+.detail-card h3 {
+  margin: 0 0 8px 0;
+  font-size: 0.89rem;
+  color: var(--ink-soft);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.detail-card pre,
+.query-result pre,
+.obs-endpoints pre {
+  margin: 0;
+  border: 1px solid #2b3a62;
+  border-radius: 8px;
+  background: #0b1120;
+  padding: 10px;
+  font-size: 0.74rem;
+  line-height: 1.45;
+  max-height: 300px;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.attempt-table-wrap {
+  max-height: 230px;
+  overflow: auto;
+  border: 1px solid #2b3a62;
+  border-radius: 8px;
+}
+
+.attempt-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.75rem;
+}
+
+.attempt-table th,
+.attempt-table td {
+  border-bottom: 1px solid #243252;
+  padding: 6px;
+  text-align: left;
+  vertical-align: top;
+}
+
+.attempt-table th {
+  color: var(--ink-soft);
+  background: #10162b;
+  position: sticky;
+  top: 0;
+}
+
+.observability-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.obs-health-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.obs-metrics-grid {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.mini-card {
+  border: 1px solid #2a3555;
+  border-radius: 10px;
+  padding: 10px;
+  background: linear-gradient(180deg, rgba(22, 29, 49, 0.9), rgba(15, 21, 35, 0.94));
+}
+
+.mini-card h3 {
+  margin: 0;
+  font-size: 0.76rem;
+  color: var(--ink-soft);
+  text-transform: uppercase;
+}
+
+.mini-card strong {
+  display: block;
+  margin-top: 8px;
+  font-size: 1.35rem;
+}
+
+.query-form {
+  display: grid;
+  gap: 10px;
+  border: 1px solid #2a3555;
+  border-radius: 10px;
+  padding: 10px;
+  background: linear-gradient(180deg, rgba(23, 30, 49, 0.9), rgba(14, 20, 34, 0.94));
+}
+
+.query-form h3 {
+  margin: 0;
+  font-size: 0.86rem;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+}
+
+.query-form label {
+  display: grid;
+  gap: 6px;
+  font-size: 0.76rem;
+  color: var(--ink-soft);
+}
+
+.query-form select,
+.query-form textarea,
+.query-form input {
+  border: 1px solid #2f4069;
+  border-radius: 7px;
+  background: #0a1020;
+  color: var(--ink);
+  padding: 8px;
+  font-size: 0.76rem;
+}
+
+.query-form textarea {
+  resize: vertical;
+}
+
+.query-form button {
+  justify-self: start;
+  border: 1px solid #59bce8;
+  border-radius: 8px;
+  background: linear-gradient(135deg, #13334d, #0d273b);
+  color: #cbeeff;
+  padding: 8px 11px;
+  font-size: 0.76rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.query-form button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.query-result h3 {
+  margin: 0 0 8px 0;
+  font-size: 0.86rem;
+  color: var(--ink-soft);
+}
+
+.empty {
+  margin: 4px 0;
+  color: var(--muted);
+  font-size: 0.82rem;
+}
+
+.error-text {
+  margin: 6px 0;
+  color: var(--bad);
+  font-size: 0.76rem;
+  overflow-wrap: anywhere;
+}
+
+.ok-text {
+  color: var(--good);
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  padding: 4px 8px;
+}
+
+.pill-complete {
+  color: #b3ffd9;
+  border-color: rgba(44, 208, 143, 0.55);
+  background: rgba(27, 86, 63, 0.35);
+}
+
+.pill-running {
+  color: #ffe1ab;
+  border-color: rgba(255, 187, 77, 0.55);
+  background: rgba(102, 68, 14, 0.4);
+}
+
+.pill-failed {
+  color: #ffd0d8;
+  border-color: rgba(255, 107, 125, 0.65);
+  background: rgba(108, 27, 40, 0.38);
+}
+
+.pill-pending {
+  color: #ccddff;
+  border-color: rgba(122, 165, 255, 0.6);
+  background: rgba(39, 60, 104, 0.4);
+}
+
+.pill-muted {
+  color: var(--ink-soft);
+  border-color: #334a7f;
+  background: rgba(29, 41, 72, 0.4);
+}
+
+@media (max-width: 1520px) {
+  .layout-grid {
+    grid-template-columns: 300px 1fr;
+  }
+
+  .observability-panel {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (max-width: 1080px) {
+  .portal-shell {
+    padding: 12px;
+  }
+
+  .portal-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .status-stack {
+    align-items: flex-start;
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+
+  .kpi-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .layout-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .detail-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .detail-card.wide {
+    grid-column: auto;
+  }
+}

--- a/apps/portal/app/layout.tsx
+++ b/apps/portal/app/layout.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "Agent Coworker Harness Portal",
+  description: "Live portal for harness runs, traces, artifacts, and observability.",
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/apps/portal/app/page.tsx
+++ b/apps/portal/app/page.tsx
@@ -1,0 +1,5 @@
+import { Dashboard } from "@/components/dashboard";
+
+export default function Page() {
+  return <Dashboard />;
+}

--- a/apps/portal/bun.lock
+++ b/apps/portal/bun.lock
@@ -1,0 +1,138 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "agent-coworker-portal",
+      "dependencies": {
+        "next": "15.3.4",
+        "react": "19.0.0",
+        "react-dom": "19.0.0",
+      },
+      "devDependencies": {
+        "@types/node": "^24.3.0",
+        "@types/react": "^19.1.10",
+        "typescript": "^5.9.2",
+      },
+    },
+  },
+  "packages": {
+    "@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
+
+    "@img/colour": ["@img/colour@1.0.0", "", {}, "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw=="],
+
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
+
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
+
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
+
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
+
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
+
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
+
+    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA=="],
+
+    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.2.4", "", { "os": "linux", "cpu": "none" }, "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA=="],
+
+    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
+
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
+
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
+
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
+
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
+
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
+
+    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.4" }, "os": "linux", "cpu": "ppc64" }, "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA=="],
+
+    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.2.4" }, "os": "linux", "cpu": "none" }, "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw=="],
+
+    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
+
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
+
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
+
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
+
+    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
+
+    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
+
+    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
+
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
+
+    "@next/env": ["@next/env@15.3.4", "", {}, "sha512-ZkdYzBseS6UjYzz6ylVKPOK+//zLWvD6Ta+vpoye8cW11AjiQjGYVibF0xuvT4L0iJfAPfZLFidaEzAOywyOAQ=="],
+
+    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@15.3.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-z0qIYTONmPRbwHWvpyrFXJd5F9YWLCsw3Sjrzj2ZvMYy9NPQMPZ1NjOJh4ojr4oQzcGYwgJKfidzehaNa1BpEg=="],
+
+    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@15.3.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-Z0FYJM8lritw5Wq+vpHYuCIzIlEMjewG2aRkc3Hi2rcbULknYL/xqfpBL23jQnCSrDUGAo/AEv0Z+s2bff9Zkw=="],
+
+    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@15.3.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-l8ZQOCCg7adwmsnFm8m5q9eIPAHdaB2F3cxhufYtVo84pymwKuWfpYTKcUiFcutJdp9xGHC+F1Uq3xnFU1B/7g=="],
+
+    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@15.3.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-wFyZ7X470YJQtpKot4xCY3gpdn8lE9nTlldG07/kJYexCUpX1piX+MBfZdvulo+t1yADFVEuzFfVHfklfEx8kw=="],
+
+    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@15.3.4", "", { "os": "linux", "cpu": "x64" }, "sha512-gEbH9rv9o7I12qPyvZNVTyP/PWKqOp8clvnoYZQiX800KkqsaJZuOXkWgMa7ANCCh/oEN2ZQheh3yH8/kWPSEg=="],
+
+    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@15.3.4", "", { "os": "linux", "cpu": "x64" }, "sha512-Cf8sr0ufuC/nu/yQ76AnarbSAXcwG/wj+1xFPNbyNo8ltA6kw5d5YqO8kQuwVIxk13SBdtgXrNyom3ZosHAy4A=="],
+
+    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@15.3.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-ay5+qADDN3rwRbRpEhTOreOn1OyJIXS60tg9WMYTWCy3fB6rGoyjLVxc4dR9PYjEdR2iDYsaF5h03NA+XuYPQQ=="],
+
+    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.3.4", "", { "os": "win32", "cpu": "x64" }, "sha512-4kDt31Bc9DGyYs41FTL1/kNpDeHyha2TC0j5sRRoKCyrhNcfZ/nRQkAUlF27mETwm8QyHqIjHJitfcza2Iykfg=="],
+
+    "@swc/counter": ["@swc/counter@0.1.3", "", {}, "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ=="],
+
+    "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
+
+    "@types/node": ["@types/node@24.10.13", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-oH72nZRfDv9lADUBSo104Aq7gPHpQZc4BTx38r9xf9pg5LfP6EzSyH2n7qFmmxRQXh7YlUXODcYsg6PuTDSxGg=="],
+
+    "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
+
+    "busboy": ["busboy@1.6.0", "", { "dependencies": { "streamsearch": "^1.1.0" } }, "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA=="],
+
+    "caniuse-lite": ["caniuse-lite@1.0.30001769", "", {}, "sha512-BCfFL1sHijQlBGWBMuJyhZUhzo7wer5sVj9hqekB/7xn0Ypy+pER/edCYQm4exbXj4WiySGp40P8UuTh6w1srg=="],
+
+    "client-only": ["client-only@0.0.1", "", {}, "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="],
+
+    "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
+    "next": ["next@15.3.4", "", { "dependencies": { "@next/env": "15.3.4", "@swc/counter": "0.1.3", "@swc/helpers": "0.5.15", "busboy": "1.6.0", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.3.4", "@next/swc-darwin-x64": "15.3.4", "@next/swc-linux-arm64-gnu": "15.3.4", "@next/swc-linux-arm64-musl": "15.3.4", "@next/swc-linux-x64-gnu": "15.3.4", "@next/swc-linux-x64-musl": "15.3.4", "@next/swc-win32-arm64-msvc": "15.3.4", "@next/swc-win32-x64-msvc": "15.3.4", "sharp": "^0.34.1" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.41.2", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-mHKd50C+mCjam/gcnwqL1T1vPx/XQNFlXqFIVdgQdVAFY9iIQtY0IfaVflEYzKiqjeA7B0cYYMaCrmAYFjs4rA=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
+
+    "react": ["react@19.0.0", "", {}, "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ=="],
+
+    "react-dom": ["react-dom@19.0.0", "", { "dependencies": { "scheduler": "^0.25.0" }, "peerDependencies": { "react": "^19.0.0" } }, "sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ=="],
+
+    "scheduler": ["scheduler@0.25.0", "", {}, "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA=="],
+
+    "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "streamsearch": ["streamsearch@1.1.0", "", {}, "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="],
+
+    "styled-jsx": ["styled-jsx@5.1.6", "", { "dependencies": { "client-only": "0.0.1" }, "peerDependencies": { "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0" } }, "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+  }
+}

--- a/apps/portal/components/dashboard.tsx
+++ b/apps/portal/components/dashboard.tsx
@@ -1,0 +1,642 @@
+"use client";
+
+import { FormEvent, useEffect, useMemo, useState } from "react";
+
+type RunStatus = "pending" | "running" | "completed" | "failed";
+
+type HarnessRunSummary = {
+  runId: string;
+  runDirName: string;
+  provider: string;
+  requestedModel: string | null;
+  resolvedModel: string | null;
+  startedAt: string | null;
+  finishedAt: string | null;
+  status: RunStatus;
+  attemptsTotal: number;
+  attemptsSucceeded: number;
+  lastError: string | null;
+  finalPreview: string;
+  observabilityEnabled: boolean;
+  sloPassed: boolean | null;
+  updatedAtMs: number;
+};
+
+type HarnessRunRootSummary = {
+  runRootName: string;
+  createdAt: string | null;
+  harness: {
+    observability: boolean;
+    reportOnly: boolean;
+    strictMode: boolean;
+    keepStack: boolean;
+  } | null;
+  runs: HarnessRunSummary[];
+  updatedAtMs: number;
+};
+
+type HarnessRunsSnapshot = {
+  repoRoot: string;
+  outputDirectory: string;
+  generatedAt: string;
+  roots: HarnessRunRootSummary[];
+};
+
+type HarnessRunDetail = {
+  repoRoot: string;
+  runRootName: string;
+  runDirName: string;
+  manifest: Record<string, unknown> | null;
+  runMeta: Record<string, unknown> | null;
+  prompt: string;
+  system: string;
+  final: string;
+  finalReasoning: string;
+  attempts: Array<Record<string, unknown>>;
+  traceSummary: {
+    startedAt: string | null;
+    finishedAt: string | null;
+    stepCount: number;
+    askEvents: number;
+    approvalEvents: number;
+    todoEvents: number;
+    error: string | null;
+    responseMessages: number;
+  };
+  traceStepPreview: {
+    first: Array<Record<string, unknown>>;
+    last: Array<Record<string, unknown>>;
+  };
+  sloChecks: Array<Record<string, unknown>>;
+  sloReport: Record<string, unknown> | null;
+  observabilityQueries: Array<Record<string, unknown>>;
+  artifactsIndex: Array<Record<string, unknown>>;
+  toolLogTail: string[];
+  files: string[];
+  updatedAtMs: number;
+};
+
+type ObservabilitySnapshot = {
+  generatedAt: string;
+  endpoints: {
+    otlpHttpEndpoint: string;
+    logsBaseUrl: string;
+    metricsBaseUrl: string;
+    tracesBaseUrl: string;
+  };
+  health: {
+    logs: boolean;
+    metrics: boolean;
+    traces: boolean;
+  };
+  metrics: {
+    vectorErrorRate: number | null;
+    recentAgentTurnSpans: number | null;
+  };
+};
+
+type QueryType = "logql" | "promql" | "traceql";
+
+type ObservabilityQueryResult = {
+  queryType: QueryType;
+  query: string;
+  fromMs: number;
+  toMs: number;
+  status: "ok" | "error";
+  data: unknown;
+  error?: string;
+};
+
+type ConnectionState = "connecting" | "connected" | "disconnected" | "error";
+
+function formatDate(input: string | null): string {
+  if (!input) return "n/a";
+  const parsed = new Date(input);
+  if (Number.isNaN(parsed.valueOf())) return input;
+  return parsed.toLocaleString();
+}
+
+function statusClass(status: RunStatus): string {
+  if (status === "completed") return "pill pill-complete";
+  if (status === "running") return "pill pill-running";
+  if (status === "failed") return "pill pill-failed";
+  return "pill pill-pending";
+}
+
+function healthClass(ok: boolean): string {
+  return ok ? "pill pill-complete" : "pill pill-failed";
+}
+
+function safeJson(value: unknown): string {
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function findFirstRun(snapshot: HarnessRunsSnapshot | null): { runRoot: string; runDir: string } | null {
+  if (!snapshot || snapshot.roots.length === 0) return null;
+  const root = snapshot.roots.find((entry) => entry.runs.length > 0);
+  if (!root) return null;
+  return { runRoot: root.runRootName, runDir: root.runs[0]!.runDirName };
+}
+
+export function Dashboard() {
+  const [runsSnapshot, setRunsSnapshot] = useState<HarnessRunsSnapshot | null>(null);
+  const [runsConnection, setRunsConnection] = useState<ConnectionState>("connecting");
+  const [runsError, setRunsError] = useState<string>("");
+
+  const [selectedRunRoot, setSelectedRunRoot] = useState<string>("");
+  const [selectedRunDir, setSelectedRunDir] = useState<string>("");
+
+  const [runDetail, setRunDetail] = useState<HarnessRunDetail | null>(null);
+  const [detailLoading, setDetailLoading] = useState<boolean>(false);
+  const [detailError, setDetailError] = useState<string>("");
+
+  const [obsSnapshot, setObsSnapshot] = useState<ObservabilitySnapshot | null>(null);
+  const [obsLoading, setObsLoading] = useState<boolean>(false);
+  const [obsError, setObsError] = useState<string>("");
+
+  const [queryType, setQueryType] = useState<QueryType>("traceql");
+  const [queryText, setQueryText] = useState<string>("_time:[now-5m, now] name:agent.turn.*");
+  const [queryLimit, setQueryLimit] = useState<number>(200);
+  const [queryResult, setQueryResult] = useState<ObservabilityQueryResult | null>(null);
+  const [queryLoading, setQueryLoading] = useState<boolean>(false);
+  const [queryError, setQueryError] = useState<string>("");
+
+  useEffect(() => {
+    const source = new EventSource("/api/stream/runs?limitRoots=40&intervalMs=2000");
+    setRunsConnection("connecting");
+
+    source.onopen = () => {
+      setRunsConnection("connected");
+      setRunsError("");
+    };
+
+    source.onmessage = (event) => {
+      try {
+        const payload = JSON.parse(event.data) as HarnessRunsSnapshot | { type: "stream_error"; message: string };
+        if ((payload as { type?: string }).type === "stream_error") {
+          setRunsError((payload as { message: string }).message);
+          return;
+        }
+        const snapshot = payload as HarnessRunsSnapshot;
+        setRunsSnapshot(snapshot);
+      } catch (err) {
+        setRunsError(`Bad stream payload: ${String(err)}`);
+      }
+    };
+
+    source.onerror = () => {
+      setRunsConnection("error");
+    };
+
+    return () => {
+      setRunsConnection("disconnected");
+      source.close();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!runsSnapshot) return;
+
+    const selectedStillExists = runsSnapshot.roots.some(
+      (root) => root.runRootName === selectedRunRoot && root.runs.some((run) => run.runDirName === selectedRunDir)
+    );
+
+    if (selectedRunRoot && selectedRunDir && selectedStillExists) {
+      return;
+    }
+
+    const first = findFirstRun(runsSnapshot);
+    if (!first) {
+      setSelectedRunRoot("");
+      setSelectedRunDir("");
+      setRunDetail(null);
+      return;
+    }
+
+    setSelectedRunRoot(first.runRoot);
+    setSelectedRunDir(first.runDir);
+  }, [runsSnapshot, selectedRunRoot, selectedRunDir]);
+
+  useEffect(() => {
+    if (!selectedRunRoot || !selectedRunDir) return;
+
+    let cancelled = false;
+
+    const loadDetail = async () => {
+      setDetailLoading(true);
+      try {
+        const response = await fetch(
+          `/api/runs/detail?runRoot=${encodeURIComponent(selectedRunRoot)}&runDir=${encodeURIComponent(selectedRunDir)}`,
+          { cache: "no-store" }
+        );
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`);
+        }
+        const payload = (await response.json()) as HarnessRunDetail;
+        if (cancelled) return;
+        setRunDetail(payload);
+        setDetailError("");
+      } catch (err) {
+        if (cancelled) return;
+        setDetailError(String(err));
+      } finally {
+        if (!cancelled) setDetailLoading(false);
+      }
+    };
+
+    void loadDetail();
+    const timer = setInterval(() => {
+      void loadDetail();
+    }, 4_000);
+
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+  }, [selectedRunRoot, selectedRunDir]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadObs = async () => {
+      setObsLoading(true);
+      try {
+        const response = await fetch("/api/observability/snapshot", { cache: "no-store" });
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        const payload = (await response.json()) as ObservabilitySnapshot;
+        if (cancelled) return;
+        setObsSnapshot(payload);
+        setObsError("");
+      } catch (err) {
+        if (!cancelled) setObsError(String(err));
+      } finally {
+        if (!cancelled) setObsLoading(false);
+      }
+    };
+
+    void loadObs();
+    const timer = setInterval(() => {
+      void loadObs();
+    }, 3_000);
+
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+  }, []);
+
+  const selectedRunSummary = useMemo(() => {
+    if (!runsSnapshot) return null;
+    const root = runsSnapshot.roots.find((entry) => entry.runRootName === selectedRunRoot);
+    if (!root) return null;
+    return root.runs.find((run) => run.runDirName === selectedRunDir) ?? null;
+  }, [runsSnapshot, selectedRunRoot, selectedRunDir]);
+
+  const totalRuns = useMemo(() => {
+    if (!runsSnapshot) return 0;
+    return runsSnapshot.roots.reduce((acc, root) => acc + root.runs.length, 0);
+  }, [runsSnapshot]);
+
+  const runningRuns = useMemo(() => {
+    if (!runsSnapshot) return 0;
+    return runsSnapshot.roots.reduce(
+      (acc, root) => acc + root.runs.filter((run) => run.status === "running").length,
+      0
+    );
+  }, [runsSnapshot]);
+
+  const failedRuns = useMemo(() => {
+    if (!runsSnapshot) return 0;
+    return runsSnapshot.roots.reduce(
+      (acc, root) => acc + root.runs.filter((run) => run.status === "failed").length,
+      0
+    );
+  }, [runsSnapshot]);
+
+  const completeRuns = useMemo(() => {
+    if (!runsSnapshot) return 0;
+    return runsSnapshot.roots.reduce(
+      (acc, root) => acc + root.runs.filter((run) => run.status === "completed").length,
+      0
+    );
+  }, [runsSnapshot]);
+
+  const submitQuery = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setQueryLoading(true);
+    setQueryError("");
+    try {
+      const response = await fetch("/api/observability/query", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          queryType,
+          query: queryText,
+          limit: queryLimit,
+        }),
+      });
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      const payload = (await response.json()) as ObservabilityQueryResult;
+      setQueryResult(payload);
+    } catch (err) {
+      setQueryError(String(err));
+    } finally {
+      setQueryLoading(false);
+    }
+  };
+
+  return (
+    <main className="portal-shell">
+      <header className="portal-header">
+        <div>
+          <p className="eyebrow">Harness Portal</p>
+          <h1>Realtime Runs + Observability</h1>
+          <p className="subtle">
+            A live Next.js view over run artifacts, attempts, traces, SLO checks, and local observability endpoints.
+          </p>
+        </div>
+        <div className="status-stack">
+          <span className={`pill ${runsConnection === "connected" ? "pill-complete" : runsConnection === "error" ? "pill-failed" : "pill-running"}`}>
+            stream: {runsConnection}
+          </span>
+          {runsSnapshot ? <span className="pill pill-muted">updated {formatDate(runsSnapshot.generatedAt)}</span> : null}
+        </div>
+      </header>
+
+      <section className="kpi-grid">
+        <article className="kpi-card">
+          <h2>Run Roots</h2>
+          <strong>{runsSnapshot?.roots.length ?? 0}</strong>
+        </article>
+        <article className="kpi-card">
+          <h2>Total Runs</h2>
+          <strong>{totalRuns}</strong>
+        </article>
+        <article className="kpi-card">
+          <h2>Running</h2>
+          <strong>{runningRuns}</strong>
+        </article>
+        <article className="kpi-card">
+          <h2>Completed</h2>
+          <strong>{completeRuns}</strong>
+        </article>
+        <article className="kpi-card">
+          <h2>Failed</h2>
+          <strong>{failedRuns}</strong>
+        </article>
+      </section>
+
+      <section className="layout-grid">
+        <aside className="panel run-list-panel">
+          <div className="panel-header">
+            <h2>Run Catalog</h2>
+            <p className="subtle">{runsSnapshot?.outputDirectory ?? "No output directory found"}</p>
+          </div>
+          {runsError ? <p className="error-text">{runsError}</p> : null}
+          {!runsSnapshot || runsSnapshot.roots.length === 0 ? (
+            <p className="empty">No `raw-agent-loop_mixed_*` runs found yet.</p>
+          ) : (
+            <div className="run-root-list">
+              {runsSnapshot.roots.map((root) => (
+                <section key={root.runRootName} className="run-root-card">
+                  <header>
+                    <h3>{root.runRootName}</h3>
+                    <p className="subtle">created {formatDate(root.createdAt)}</p>
+                    {root.harness ? (
+                      <p className="micro">
+                        obs={String(root.harness.observability)} | reportOnly={String(root.harness.reportOnly)} | strict={String(root.harness.strictMode)}
+                      </p>
+                    ) : null}
+                  </header>
+                  <div className="run-item-list">
+                    {root.runs.map((run) => {
+                      const selected = root.runRootName === selectedRunRoot && run.runDirName === selectedRunDir;
+                      return (
+                        <button
+                          key={`${root.runRootName}:${run.runDirName}`}
+                          className={`run-item ${selected ? "selected" : ""}`}
+                          onClick={() => {
+                            setSelectedRunRoot(root.runRootName);
+                            setSelectedRunDir(run.runDirName);
+                          }}
+                          type="button"
+                        >
+                          <div className="run-item-head">
+                            <span className={statusClass(run.status)}>{run.status}</span>
+                            <strong>{run.runId}</strong>
+                          </div>
+                          <p className="micro">
+                            {run.provider} · {run.resolvedModel ?? run.requestedModel ?? "model?"}
+                          </p>
+                          <p className="micro">attempts {run.attemptsSucceeded}/{run.attemptsTotal}</p>
+                          {run.finalPreview ? <p className="run-preview">{run.finalPreview}</p> : null}
+                          {run.lastError ? <p className="error-text">{run.lastError}</p> : null}
+                        </button>
+                      );
+                    })}
+                    {root.runs.length === 0 ? <p className="empty">No run directories yet.</p> : null}
+                  </div>
+                </section>
+              ))}
+            </div>
+          )}
+        </aside>
+
+        <section className="panel details-panel">
+          <div className="panel-header">
+            <h2>Selected Run</h2>
+            {selectedRunSummary ? (
+              <p className="subtle">
+                {selectedRunRoot}/{selectedRunSummary.runDirName}
+              </p>
+            ) : (
+              <p className="subtle">Select a run</p>
+            )}
+          </div>
+
+          {detailError ? <p className="error-text">{detailError}</p> : null}
+          {detailLoading && !runDetail ? <p className="empty">Loading run detail…</p> : null}
+
+          {selectedRunSummary ? (
+            <div className="detail-grid">
+              <article className="detail-card">
+                <h3>Run Status</h3>
+                <p><span className={statusClass(selectedRunSummary.status)}>{selectedRunSummary.status}</span></p>
+                <p className="micro">provider: {selectedRunSummary.provider}</p>
+                <p className="micro">model: {selectedRunSummary.resolvedModel ?? selectedRunSummary.requestedModel ?? "n/a"}</p>
+                <p className="micro">started: {formatDate(selectedRunSummary.startedAt)}</p>
+                <p className="micro">finished: {formatDate(selectedRunSummary.finishedAt)}</p>
+                <p className="micro">attempts: {selectedRunSummary.attemptsSucceeded}/{selectedRunSummary.attemptsTotal}</p>
+                <p className="micro">observability: {String(selectedRunSummary.observabilityEnabled)}</p>
+                <p className="micro">SLO passed: {selectedRunSummary.sloPassed === null ? "n/a" : String(selectedRunSummary.sloPassed)}</p>
+              </article>
+
+              <article className="detail-card">
+                <h3>Trace Summary</h3>
+                {runDetail ? (
+                  <>
+                    <p className="micro">steps: {runDetail.traceSummary.stepCount}</p>
+                    <p className="micro">ask events: {runDetail.traceSummary.askEvents}</p>
+                    <p className="micro">approval events: {runDetail.traceSummary.approvalEvents}</p>
+                    <p className="micro">todo events: {runDetail.traceSummary.todoEvents}</p>
+                    <p className="micro">response messages: {runDetail.traceSummary.responseMessages}</p>
+                    {runDetail.traceSummary.error ? <p className="error-text">{runDetail.traceSummary.error}</p> : null}
+                  </>
+                ) : (
+                  <p className="empty">No trace loaded.</p>
+                )}
+              </article>
+
+              <article className="detail-card">
+                <h3>SLO Result</h3>
+                {runDetail?.sloReport ? (
+                  <pre>{safeJson(runDetail.sloReport)}</pre>
+                ) : (
+                  <p className="empty">No `slo_report.json` in this run.</p>
+                )}
+              </article>
+
+              <article className="detail-card wide">
+                <h3>Attempts</h3>
+                {runDetail?.attempts.length ? (
+                  <div className="attempt-table-wrap">
+                    <table className="attempt-table">
+                      <thead>
+                        <tr>
+                          <th>#</th>
+                          <th>Started</th>
+                          <th>Finished</th>
+                          <th>OK</th>
+                          <th>Error</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {runDetail.attempts.map((attempt, index) => (
+                          <tr key={`${index}-${String(attempt.attempt ?? index)}`}>
+                            <td>{String(attempt.attempt ?? index + 1)}</td>
+                            <td>{formatDate(typeof attempt.startedAt === "string" ? attempt.startedAt : null)}</td>
+                            <td>{formatDate(typeof attempt.finishedAt === "string" ? attempt.finishedAt : null)}</td>
+                            <td>{String(Boolean(attempt.ok))}</td>
+                            <td>{typeof attempt.error === "string" ? attempt.error : ""}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                ) : (
+                  <p className="empty">No attempts file.</p>
+                )}
+              </article>
+
+              <article className="detail-card wide">
+                <h3>Final Output</h3>
+                <pre>{runDetail?.final || "(empty)"}</pre>
+              </article>
+
+              <article className="detail-card wide">
+                <h3>Reasoning Output</h3>
+                <pre>{runDetail?.finalReasoning || "(empty)"}</pre>
+              </article>
+
+              <article className="detail-card wide">
+                <h3>Observability Queries</h3>
+                {runDetail?.observabilityQueries.length ? (
+                  <pre>{safeJson(runDetail.observabilityQueries)}</pre>
+                ) : (
+                  <p className="empty">No `observability_queries.json` file.</p>
+                )}
+              </article>
+
+              <article className="detail-card wide">
+                <h3>Tool Log Tail (last 220 lines)</h3>
+                <pre>{runDetail?.toolLogTail.join("\n") || "(empty)"}</pre>
+              </article>
+            </div>
+          ) : (
+            <p className="empty">No run selected.</p>
+          )}
+        </section>
+
+        <section className="panel observability-panel">
+          <div className="panel-header">
+            <h2>Live Observability</h2>
+            <p className="subtle">Snapshot refreshes every 3s</p>
+          </div>
+
+          {obsError ? <p className="error-text">{obsError}</p> : null}
+
+          <div className="obs-health-row">
+            <span className={healthClass(Boolean(obsSnapshot?.health.logs))}>logs {String(Boolean(obsSnapshot?.health.logs))}</span>
+            <span className={healthClass(Boolean(obsSnapshot?.health.metrics))}>metrics {String(Boolean(obsSnapshot?.health.metrics))}</span>
+            <span className={healthClass(Boolean(obsSnapshot?.health.traces))}>traces {String(Boolean(obsSnapshot?.health.traces))}</span>
+            {obsLoading ? <span className="pill pill-running">refreshing</span> : null}
+          </div>
+
+          {obsSnapshot ? (
+            <div className="obs-metrics-grid">
+              <article className="mini-card">
+                <h3>Vector Error Rate</h3>
+                <strong>{obsSnapshot.metrics.vectorErrorRate ?? "n/a"}</strong>
+              </article>
+              <article className="mini-card">
+                <h3>Recent Turn Spans (2m)</h3>
+                <strong>{obsSnapshot.metrics.recentAgentTurnSpans ?? "n/a"}</strong>
+              </article>
+            </div>
+          ) : (
+            <p className="empty">No snapshot yet.</p>
+          )}
+
+          <details className="obs-endpoints" open>
+            <summary>Endpoints</summary>
+            <pre>{safeJson(obsSnapshot?.endpoints ?? {})}</pre>
+          </details>
+
+          <form className="query-form" onSubmit={submitQuery}>
+            <h3>Run Custom Query</h3>
+            <label>
+              Query Type
+              <select value={queryType} onChange={(event) => setQueryType(event.target.value as QueryType)}>
+                <option value="traceql">traceql</option>
+                <option value="promql">promql</option>
+                <option value="logql">logql</option>
+              </select>
+            </label>
+            <label>
+              Query
+              <textarea value={queryText} onChange={(event) => setQueryText(event.target.value)} rows={4} />
+            </label>
+            <label>
+              Limit
+              <input
+                type="number"
+                min={1}
+                max={10000}
+                value={queryLimit}
+                onChange={(event) => setQueryLimit(Number(event.target.value) || 200)}
+              />
+            </label>
+            <button type="submit" disabled={queryLoading}>
+              {queryLoading ? "Running…" : "Run Query"}
+            </button>
+          </form>
+
+          {queryError ? <p className="error-text">{queryError}</p> : null}
+          {queryResult ? (
+            <article className="query-result">
+              <h3>
+                Query Result: <span className={queryResult.status === "ok" ? "ok-text" : "error-text"}>{queryResult.status}</span>
+              </h3>
+              {queryResult.error ? <p className="error-text">{queryResult.error}</p> : null}
+              <pre>{safeJson(queryResult.data)}</pre>
+            </article>
+          ) : null}
+        </section>
+      </section>
+    </main>
+  );
+}

--- a/apps/portal/lib/harness.ts
+++ b/apps/portal/lib/harness.ts
@@ -1,0 +1,422 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const RUN_ROOT_PREFIX = "raw-agent-loop_mixed_";
+
+export type RunStatus = "pending" | "running" | "completed" | "failed";
+
+export interface HarnessRunSummary {
+  runId: string;
+  runDirName: string;
+  provider: string;
+  requestedModel: string | null;
+  resolvedModel: string | null;
+  startedAt: string | null;
+  finishedAt: string | null;
+  status: RunStatus;
+  attemptsTotal: number;
+  attemptsSucceeded: number;
+  lastError: string | null;
+  finalPreview: string;
+  observabilityEnabled: boolean;
+  sloPassed: boolean | null;
+  updatedAtMs: number;
+}
+
+export interface HarnessRunRootSummary {
+  runRootName: string;
+  createdAt: string | null;
+  harness: {
+    observability: boolean;
+    reportOnly: boolean;
+    strictMode: boolean;
+    keepStack: boolean;
+  } | null;
+  runs: HarnessRunSummary[];
+  updatedAtMs: number;
+}
+
+export interface HarnessRunsSnapshot {
+  repoRoot: string;
+  outputDirectory: string;
+  generatedAt: string;
+  roots: HarnessRunRootSummary[];
+}
+
+export interface HarnessRunDetail {
+  repoRoot: string;
+  runRootName: string;
+  runDirName: string;
+  manifest: Record<string, unknown> | null;
+  runMeta: Record<string, unknown> | null;
+  prompt: string;
+  system: string;
+  final: string;
+  finalReasoning: string;
+  attempts: Array<Record<string, unknown>>;
+  traceSummary: {
+    startedAt: string | null;
+    finishedAt: string | null;
+    stepCount: number;
+    askEvents: number;
+    approvalEvents: number;
+    todoEvents: number;
+    error: string | null;
+    responseMessages: number;
+  };
+  traceStepPreview: {
+    first: Array<Record<string, unknown>>;
+    last: Array<Record<string, unknown>>;
+  };
+  sloChecks: Array<Record<string, unknown>>;
+  sloReport: Record<string, unknown> | null;
+  observabilityQueries: Array<Record<string, unknown>>;
+  artifactsIndex: Array<Record<string, unknown>>;
+  toolLogTail: string[];
+  files: string[];
+  updatedAtMs: number;
+}
+
+function isSafeSegment(input: string): boolean {
+  return !!input && !input.includes("/") && !input.includes("\\") && !input.includes("..") && input !== ".";
+}
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.stat(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readJsonFile<T>(filePath: string): Promise<T | null> {
+  try {
+    const raw = await fs.readFile(filePath, "utf-8");
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+}
+
+async function readTextFile(filePath: string): Promise<string> {
+  try {
+    return await fs.readFile(filePath, "utf-8");
+  } catch {
+    return "";
+  }
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value : null;
+}
+
+function asBoolean(value: unknown, fallback = false): boolean {
+  return typeof value === "boolean" ? value : fallback;
+}
+
+function asNumber(value: unknown, fallback = 0): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function getNowIso(): string {
+  return new Date().toISOString();
+}
+
+function getPreview(text: string, maxChars = 280): string {
+  const normalized = text.replace(/\s+/g, " ").trim();
+  if (!normalized) return "";
+  if (normalized.length <= maxChars) return normalized;
+  return `${normalized.slice(0, maxChars - 1)}…`;
+}
+
+function toRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function toArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+async function maxMtimeMs(paths: string[]): Promise<number> {
+  let max = 0;
+  await Promise.all(
+    paths.map(async (filePath) => {
+      try {
+        const st = await fs.stat(filePath);
+        if (st.mtimeMs > max) max = st.mtimeMs;
+      } catch {
+        // ignore missing files
+      }
+    })
+  );
+  return max;
+}
+
+export async function resolveRepoRoot(): Promise<string> {
+  const fromEnv = process.env.HARNESS_REPO_ROOT;
+  if (fromEnv && (await pathExists(path.join(fromEnv, "package.json")))) {
+    return path.resolve(fromEnv);
+  }
+
+  const cwd = process.cwd();
+  const candidates = [
+    cwd,
+    path.resolve(cwd, ".."),
+    path.resolve(cwd, "../.."),
+    path.resolve(cwd, "../../.."),
+  ];
+
+  for (const candidate of candidates) {
+    const pkg = await readJsonFile<{ name?: string }>(path.join(candidate, "package.json"));
+    if (pkg?.name === "agent-coworker") {
+      return candidate;
+    }
+  }
+
+  return path.resolve(cwd, "../..");
+}
+
+function outputDirectory(repoRoot: string): string {
+  return path.join(repoRoot, "output");
+}
+
+async function listRunRootNames(repoRoot: string): Promise<string[]> {
+  const outputDir = outputDirectory(repoRoot);
+  try {
+    const entries = await fs.readdir(outputDir, { withFileTypes: true });
+    return entries
+      .filter((entry) => entry.isDirectory() && entry.name.startsWith(RUN_ROOT_PREFIX))
+      .map((entry) => entry.name)
+      .sort((a, b) => b.localeCompare(a));
+  } catch {
+    return [];
+  }
+}
+
+async function readRunSummary(runRootPath: string, runDirName: string): Promise<HarnessRunSummary | null> {
+  const runDir = path.join(runRootPath, runDirName);
+  const runMeta = await readJsonFile<Record<string, unknown>>(path.join(runDir, "run_meta.json"));
+  const attempts = (await readJsonFile<Array<Record<string, unknown>>>(path.join(runDir, "attempts.json"))) ?? [];
+  const trace = await readJsonFile<Record<string, unknown>>(path.join(runDir, "trace.json"));
+  const sloReport = await readJsonFile<Record<string, unknown>>(path.join(runDir, "slo_report.json"));
+  const finalText = await readTextFile(path.join(runDir, "final.txt"));
+
+  const runId = asString(runMeta?.runId) ?? runDirName;
+  const provider = asString(runMeta?.provider) ?? "unknown";
+  const requestedModel = asString(runMeta?.requestedModel);
+  const resolvedModel = asString(runMeta?.resolvedModel);
+
+  const traceResult = toRecord(trace?.result);
+  const traceError = asString(traceResult?.error);
+  const startedAt = asString(runMeta?.startedAt) ?? asString(trace?.startedAt);
+  const finishedAt = asString(runMeta?.finishedAt) ?? asString(trace?.finishedAt);
+  const observabilityEnabled = asBoolean(runMeta?.observabilityEnabled, false);
+
+  const attemptSucceeded = attempts.filter((attempt) => asBoolean(attempt.ok, false)).length;
+  const lastAttempt = attempts.length > 0 ? attempts[attempts.length - 1] : null;
+  const attemptError = asString(lastAttempt?.error);
+  const lastError = traceError ?? attemptError;
+
+  let status: RunStatus = "pending";
+  if (finishedAt) status = lastError ? "failed" : "completed";
+  else if (attempts.length > 0 || (await pathExists(path.join(runDir, "trace_attempt-01.json")))) status = "running";
+
+  const updatedAtMs = await maxMtimeMs([
+    runDir,
+    path.join(runDir, "run_meta.json"),
+    path.join(runDir, "attempts.json"),
+    path.join(runDir, "trace.json"),
+    path.join(runDir, "final.txt"),
+    path.join(runDir, "slo_report.json"),
+  ]);
+
+  return {
+    runId,
+    runDirName,
+    provider,
+    requestedModel,
+    resolvedModel,
+    startedAt,
+    finishedAt,
+    status,
+    attemptsTotal: attempts.length,
+    attemptsSucceeded: attemptSucceeded,
+    lastError,
+    finalPreview: getPreview(finalText),
+    observabilityEnabled,
+    sloPassed: typeof sloReport?.passed === "boolean" ? (sloReport.passed as boolean) : null,
+    updatedAtMs,
+  };
+}
+
+async function readRunRootSummary(repoRoot: string, runRootName: string): Promise<HarnessRunRootSummary | null> {
+  if (!isSafeSegment(runRootName)) return null;
+
+  const runRootPath = path.join(outputDirectory(repoRoot), runRootName);
+  const manifest = await readJsonFile<Record<string, unknown>>(path.join(runRootPath, "manifest.json"));
+
+  let runDirNames: string[] = [];
+  try {
+    const entries = await fs.readdir(runRootPath, { withFileTypes: true });
+    runDirNames = entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name);
+  } catch {
+    runDirNames = [];
+  }
+
+  const runs = (
+    await Promise.all(runDirNames.map((runDirName) => readRunSummary(runRootPath, runDirName)))
+  ).filter((run): run is HarnessRunSummary => run !== null);
+
+  runs.sort((a, b) => {
+    const left = a.startedAt ?? "";
+    const right = b.startedAt ?? "";
+    if (left !== right) return right.localeCompare(left);
+    return b.runDirName.localeCompare(a.runDirName);
+  });
+
+  const harness = toRecord(manifest?.harness);
+  const updatedAtMs = Math.max(
+    await maxMtimeMs([runRootPath, path.join(runRootPath, "manifest.json")]),
+    ...runs.map((run) => run.updatedAtMs)
+  );
+
+  return {
+    runRootName,
+    createdAt: asString(manifest?.createdAt),
+    harness: harness
+      ? {
+          observability: asBoolean(harness.observability, false),
+          reportOnly: asBoolean(harness.reportOnly, true),
+          strictMode: asBoolean(harness.strictMode, false),
+          keepStack: asBoolean(harness.keepStack, false),
+        }
+      : null,
+    runs,
+    updatedAtMs,
+  };
+}
+
+export async function getHarnessRunsSnapshot(opts?: { limitRoots?: number }): Promise<HarnessRunsSnapshot> {
+  const repoRoot = await resolveRepoRoot();
+  const outputDir = outputDirectory(repoRoot);
+  const limitRoots = Math.max(1, Math.min(100, opts?.limitRoots ?? 30));
+
+  const runRootNames = await listRunRootNames(repoRoot);
+  const roots = (
+    await Promise.all(runRootNames.slice(0, limitRoots).map((runRootName) => readRunRootSummary(repoRoot, runRootName)))
+  ).filter((root): root is HarnessRunRootSummary => root !== null);
+
+  return {
+    repoRoot,
+    outputDirectory: outputDir,
+    generatedAt: getNowIso(),
+    roots,
+  };
+}
+
+export function runDirectoryPath(repoRoot: string, runRootName: string, runDirName: string): string | null {
+  if (!isSafeSegment(runRootName) || !isSafeSegment(runDirName)) return null;
+  return path.join(outputDirectory(repoRoot), runRootName, runDirName);
+}
+
+function tailLines(text: string, maxLines = 200): string[] {
+  const lines = text.replace(/\r\n/g, "\n").split("\n");
+  return lines.slice(Math.max(0, lines.length - maxLines));
+}
+
+function normalizeTracePreview(steps: unknown[]): { first: Array<Record<string, unknown>>; last: Array<Record<string, unknown>> } {
+  const first = steps.slice(0, 5).map((step) => (toRecord(step) ?? { value: step }));
+  const last = steps.slice(Math.max(0, steps.length - 5)).map((step) => (toRecord(step) ?? { value: step }));
+  return { first, last };
+}
+
+export async function getHarnessRunDetail(runRootName: string, runDirName: string): Promise<HarnessRunDetail | null> {
+  if (!isSafeSegment(runRootName) || !isSafeSegment(runDirName)) return null;
+
+  const repoRoot = await resolveRepoRoot();
+  const runDir = runDirectoryPath(repoRoot, runRootName, runDirName);
+  if (!runDir) return null;
+  if (!(await pathExists(runDir))) return null;
+
+  const runRootPath = path.dirname(runDir);
+  const manifest = await readJsonFile<Record<string, unknown>>(path.join(runRootPath, "manifest.json"));
+  const runMeta = await readJsonFile<Record<string, unknown>>(path.join(runDir, "run_meta.json"));
+
+  const [prompt, system, final, finalReasoning, toolLogText] = await Promise.all([
+    readTextFile(path.join(runDir, "prompt.txt")),
+    readTextFile(path.join(runDir, "system.txt")),
+    readTextFile(path.join(runDir, "final.txt")),
+    readTextFile(path.join(runDir, "final_reasoning.txt")),
+    readTextFile(path.join(runDir, "tool-log.txt")),
+  ]);
+
+  const attempts = (await readJsonFile<Array<Record<string, unknown>>>(path.join(runDir, "attempts.json"))) ?? [];
+  const trace = await readJsonFile<Record<string, unknown>>(path.join(runDir, "trace.json"));
+  const sloChecks = (await readJsonFile<Array<Record<string, unknown>>>(path.join(runDir, "slo_checks.json"))) ?? [];
+  const sloReport = await readJsonFile<Record<string, unknown>>(path.join(runDir, "slo_report.json"));
+  const observabilityQueries =
+    (await readJsonFile<Array<Record<string, unknown>>>(path.join(runDir, "observability_queries.json"))) ?? [];
+  const artifactsIndex =
+    (await readJsonFile<Array<Record<string, unknown>>>(path.join(runDir, "artifacts_index.json"))) ?? [];
+
+  const traceRecord = toRecord(trace) ?? {};
+  const traceResult = toRecord(traceRecord.result) ?? {};
+  const traceSteps = toArray(traceRecord.steps);
+  const traceAskEvents = toArray(traceRecord.askEvents);
+  const traceApprovalEvents = toArray(traceRecord.approvalEvents);
+  const traceTodoEvents = toArray(traceRecord.todoEvents);
+  const traceResponseMessages = toArray(traceResult.responseMessages);
+
+  const files = (() => {
+    try {
+      return fs.readdir(runDir);
+    } catch {
+      return Promise.resolve([] as string[]);
+    }
+  })();
+
+  const updatedAtMs = await maxMtimeMs([
+    runDir,
+    path.join(runDir, "run_meta.json"),
+    path.join(runDir, "trace.json"),
+    path.join(runDir, "attempts.json"),
+    path.join(runDir, "slo_report.json"),
+    path.join(runDir, "observability_queries.json"),
+    path.join(runDir, "artifacts_index.json"),
+    path.join(runDir, "tool-log.txt"),
+  ]);
+
+  return {
+    repoRoot,
+    runRootName,
+    runDirName,
+    manifest,
+    runMeta,
+    prompt,
+    system,
+    final,
+    finalReasoning,
+    attempts,
+    traceSummary: {
+      startedAt: asString(traceRecord.startedAt),
+      finishedAt: asString(traceRecord.finishedAt),
+      stepCount: traceSteps.length,
+      askEvents: traceAskEvents.length,
+      approvalEvents: traceApprovalEvents.length,
+      todoEvents: traceTodoEvents.length,
+      error: asString(traceResult.error),
+      responseMessages: traceResponseMessages.length,
+    },
+    traceStepPreview: normalizeTracePreview(traceSteps),
+    sloChecks,
+    sloReport,
+    observabilityQueries,
+    artifactsIndex,
+    toolLogTail: tailLines(toolLogText, 220),
+    files: (await files).sort((a, b) => a.localeCompare(b)),
+    updatedAtMs,
+  };
+}

--- a/apps/portal/lib/observability.ts
+++ b/apps/portal/lib/observability.ts
@@ -1,0 +1,431 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import { resolveRepoRoot } from "./harness";
+
+export type ObservabilityQueryType = "logql" | "promql" | "traceql";
+
+export interface ObservabilityEndpoints {
+  otlpHttpEndpoint: string;
+  logsBaseUrl: string;
+  metricsBaseUrl: string;
+  tracesBaseUrl: string;
+}
+
+export interface ObservabilityQueryRequest {
+  queryType: ObservabilityQueryType;
+  query: string;
+  fromMs?: number;
+  toMs?: number;
+  limit?: number;
+}
+
+export interface ObservabilityQueryResult {
+  queryType: ObservabilityQueryType;
+  query: string;
+  fromMs: number;
+  toMs: number;
+  status: "ok" | "error";
+  data: unknown;
+  error?: string;
+}
+
+export interface ObservabilitySnapshot {
+  generatedAt: string;
+  endpoints: ObservabilityEndpoints;
+  health: {
+    logs: boolean;
+    metrics: boolean;
+    traces: boolean;
+  };
+  metrics: {
+    vectorErrorRate: number | null;
+    recentAgentTurnSpans: number | null;
+  };
+}
+
+function appendQuery(url: string, params: Record<string, string | number | undefined>): string {
+  const parsed = new URL(url);
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined) continue;
+    parsed.searchParams.set(key, String(value));
+  }
+  return parsed.toString();
+}
+
+function parseAnyResponse(text: string): unknown {
+  if (!text.trim()) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.stat(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readJsonFile<T>(filePath: string): Promise<T | null> {
+  try {
+    const raw = await fs.readFile(filePath, "utf-8");
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+}
+
+function toEndpoints(value: unknown): ObservabilityEndpoints | null {
+  if (!value || typeof value !== "object") return null;
+  const obj = value as Record<string, unknown>;
+  const otlpHttpEndpoint = typeof obj.otlpHttpEndpoint === "string" ? obj.otlpHttpEndpoint : null;
+  const logsBaseUrl = typeof obj.logsBaseUrl === "string" ? obj.logsBaseUrl : null;
+  const metricsBaseUrl = typeof obj.metricsBaseUrl === "string" ? obj.metricsBaseUrl : null;
+  const tracesBaseUrl = typeof obj.tracesBaseUrl === "string" ? obj.tracesBaseUrl : null;
+  if (!otlpHttpEndpoint || !logsBaseUrl || !metricsBaseUrl || !tracesBaseUrl) return null;
+  return { otlpHttpEndpoint, logsBaseUrl, metricsBaseUrl, tracesBaseUrl };
+}
+
+function hostMappedFallbackEndpoints(): ObservabilityEndpoints {
+  return {
+    otlpHttpEndpoint: "http://127.0.0.1:14318",
+    logsBaseUrl: "http://127.0.0.1:19428",
+    metricsBaseUrl: "http://127.0.0.1:18428",
+    tracesBaseUrl: "http://127.0.0.1:10428",
+  };
+}
+
+function dedupeEndpoints(candidates: ObservabilityEndpoints[]): ObservabilityEndpoints[] {
+  const seen = new Set<string>();
+  const unique: ObservabilityEndpoints[] = [];
+  for (const candidate of candidates) {
+    const key = JSON.stringify(candidate);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    unique.push(candidate);
+  }
+  return unique;
+}
+
+async function endpointHealthScore(endpoints: ObservabilityEndpoints): Promise<number> {
+  const [logs, metrics, traces] = await Promise.all([
+    checkHealth(`${endpoints.logsBaseUrl.replace(/\/$/, "")}/`),
+    checkHealth(`${endpoints.metricsBaseUrl.replace(/\/$/, "")}/metrics`),
+    checkHealth(`${endpoints.tracesBaseUrl.replace(/\/$/, "")}/`),
+  ]);
+  return Number(logs) + Number(metrics) + Number(traces);
+}
+
+async function readLatestStackStateEndpoints(repoRoot: string): Promise<ObservabilityEndpoints | null> {
+  const stateDir = path.join(repoRoot, ".agent", "observability-stack");
+  if (!(await pathExists(stateDir))) return null;
+
+  let entries: Array<{ filePath: string; mtimeMs: number }> = [];
+  try {
+    const dirEntries = await fs.readdir(stateDir, { withFileTypes: true });
+    entries = (
+      await Promise.all(
+        dirEntries
+          .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
+          .map(async (entry) => {
+            const filePath = path.join(stateDir, entry.name);
+            const st = await fs.stat(filePath);
+            return { filePath, mtimeMs: st.mtimeMs };
+          })
+      )
+    ).sort((a, b) => b.mtimeMs - a.mtimeMs);
+  } catch {
+    return null;
+  }
+
+  for (const entry of entries) {
+    const parsed = await readJsonFile<{ stack?: { endpoints?: unknown } }>(entry.filePath);
+    const endpoints = toEndpoints(parsed?.stack?.endpoints);
+    if (endpoints) return endpoints;
+  }
+
+  return null;
+}
+
+function clampLimit(limit: number | undefined): number {
+  if (typeof limit !== "number" || !Number.isFinite(limit)) return 200;
+  return Math.max(1, Math.min(10_000, Math.floor(limit)));
+}
+
+async function fetchWithTimeout(url: string, init: RequestInit = {}, timeoutMs = 5_000): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function buildCandidates(
+  queryType: ObservabilityQueryType,
+  baseUrl: string,
+  query: string,
+  fromMs: number,
+  toMs: number,
+  limit: number
+): Array<{ url: string; method: "GET" | "POST"; body?: string }> {
+  const startSec = Math.floor(fromMs / 1000);
+  const endSec = Math.floor(toMs / 1000);
+  const stepSec = Math.max(1, Math.floor((toMs - fromMs) / 1000 / 60));
+
+  if (queryType === "promql") {
+    return [
+      {
+        method: "GET",
+        url: appendQuery(`${baseUrl.replace(/\/$/, "")}/api/v1/query_range`, {
+          query,
+          start: startSec,
+          end: endSec,
+          step: stepSec,
+        }),
+      },
+      {
+        method: "GET",
+        url: appendQuery(`${baseUrl.replace(/\/$/, "")}/api/v1/query`, { query, time: endSec }),
+      },
+    ];
+  }
+
+  if (queryType === "logql") {
+    return [
+      {
+        method: "GET",
+        url: appendQuery(`${baseUrl.replace(/\/$/, "")}/select/logsql/query`, {
+          query,
+          start: fromMs,
+          end: toMs,
+          limit,
+        }),
+      },
+      {
+        method: "POST",
+        url: `${baseUrl.replace(/\/$/, "")}/select/logsql/query`,
+        body: JSON.stringify({ query, start: fromMs, end: toMs, limit }),
+      },
+    ];
+  }
+
+  return [
+    {
+      method: "GET",
+      url: appendQuery(`${baseUrl.replace(/\/$/, "")}/select/traceql/query`, {
+        query,
+        start: fromMs,
+        end: toMs,
+        limit,
+      }),
+    },
+    {
+      method: "POST",
+      url: `${baseUrl.replace(/\/$/, "")}/select/traceql/query`,
+      body: JSON.stringify({ query, start: fromMs, end: toMs, limit }),
+    },
+    {
+      method: "GET",
+      url: appendQuery(`${baseUrl.replace(/\/$/, "")}/select/logsql/query`, {
+        query,
+        start: fromMs,
+        end: toMs,
+        limit,
+      }),
+    },
+    {
+      method: "POST",
+      url: `${baseUrl.replace(/\/$/, "")}/select/logsql/query`,
+      body: JSON.stringify({ query, start: fromMs, end: toMs, limit }),
+    },
+  ];
+}
+
+function safeExtractPromValue(data: unknown): number | null {
+  const root = typeof data === "object" && data !== null ? (data as Record<string, unknown>) : null;
+  const payload = root && typeof root.data === "object" && root.data !== null ? (root.data as Record<string, unknown>) : null;
+  const result = payload && Array.isArray(payload.result) ? payload.result : [];
+  if (result.length === 0) return null;
+  const first = typeof result[0] === "object" && result[0] !== null ? (result[0] as Record<string, unknown>) : null;
+  const value = first && Array.isArray(first.value) ? first.value : null;
+  if (!value || value.length < 2) return null;
+  const num = Number(value[1]);
+  return Number.isFinite(num) ? num : null;
+}
+
+function safeCountRows(data: unknown): number | null {
+  if (Array.isArray(data)) return data.length;
+  if (typeof data === "string") {
+    const trimmed = data.trim();
+    if (!trimmed) return 0;
+    return trimmed.split(/\n+/).filter((line) => line.trim().length > 0).length;
+  }
+  return null;
+}
+
+async function checkHealth(url: string): Promise<boolean> {
+  try {
+    const res = await fetchWithTimeout(url, { method: "GET" }, 2_500);
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+export async function resolveObservabilityEndpoints(): Promise<ObservabilityEndpoints> {
+  const fromEnv = toEndpoints({
+    otlpHttpEndpoint: process.env.HARNESS_OBS_OTLP_HTTP,
+    logsBaseUrl: process.env.HARNESS_OBS_LOGS_URL,
+    metricsBaseUrl: process.env.HARNESS_OBS_METRICS_URL,
+    tracesBaseUrl: process.env.HARNESS_OBS_TRACES_URL,
+  });
+  if (fromEnv) return fromEnv;
+
+  const repoRoot = await resolveRepoRoot();
+  const candidates: ObservabilityEndpoints[] = [];
+
+  const stackStatePath = path.join(repoRoot, ".agent", "observability-stack", "default.json");
+  if (await pathExists(stackStatePath)) {
+    const parsed = await readJsonFile<{ stack?: { endpoints?: Partial<ObservabilityEndpoints> } }>(stackStatePath);
+    const endpoints = toEndpoints(parsed?.stack?.endpoints);
+    if (endpoints) candidates.push(endpoints);
+  }
+
+  const latestStateEndpoints = await readLatestStackStateEndpoints(repoRoot);
+  if (latestStateEndpoints) candidates.push(latestStateEndpoints);
+
+  const defaults = await readJsonFile<{
+    observability?: {
+      otlpHttpEndpoint?: string;
+      queryApi?: {
+        logsBaseUrl?: string;
+        metricsBaseUrl?: string;
+        tracesBaseUrl?: string;
+      };
+    };
+  }>(path.join(repoRoot, "config", "defaults.json"));
+
+  candidates.push({
+    otlpHttpEndpoint: defaults?.observability?.otlpHttpEndpoint ?? "http://127.0.0.1:14318",
+    logsBaseUrl: defaults?.observability?.queryApi?.logsBaseUrl ?? "http://127.0.0.1:19428",
+    metricsBaseUrl: defaults?.observability?.queryApi?.metricsBaseUrl ?? "http://127.0.0.1:18428",
+    tracesBaseUrl: defaults?.observability?.queryApi?.tracesBaseUrl ?? "http://127.0.0.1:10428",
+  });
+  candidates.push(hostMappedFallbackEndpoints());
+
+  const unique = dedupeEndpoints(candidates);
+  if (unique.length === 1) return unique[0];
+
+  let best = unique[0];
+  let bestScore = -1;
+  for (const candidate of unique) {
+    const score = await endpointHealthScore(candidate);
+    if (score > bestScore) {
+      bestScore = score;
+      best = candidate;
+    }
+  }
+
+  return best;
+}
+
+export async function runObservabilityQuery(req: ObservabilityQueryRequest): Promise<ObservabilityQueryResult> {
+  const endpoints = await resolveObservabilityEndpoints();
+  const query = req.query.trim();
+  const nowMs = Date.now();
+  const toMs = typeof req.toMs === "number" && Number.isFinite(req.toMs) ? Math.floor(req.toMs) : nowMs;
+  const fromMs = typeof req.fromMs === "number" && Number.isFinite(req.fromMs) ? Math.floor(req.fromMs) : toMs - 5 * 60_000;
+  const limit = clampLimit(req.limit);
+
+  const baseUrl =
+    req.queryType === "logql"
+      ? endpoints.logsBaseUrl
+      : req.queryType === "promql"
+        ? endpoints.metricsBaseUrl
+        : endpoints.tracesBaseUrl;
+
+  const candidates = buildCandidates(req.queryType, baseUrl, query, fromMs, toMs, limit);
+  let lastError: string | null = null;
+
+  for (const candidate of candidates) {
+    try {
+      const res = await fetchWithTimeout(
+        candidate.url,
+        {
+          method: candidate.method,
+          headers: candidate.body ? { "content-type": "application/json" } : undefined,
+          body: candidate.body,
+        },
+        8_000
+      );
+      const text = await res.text();
+      if (!res.ok) {
+        lastError = `HTTP ${res.status}: ${text.slice(0, 400)}`;
+        continue;
+      }
+      return {
+        queryType: req.queryType,
+        query,
+        fromMs,
+        toMs,
+        status: "ok",
+        data: parseAnyResponse(text),
+      };
+    } catch (err) {
+      lastError = String(err);
+    }
+  }
+
+  return {
+    queryType: req.queryType,
+    query,
+    fromMs,
+    toMs,
+    status: "error",
+    data: null,
+    error: lastError ?? "Unknown observability query failure",
+  };
+}
+
+export async function getObservabilitySnapshot(): Promise<ObservabilitySnapshot> {
+  const endpoints = await resolveObservabilityEndpoints();
+  const [logs, metrics, traces] = await Promise.all([
+    checkHealth(`${endpoints.logsBaseUrl.replace(/\/$/, "")}/`),
+    checkHealth(`${endpoints.metricsBaseUrl.replace(/\/$/, "")}/metrics`),
+    checkHealth(`${endpoints.tracesBaseUrl.replace(/\/$/, "")}/`),
+  ]);
+
+  const [vectorErrResult, turnsResult] = await Promise.all([
+    runObservabilityQuery({
+      queryType: "promql",
+      query: "sum(rate(vector_component_errors_total[5m]))",
+      toMs: Date.now(),
+      fromMs: Date.now() - 5 * 60_000,
+      limit: 1,
+    }),
+    runObservabilityQuery({
+      queryType: "traceql",
+      query: "_time:[now-2m, now] name:agent.turn.*",
+      toMs: Date.now(),
+      fromMs: Date.now() - 2 * 60_000,
+      limit: 300,
+    }),
+  ]);
+
+  return {
+    generatedAt: new Date().toISOString(),
+    endpoints,
+    health: { logs, metrics, traces },
+    metrics: {
+      vectorErrorRate: vectorErrResult.status === "ok" ? safeExtractPromValue(vectorErrResult.data) : null,
+      recentAgentTurnSpans: turnsResult.status === "ok" ? safeCountRows(turnsResult.data) : null,
+    },
+  };
+}

--- a/apps/portal/next-env.d.ts
+++ b/apps/portal/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/portal/next.config.ts
+++ b/apps/portal/next.config.ts
@@ -1,0 +1,9 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  experimental: {
+    reactCompiler: false,
+  },
+};
+
+export default nextConfig;

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "agent-coworker-portal",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "15.3.4",
+    "react": "19.0.0",
+    "react-dom": "19.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^24.3.0",
+    "@types/react": "^19.1.10",
+    "typescript": "^5.9.2"
+  }
+}

--- a/apps/portal/tsconfig.json
+++ b/apps/portal/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    },
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -3,5 +3,20 @@
   "outputDirectory": "output",
   "uploadsDirectory": "uploads",
   "userName": "",
-  "knowledgeCutoff": "End of May 2025"
+  "knowledgeCutoff": "End of May 2025",
+  "observabilityEnabled": false,
+  "observability": {
+    "mode": "local_docker",
+    "otlpHttpEndpoint": "http://127.0.0.1:4318",
+    "queryApi": {
+      "logsBaseUrl": "http://127.0.0.1:9428",
+      "metricsBaseUrl": "http://127.0.0.1:8428",
+      "tracesBaseUrl": "http://127.0.0.1:10428"
+    },
+    "defaultWindowSec": 300
+  },
+  "harness": {
+    "reportOnly": true,
+    "strictMode": false
+  }
 }

--- a/config/observability/docker-compose.yml
+++ b/config/observability/docker-compose.yml
@@ -1,0 +1,32 @@
+services:
+  vector:
+    image: timberio/vector:0.40.1-debian
+    restart: unless-stopped
+    command: ["--config", "/etc/vector/vector.toml"]
+    ports:
+      - "${VECTOR_OTLP_HTTP_PORT}:4318"
+    depends_on:
+      - victoria-logs
+      - victoria-metrics
+      - victoria-traces
+    volumes:
+      - ./vector/vector.toml:/etc/vector/vector.toml:ro
+
+  victoria-logs:
+    image: victoriametrics/victoria-logs:v1.11.0-victorialogs
+    restart: unless-stopped
+    ports:
+      - "${VICTORIA_LOGS_PORT}:9428"
+
+  victoria-metrics:
+    image: victoriametrics/victoria-metrics:v1.103.0
+    restart: unless-stopped
+    command: ["-selfScrapeInterval=0"]
+    ports:
+      - "${VICTORIA_METRICS_PORT}:8428"
+
+  victoria-traces:
+    image: victoriametrics/victoria-traces:v0.7.1
+    restart: unless-stopped
+    ports:
+      - "${VICTORIA_TRACES_PORT}:10428"

--- a/config/observability/vector/vector.toml
+++ b/config/observability/vector/vector.toml
@@ -1,0 +1,32 @@
+# Ingest OTLP (JSON/protobuf over HTTP) and fan out to Victoria endpoints.
+
+[sources.otlp]
+type = "opentelemetry"
+grpc.address = "0.0.0.0:4317"
+http.address = "0.0.0.0:4318"
+
+[transforms.log_events]
+type = "filter"
+inputs = ["otlp.logs"]
+condition = "true"
+
+[sinks.victoria_logs]
+type = "http"
+inputs = ["log_events"]
+uri = "http://victoria-logs:9428/insert/jsonline?_stream_fields=service.name,sessionId"
+method = "post"
+encoding.codec = "json"
+compression = "none"
+
+[transforms.trace_events]
+type = "filter"
+inputs = ["otlp.traces"]
+condition = "true"
+
+[sinks.victoria_traces]
+type = "http"
+inputs = ["trace_events"]
+uri = "http://victoria-traces:10428/insert/opentelemetry/v1/traces"
+method = "post"
+encoding.codec = "json"
+compression = "none"

--- a/docs/harness/context.md
+++ b/docs/harness/context.md
@@ -1,0 +1,27 @@
+# Harness Context
+
+Harness context captures run intent in a structured format that agents can read/write over WebSocket.
+
+## Schema
+
+`HarnessContextPayload`:
+
+- `runId: string`
+- `taskId?: string`
+- `objective: string`
+- `acceptanceCriteria: string[]`
+- `constraints: string[]`
+- `metadata?: Record<string, string>`
+
+Server stores an `updatedAt` timestamp and returns `HarnessContextState`.
+
+## WebSocket Messages
+
+- Client `harness_context_get` requests the current context for the session.
+- Client `harness_context_set` sets/replaces the current context payload.
+- Server emits `harness_context` with the updated/current value (or `null`).
+
+## Storage Behavior
+
+The context store is session-scoped in memory (`src/harness/contextStore.ts`).  
+Context is cleared on session dispose.

--- a/docs/harness/index.md
+++ b/docs/harness/index.md
@@ -1,0 +1,13 @@
+# Harness Docs Index
+
+This directory is the system-of-record for harness engineering in `agent-coworker`.
+
+- `observability.md`: local observability stack (OTel + Vector + Victoria) and query APIs.
+- `context.md`: harness context schema and WebSocket interaction flow.
+- `slo.md`: SLO check schema, report-only semantics, and strict mode behavior.
+- `runbook.md`: exhaustive operator guide for running, using, viewing, and troubleshooting the full harness stack.
+  - Includes the Next.js realtime portal workflow (`apps/portal`).
+
+See also:
+- `docs/websocket-protocol.md` for wire-level message/event definitions.
+- `scripts/run_raw_agent_loops.ts` for the current harness runner implementation.

--- a/docs/harness/observability.md
+++ b/docs/harness/observability.md
@@ -1,0 +1,36 @@
+# Harness Observability
+
+The harness uses a local Docker Compose stack per run/worktree:
+
+- OpenTelemetry OTLP/HTTP ingest (Vector source)
+- Vector fan-out pipeline
+- VictoriaLogs query API (`logql`)
+- VictoriaMetrics query API (`promql`)
+- VictoriaTraces query API (`traceql`)
+
+Notes on trace querying:
+
+- `queryType: "traceql"` first tries `/select/traceql/query`.
+- For VictoriaTraces builds that expose trace search via LogsQL (`/select/logsql/query`), harness query code automatically falls back to that endpoint.
+- In practice, this means `observability_query` with `queryType: "traceql"` still works across endpoint variants.
+
+## Lifecycle
+
+- Stack config: `config/observability/docker-compose.yml`
+- Vector routing: `config/observability/vector/vector.toml`
+- Runtime control: `src/observability/runtime.ts`
+- CLI helper: `scripts/observability_stack.ts`
+
+The primary harness runner (`scripts/run_raw_agent_loops.ts`) boots and tears down the stack per run when `--observability` is enabled.
+
+## Endpoint Injection
+
+When observability is enabled, the harness injects:
+
+- `AGENT_OBSERVABILITY_ENABLED=true`
+- `AGENT_OBS_OTLP_HTTP=<vector otlp endpoint>`
+- `AGENT_OBS_LOGS_URL=<victoria logs base url>`
+- `AGENT_OBS_METRICS_URL=<victoria metrics base url>`
+- `AGENT_OBS_TRACES_URL=<victoria traces base url>`
+
+Run-level endpoint details are written to `observability_endpoints.json` inside each run directory.

--- a/docs/harness/runbook.md
+++ b/docs/harness/runbook.md
@@ -1,0 +1,883 @@
+# Harness Runbook (Verbose)
+
+This is the deep operational guide for the harness stack in `agent-coworker`.
+
+It is intentionally long and explicit. Use it when you want to:
+
+- bring up observability locally;
+- run harness smoke checks and full harness loops;
+- operate harness controls from Desktop and TUI clients;
+- inspect traces/artifacts/SLO reports after runs;
+- debug failures quickly without guessing.
+
+If you only need the short map, see `docs/harness/index.md`.
+
+## 1. What "Harness" Means In This Repo
+
+In this repository, "harness" means the combined system of:
+
+- session-level context controls (`harness_context_get`, `harness_context_set`);
+- observability querying (`observability_query`);
+- SLO evaluation (`harness_slo_evaluate`);
+- local observability infrastructure (Docker Compose with Vector + Victoria services);
+- runner scripts that execute model-driven tasks and write reproducible artifacts.
+
+Core references:
+
+- Protocol: `src/server/protocol.ts`
+- Server handlers: `src/server/startServer.ts`, `src/server/session.ts`
+- Context store: `src/harness/contextStore.ts`
+- Query engine: `src/observability/query.ts`
+- SLO evaluator: `src/observability/slo.ts`
+- Stack runtime: `src/observability/runtime.ts`
+- Stack helper CLI: `scripts/observability_stack.ts`
+- Smoke runner: `scripts/harness_smoke.ts`
+- Full runner: `scripts/run_raw_agent_loops.ts`
+- Wire docs: `docs/websocket-protocol.md`
+
+## 2. Fast Start (Minimal Commands)
+
+From repo root:
+
+```bash
+bun install
+bun run docs:check
+bun test
+bun run harness:smoke
+```
+
+If all four pass, your harness setup is healthy.
+
+## 3. Prerequisites And Preflight
+
+### 3.1 Required tools
+
+- Bun
+- Docker Desktop (or Docker Engine with `docker compose`)
+
+Verify:
+
+```bash
+bun --version
+docker version
+docker compose version
+```
+
+### 3.2 Provider auth for model-backed runs
+
+`harness:smoke` does not require provider keys.
+
+`harness:run` **does** require all of these in environment:
+
+- `GOOGLE_GENERATIVE_AI_API_KEY` (or `GEMINI_API_KEY`)
+- `OPENAI_API_KEY`
+- `ANTHROPIC_API_KEY`
+
+`scripts/run_raw_agent_loops.ts` fails early if any are missing.
+
+### 3.3 Optional auth path via saved connections
+
+Desktop/TUI normal chat usage can also use `~/.cowork/auth/connections.json` entries (API key or OAuth modes), but full harness loop script still enforces env key presence.
+
+## 4. Operational Modes
+
+There are three practical modes.
+
+### 4.1 Mode A: Smoke test only (recommended first)
+
+Purpose:
+
+- validate Docker stack boot;
+- validate query API reachability;
+- validate SLO evaluation end-to-end.
+
+Command:
+
+```bash
+bun run harness:smoke
+```
+
+### 4.2 Mode B: Full harness mixed-model run
+
+Purpose:
+
+- run multiple scripted tasks across providers/models;
+- capture prompts, traces, steps, tool logs, artifacts, SLO reports.
+
+Command:
+
+```bash
+bun run harness:run
+```
+
+Variant flags:
+
+```bash
+bun scripts/run_raw_agent_loops.ts --observability --report-only
+bun scripts/run_raw_agent_loops.ts --observability --strict
+bun scripts/run_raw_agent_loops.ts --observability --strict --keep-stack
+```
+
+### 4.3 Mode C: Manual stack control + UI usage
+
+Purpose:
+
+- keep stack up while using Desktop/TUI interactively;
+- inspect status/endpoints on demand.
+
+Commands:
+
+```bash
+bun run obs:up
+bun run obs:status
+bun scripts/observability_stack.ts endpoints --run-id default --json
+bun run obs:down
+```
+
+## 5. Smoke Run Details (`harness:smoke`)
+
+Entry point: `scripts/harness_smoke.ts`
+
+### 5.1 What it does
+
+1. Creates isolated stack config with run-specific ports.
+2. Starts Docker Compose stack from `config/observability/docker-compose.yml`.
+3. Forces local config:
+   - `observabilityEnabled = true`
+   - stack OTLP + query endpoints from runtime allocation
+   - harness mode report-only, non-strict
+4. Waits for metrics query readiness.
+5. Runs a PromQL smoke query (`1`).
+6. Runs SLO check requiring result `== 1`.
+7. Exits non-zero on failure.
+8. Tears stack down (unless `--keep-stack`).
+
+### 5.2 CLI options
+
+```bash
+bun scripts/harness_smoke.ts --run-id my-smoke
+bun scripts/harness_smoke.ts --run-id my-smoke --keep-stack
+```
+
+### 5.3 Expected success output shape
+
+Example:
+
+```json
+{
+  "ok": true,
+  "runId": "smoke-...",
+  "stack": {
+    "projectName": "cowork-obs-smoke-...",
+    "metricsBaseUrl": "http://127.0.0.1:18428"
+  },
+  "queryStatus": "ok",
+  "sloPassed": true
+}
+```
+
+## 6. Full Harness Loop Details (`harness:run`)
+
+Entry point: `scripts/run_raw_agent_loops.ts`
+
+### 6.1 Runtime behavior summary
+
+- Builds a run root under:
+  - `output/raw-agent-loop_mixed_<timestamp>/`
+- Executes multiple run specs across providers.
+- For each run:
+  - creates isolated `workingDirectory`;
+  - writes system prompt, user prompt, input messages;
+  - runs model turn with retries;
+  - captures step-level traces;
+  - writes outputs and artifact index;
+  - optionally evaluates SLO checks and writes reports.
+
+### 6.2 Harness flags
+
+- `--observability`
+  - boot local stack per run;
+  - inject observability endpoint env vars;
+  - collect SLO/query artifacts.
+- `--report-only`
+  - failed SLO checks are recorded but do not fail run.
+- `--strict`
+  - sets strict mode and disables report-only;
+  - failed SLO checks fail run.
+- `--keep-stack`
+  - keep per-run stack after completion (for deep inspection).
+
+### 6.3 Environment injection during observability runs
+
+Per run, script sets:
+
+- `AGENT_OBSERVABILITY_ENABLED=true`
+- `AGENT_OBS_OTLP_HTTP=<allocated vector endpoint>`
+- `AGENT_OBS_LOGS_URL=<allocated logs endpoint>`
+- `AGENT_OBS_METRICS_URL=<allocated metrics endpoint>`
+- `AGENT_OBS_TRACES_URL=<allocated traces endpoint>`
+- `AGENT_HARNESS_REPORT_ONLY=true|false`
+- `AGENT_HARNESS_STRICT_MODE=true|false`
+
+### 6.4 Run directory naming
+
+Run directory is:
+
+- `<run_id>_<provider>_<resolved_model>`
+
+inside run root.
+
+## 7. Artifacts: What To View And Why
+
+After `harness:run`, inspect:
+
+### 7.1 Run root files
+
+- `manifest.json`
+  - top-level run metadata;
+  - selected harness flags;
+  - masked key presence;
+  - run IDs/provider/model matrix.
+- `anthropic_models_raw.json` (or error file)
+  - raw model list response used for alias resolution diagnostics.
+
+### 7.2 Per-run files
+
+- `run_meta.json`
+  - resolved model/provider/max steps/observability-enabled status.
+- `prompt.txt`
+  - the user task prompt sent for that run.
+- `system.txt`
+  - resolved system prompt with skill context.
+- `input_messages.json`
+  - initial model message list.
+- `attempts.json`
+  - retry timeline (`ok`, `error`, retry delay).
+- `trace_attempt-XX.json`
+  - per-attempt detailed trace.
+- `trace.json`
+  - final canonical trace.
+- `tool-log.txt`
+  - line logs including tool call in/out envelopes.
+- `final.txt`
+  - final assistant text output.
+- `final_reasoning.txt`
+  - reasoning summary/stream capture if present.
+- `response_messages.json`
+  - structured response message payloads.
+- `artifacts_index.json`
+  - file inventory with hash/mtime/size.
+
+Observability-enabled runs also include:
+
+- `observability_endpoints.json`
+- `slo_checks.json`
+- `observability_queries.json`
+- `slo_report.json`
+- `observability_teardown_error.txt` (only if teardown fails)
+
+### 7.3 Useful inspection commands
+
+```bash
+# latest run root
+ls -1dt output/raw-agent-loop_mixed_* | head -n 1
+
+# pretty print manifest
+jq . output/raw-agent-loop_mixed_*/manifest.json
+
+# list per-run directories
+find output/raw-agent-loop_mixed_* -mindepth 1 -maxdepth 1 -type d | sort
+
+# show SLO result summary for all runs
+find output/raw-agent-loop_mixed_* -name slo_report.json -print0 | \
+  xargs -0 -I{} sh -c 'echo "--- {}"; jq "{passed, strictMode, reportOnly, checks: [.checks[] | {id, pass, actual, op, threshold}]}" "{}"'
+```
+
+## 8. Using Harness In Desktop UI
+
+Desktop store and feed wiring are in:
+
+- `apps/desktop/src/app/store.ts`
+- `apps/desktop/src/ui/ChatView.tsx`
+
+### 8.1 Start Desktop dev app
+
+```bash
+bun run desktop:dev
+```
+
+### 8.2 Harness controls in chat view
+
+At the top of the chat feed you now have:
+
+- `Refresh context`
+  - sends `harness_context_get`
+- `Set default context`
+  - sends `harness_context_set` with generated defaults
+- `Run SLO checks`
+  - sends `harness_slo_evaluate` with built-in check set
+
+### 8.3 What to watch in feed
+
+You should see dedicated cards for:
+
+- observability status (enabled/disabled + endpoint summary)
+- harness context (or "none")
+- observability query result payloads
+- SLO pass/fail summary with per-check lines
+
+Notifications are also emitted for SLO pass/fail.
+
+## 9. Using Harness In TUI
+
+TUI wiring is in `src/tui/index.tsx`.
+
+### 9.1 Start server + TUI
+
+```bash
+bun run serve
+bun run tui -- --server ws://127.0.0.1:7337/ws
+```
+
+Or use default start flow:
+
+```bash
+bun run start
+```
+
+### 9.2 Harness slash commands
+
+- `/hctx`
+  - fetch current harness context.
+- `/hctx set`
+  - set default harness context payload.
+- `/slo`
+  - run default SLO check set.
+
+### 9.3 TUI feed event visibility
+
+TUI now renders cards for:
+
+- `observability_status`
+- `harness_context`
+- `observability_query_result`
+- `harness_slo_result`
+
+On connect, TUI also auto-requests `harness_context_get`.
+
+### 9.4 End-to-end: run in a target directory + watch live traces
+
+This is the concrete "show me it working" flow for a single directory.
+
+Assume target repo path:
+
+```bash
+export TARGET_DIR="/absolute/path/to/your/project"
+```
+
+#### 9.4.1 Bring up observability stack
+
+```bash
+bun run obs:up
+bun run obs:status
+bun scripts/observability_stack.ts endpoints --run-id default --json
+```
+
+Expected default local endpoints:
+
+- OTLP HTTP: `http://127.0.0.1:14318`
+- Logs API: `http://127.0.0.1:19428`
+- Metrics API: `http://127.0.0.1:18428`
+- Traces API: `http://127.0.0.1:10428`
+
+#### 9.4.2 Start server with observability enabled for that target dir
+
+Run in Terminal A:
+
+```bash
+AGENT_OBSERVABILITY_ENABLED=true \
+AGENT_OBS_OTLP_HTTP=http://127.0.0.1:14318 \
+AGENT_OBS_LOGS_URL=http://127.0.0.1:19428 \
+AGENT_OBS_METRICS_URL=http://127.0.0.1:18428 \
+AGENT_OBS_TRACES_URL=http://127.0.0.1:10428 \
+bun src/server/index.ts --dir "$TARGET_DIR" --port 7337
+```
+
+#### 9.4.3 Option A: CLI run with prompt in that directory
+
+Run in Terminal B:
+
+```bash
+bun run cli -- --dir "$TARGET_DIR"
+```
+
+At the `you>` prompt, send a task (example):
+
+```text
+List the top-level files in this directory and then summarize what kind of project this is in 2 bullets.
+```
+
+You are now running a real prompt in your specified directory.
+
+#### 9.4.4 Option B: TUI run with prompt in that directory
+
+If you prefer TUI instead of CLI:
+
+```bash
+bun run tui -- --server ws://127.0.0.1:7337/ws
+```
+
+Then:
+
+1. run `/status` and confirm `CWD` equals `TARGET_DIR`;
+2. send your prompt;
+3. optional: run `/hctx set`, `/hctx`, and `/slo` to exercise harness controls.
+
+#### 9.4.5 Watch traces live while prompt runs
+
+Run in Terminal C:
+
+```bash
+while true; do
+  clear
+  date -u +"%Y-%m-%dT%H:%M:%SZ"
+  curl -sG 'http://127.0.0.1:10428/select/logsql/query' \
+    --data-urlencode 'query=_time:[now-2m, now]' \
+    --data-urlencode 'limit=50' | rg 'agent.turn|trace_id|span_id|name'
+  sleep 2
+done
+```
+
+What you should see:
+
+- `agent.turn.started` span records as turns begin;
+- `agent.turn.completed` (or `agent.turn.failed`) records on completion;
+- `trace_id` / `span_id` fields for each emitted span.
+
+Stop the watcher with `Ctrl+C`.
+
+#### 9.4.6 Raw websocket trace query (explicit protocol check)
+
+If you want a protocol-level assertion that trace querying works, run:
+
+```bash
+bun -e '
+const ws = new WebSocket("ws://127.0.0.1:7337/ws");
+let sessionId = null;
+let asked = false;
+ws.onopen = () => ws.send(JSON.stringify({ type: "client_hello", client: "trace-demo", version: "0.1.0" }));
+ws.onmessage = (ev) => {
+  const m = JSON.parse(String(ev.data));
+  if (m.type === "server_hello") {
+    sessionId = m.sessionId;
+    ws.send(JSON.stringify({
+      type: "user_message",
+      sessionId,
+      text: "Reply with exactly TRACE_DEMO_OK",
+      clientMessageId: crypto.randomUUID()
+    }));
+    return;
+  }
+  if (m.type === "assistant_message" && !asked) {
+    asked = true;
+    ws.send(JSON.stringify({
+      type: "observability_query",
+      sessionId,
+      query: { queryType: "traceql", query: "_time:[now-5m, now]", limit: 20 }
+    }));
+    return;
+  }
+  if (m.type === "observability_query_result") {
+    console.log(JSON.stringify({ status: m.result.status, error: m.result.error ?? null }, null, 2));
+    ws.close();
+  }
+};
+'
+```
+
+Expected:
+
+- status is `ok`;
+- returned payload contains recent trace span rows (including `agent.turn.*` events).
+
+## 10. Wire-Level Usage (Raw WebSocket)
+
+If you are building another client, send/receive these protocol messages.
+
+See full details in `docs/websocket-protocol.md`.
+
+### 10.1 Request current context
+
+```json
+{
+  "type": "harness_context_get",
+  "sessionId": "<session-id>"
+}
+```
+
+### 10.2 Set context
+
+```json
+{
+  "type": "harness_context_set",
+  "sessionId": "<session-id>",
+  "context": {
+    "runId": "manual-run-001",
+    "taskId": "ticket-123",
+    "objective": "Complete feature request and verify behavior.",
+    "acceptanceCriteria": [
+      "Feature works end-to-end",
+      "Tests pass"
+    ],
+    "constraints": [
+      "No schema changes",
+      "No unrelated refactors"
+    ],
+    "metadata": {
+      "source": "manual-client"
+    }
+  }
+}
+```
+
+### 10.3 Run query
+
+```json
+{
+  "type": "observability_query",
+  "sessionId": "<session-id>",
+  "query": {
+    "queryType": "promql",
+    "query": "sum(rate(vector_component_errors_total[5m]))"
+  }
+}
+```
+
+### 10.4 Run SLO checks
+
+```json
+{
+  "type": "harness_slo_evaluate",
+  "sessionId": "<session-id>",
+  "checks": [
+    {
+      "id": "vector_errors",
+      "type": "custom",
+      "queryType": "promql",
+      "query": "sum(rate(vector_component_errors_total[5m]))",
+      "op": "<=",
+      "threshold": 0,
+      "windowSec": 300
+    }
+  ]
+}
+```
+
+### 10.5 Expected server events
+
+- `observability_status`
+- `harness_context`
+- `observability_query_result`
+- `harness_slo_result`
+
+## 11. Observability Stack Operations
+
+Stack definition:
+
+- Compose: `config/observability/docker-compose.yml`
+- Vector config: `config/observability/vector/vector.toml`
+
+Pinned images include:
+
+- `timberio/vector:0.40.1-debian`
+- `victoriametrics/victoria-logs:v1.11.0-victorialogs`
+- `victoriametrics/victoria-metrics:v1.103.0`
+- `victoriametrics/victoria-traces:v0.7.1`
+
+### 11.1 Manual lifecycle commands
+
+```bash
+bun scripts/observability_stack.ts up --run-id default
+bun scripts/observability_stack.ts status --run-id default
+bun scripts/observability_stack.ts endpoints --run-id default --json
+bun scripts/observability_stack.ts down --run-id default
+```
+
+State file path:
+
+- `.agent/observability-stack/<run-id>.json`
+
+### 11.2 Confirm containers
+
+```bash
+docker ps --format 'table {{.Names}}\t{{.Status}}'
+```
+
+### 11.3 Query endpoints directly
+
+Example PromQL query:
+
+```bash
+curl -sG 'http://127.0.0.1:8428/api/v1/query' \
+  --data-urlencode 'query=up' | jq .
+```
+
+Example logs query endpoint shape:
+
+```bash
+curl -sG 'http://127.0.0.1:9428/select/logsql/query' \
+  --data-urlencode 'query=_time:[now-5m, now] level:error' \
+  --data-urlencode 'limit=50'
+```
+
+## 12. CI Behavior
+
+Workflow file: `.github/workflows/ci.yml`
+
+Jobs:
+
+- `checks`
+  - `bun install`
+  - `bun run docs:check`
+  - `bun test`
+- `harness_smoke`
+  - Docker availability check
+  - `bun run harness:smoke -- --run-id ci-<run_id>-<attempt>`
+
+Local parity command set:
+
+```bash
+bun run docs:check
+bun test
+bun run harness:smoke
+```
+
+## 13. One-Call Live Model Probe
+
+When you want to prove model auth + generation quickly without full harness loop:
+
+```bash
+bun -e 'import { loadConfig, getModel } from "./src/config"; import { generateText } from "ai"; const cfg = await loadConfig({ cwd: process.cwd() }); const out = await generateText({ model: getModel(cfg), system: "You are a diagnostics assistant.", prompt: "Reply with exactly: HARNESS_MODEL_OK", maxRetries: 0, providerOptions: cfg.providerOptions }); console.log(out.text);'
+```
+
+Expected output:
+
+```text
+HARNESS_MODEL_OK
+```
+
+## 14. Troubleshooting
+
+### 14.1 "docker compose ... failed"
+
+Checks:
+
+- Docker app/daemon running.
+- `docker compose version` works.
+- no restrictive corporate proxy breaking image pulls.
+
+### 14.2 "Observability is disabled for this session"
+
+Cause:
+
+- session config has `observabilityEnabled=false` and no injected overrides.
+
+Fix:
+
+- run through `harness:smoke` or `harness:run --observability`;
+- or set:
+  - `AGENT_OBSERVABILITY_ENABLED=true`
+  - query and OTLP endpoint vars.
+
+### 14.3 `harness:run` exits for missing keys
+
+Cause:
+
+- one or more required provider env vars absent.
+
+Fix:
+
+- export all required keys before run.
+
+### 14.4 SLO checks fail in strict mode
+
+Expected if checks violate thresholds.
+
+Options:
+
+- use report-only mode while iterating:
+  - `--report-only`
+- keep strict mode and improve app behavior until checks pass.
+
+### 14.5 Stale state from manual stack runs
+
+If state file exists but containers are gone:
+
+```bash
+rm -f .agent/observability-stack/default.json
+```
+
+Then run `obs:up` again.
+
+### 14.6 Need to keep stack for inspection
+
+Use:
+
+```bash
+bun run harness:smoke -- --keep-stack
+# or
+bun scripts/run_raw_agent_loops.ts --observability --keep-stack --report-only
+```
+
+Remember cleanup:
+
+```bash
+bun run obs:down
+```
+
+### 14.7 Port already allocated during `harness:smoke`
+
+Example error:
+
+```text
+Bind for 0.0.0.0:10428 failed: port is already allocated
+```
+
+Cause:
+
+- another observability stack is already bound to default host ports (commonly from `obs:up` with `run-id=default`).
+
+Fix:
+
+```bash
+bun run obs:down
+bun run harness:smoke
+```
+
+If you intentionally need two stacks at once, use different host ports/run-ids via `scripts/observability_stack.ts`.
+
+## 15. Recommended Daily Workflow
+
+1. `bun run docs:check`
+2. `bun test`
+3. `bun run harness:smoke`
+4. Run Desktop or TUI and exercise `/hctx`, `/slo` (or Desktop buttons)
+5. For deep validation, run `bun run harness:run`
+6. Inspect `output/raw-agent-loop_mixed_*` artifacts
+7. Tear down any kept stack
+
+## 16. Related Docs
+
+- `docs/harness/index.md`
+- `docs/harness/observability.md`
+- `docs/harness/context.md`
+- `docs/harness/slo.md`
+- `docs/websocket-protocol.md`
+
+## 17. Next.js Web Portal (Realtime)
+
+Portal location:
+
+- `apps/portal`
+
+Run from repo root:
+
+```bash
+bun run portal:dev
+```
+
+Open:
+
+- `http://localhost:3000`
+
+If port 3000 is occupied:
+
+```bash
+cd apps/portal
+bun run dev -- --port 3060
+```
+
+### 17.1 What the portal reads
+
+The portal reads and combines:
+
+- run artifacts under `output/raw-agent-loop_mixed_*`
+- observability stack state from `.agent/observability-stack/default.json`
+- live query results from configured logs/metrics/traces endpoints
+
+### 17.2 Realtime behavior
+
+- run list updates via Server-Sent Events (`/api/stream/runs`) every ~2s
+- selected run detail auto-refreshes every ~4s
+- observability health/metrics snapshot refreshes every ~3s
+
+No manual browser refresh is required during active runs.
+
+### 17.3 How to watch a run live end-to-end
+
+Terminal A:
+
+```bash
+bun run obs:up
+```
+
+Terminal B (start portal):
+
+```bash
+bun run portal:dev
+```
+
+Terminal C (start your harness workload):
+
+```bash
+bun run harness:run
+```
+
+As files are written under `output/raw-agent-loop_mixed_*`, the portal run catalog and detail panes update in near real time.
+
+### 17.4 Portal API endpoints
+
+- `GET /api/runs`
+  - current run-root + run summary snapshot
+- `GET /api/runs/detail?runRoot=<name>&runDir=<name>`
+  - detail payload for one run directory
+- `GET /api/stream/runs`
+  - SSE stream for live run snapshot updates
+- `GET /api/observability/snapshot`
+  - current endpoint health + live metrics summary
+- `POST /api/observability/query`
+  - run ad-hoc `logql` / `promql` / `traceql` query from the portal
+
+### 17.5 Endpoint overrides
+
+Optional portal-specific env overrides:
+
+- `HARNESS_REPO_ROOT`
+- `HARNESS_OBS_OTLP_HTTP`
+- `HARNESS_OBS_LOGS_URL`
+- `HARNESS_OBS_METRICS_URL`
+- `HARNESS_OBS_TRACES_URL`
+
+Example:
+
+```bash
+HARNESS_REPO_ROOT=/Users/me/Projects/agent-coworker \
+HARNESS_OBS_TRACES_URL=http://127.0.0.1:10428 \
+bun run portal:dev
+```
+
+### 17.6 Endpoint auto-detection behavior
+
+If you do **not** set `HARNESS_OBS_*` overrides, the portal resolves endpoints in this order:
+
+1. `HARNESS_OBS_*` environment variables (if all are set)
+2. `.agent/observability-stack/default.json`
+3. most recent `.agent/observability-stack/*.json` state file
+4. `config/defaults.json` observability endpoints
+5. host-mapped local fallback:
+   - OTLP `http://127.0.0.1:14318`
+   - Logs `http://127.0.0.1:19428`
+   - Metrics `http://127.0.0.1:18428`
+   - Traces `http://127.0.0.1:10428`
+
+When multiple candidates are available, the portal probes them and picks the most reachable set, which avoids common cases where default config points at container-internal ports while you are querying from the host.

--- a/docs/harness/slo.md
+++ b/docs/harness/slo.md
@@ -1,0 +1,32 @@
+# Harness SLO Checks
+
+SLO checks are evaluated against observability queries and summarized as a per-run report.
+
+## Check Schema
+
+`HarnessSloCheck`:
+
+- `id: string`
+- `type: "latency" | "error_rate" | "custom"`
+- `queryType: "logql" | "promql" | "traceql"`
+- `query: string`
+- `op: "<" | "<=" | ">" | ">=" | "==" | "!="`
+- `threshold: number`
+- `windowSec: number`
+
+## Execution
+
+- Query execution: `src/observability/query.ts`
+- SLO evaluation: `src/observability/slo.ts`
+- WebSocket trigger: client `harness_slo_evaluate`, server `harness_slo_result`
+
+## Report-Only vs Strict
+
+- Report-only (default): checks are recorded but do not fail the harness run.
+- Strict mode (`--strict` and not report-only): failed checks fail the run.
+
+Harness artifacts include:
+
+- `slo_checks.json`
+- `observability_queries.json`
+- `slo_report.json`

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "cowork": "./src/index.ts"
   },
   "scripts": {
-    "postinstall": "bun install --cwd apps/desktop",
+    "postinstall": "bun install --cwd apps/desktop && bun install --cwd apps/portal",
     "start": "bun src/index.ts",
     "cli": "bun src/index.ts --cli",
     "dev": "bun --watch src/index.ts",
@@ -15,7 +15,16 @@
     "tui": "bun src/tui/index.tsx",
     "desktop:dev": "cd apps/desktop && bun run tauri dev",
     "desktop:build": "cd apps/desktop && bun run build",
+    "portal:dev": "cd apps/portal && bun run dev",
+    "portal:build": "cd apps/portal && bun run build",
+    "portal:start": "cd apps/portal && bun run start",
     "build:desktop-resources": "bun scripts/build_desktop_resources.ts",
+    "obs:up": "bun scripts/observability_stack.ts up --run-id default",
+    "obs:down": "bun scripts/observability_stack.ts down --run-id default",
+    "obs:status": "bun scripts/observability_stack.ts status --run-id default",
+    "docs:check": "bun scripts/check_docs.ts",
+    "harness:run": "bun scripts/run_raw_agent_loops.ts --observability --report-only",
+    "harness:smoke": "bun scripts/harness_smoke.ts",
     "test": "bun test"
   },
   "dependencies": {

--- a/scripts/check_docs.ts
+++ b/scripts/check_docs.ts
@@ -1,0 +1,77 @@
+#!/usr/bin/env bun
+
+import fs from "node:fs/promises";
+import path from "node:path";
+
+type CheckResult = { ok: true } | { ok: false; message: string };
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    const stat = await fs.stat(filePath);
+    return stat.isFile();
+  } catch {
+    return false;
+  }
+}
+
+async function readText(filePath: string): Promise<string> {
+  return await fs.readFile(filePath, "utf-8");
+}
+
+function assertContains(haystack: string, needle: string, context: string): CheckResult {
+  if (!haystack.includes(needle)) {
+    return { ok: false, message: `${context} is missing required reference: ${needle}` };
+  }
+  return { ok: true };
+}
+
+async function main() {
+  const cwd = process.cwd();
+  const requiredFiles = [
+    "docs/harness/index.md",
+    "docs/harness/observability.md",
+    "docs/harness/context.md",
+    "docs/harness/slo.md",
+    "docs/websocket-protocol.md",
+  ];
+
+  for (const rel of requiredFiles) {
+    const abs = path.join(cwd, rel);
+    if (!(await fileExists(abs))) {
+      throw new Error(`Missing required documentation file: ${rel}`);
+    }
+  }
+
+  const agents = await readText(path.join(cwd, "AGENTS.md"));
+  const harnessIndex = await readText(path.join(cwd, "docs/harness/index.md"));
+  const wsProtocol = await readText(path.join(cwd, "docs/websocket-protocol.md"));
+
+  const checks: CheckResult[] = [
+    assertContains(agents, "docs/harness/index.md", "AGENTS.md"),
+    assertContains(harnessIndex, "observability.md", "docs/harness/index.md"),
+    assertContains(harnessIndex, "context.md", "docs/harness/index.md"),
+    assertContains(harnessIndex, "slo.md", "docs/harness/index.md"),
+    assertContains(wsProtocol, "harness_context_get", "docs/websocket-protocol.md"),
+    assertContains(wsProtocol, "observability_query", "docs/websocket-protocol.md"),
+    assertContains(wsProtocol, "harness_slo_evaluate", "docs/websocket-protocol.md"),
+  ];
+
+  const failures = checks.filter((check): check is { ok: false; message: string } => !check.ok);
+  if (failures.length > 0) {
+    for (const failure of failures) {
+      console.error(`[docs-check] ${failure.message}`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log("[docs-check] OK");
+}
+
+if (import.meta.main) {
+  main().catch((err) => {
+    console.error(err);
+    process.exitCode = 1;
+  });
+}
+

--- a/scripts/harness_smoke.ts
+++ b/scripts/harness_smoke.ts
@@ -1,0 +1,170 @@
+#!/usr/bin/env bun
+
+import path from "node:path";
+
+import { loadConfig } from "../src/config";
+import { runObservabilityQuery } from "../src/observability/query";
+import { evaluateHarnessSlo } from "../src/observability/slo";
+import {
+  createLocalObservabilityStack,
+  startLocalObservabilityStack,
+  stopLocalObservabilityStack,
+  type LocalObservabilityStack,
+} from "../src/observability/runtime";
+import type { AgentConfig, HarnessSloCheck } from "../src/types";
+
+type SmokeArgs = {
+  runId: string;
+  keepStack: boolean;
+};
+
+function parseArgs(argv: string[]): SmokeArgs {
+  let runId = `smoke-${Date.now()}`;
+  let keepStack = false;
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--run-id") {
+      const next = argv[i + 1];
+      if (!next) throw new Error("Missing value for --run-id");
+      runId = next;
+      i += 1;
+      continue;
+    }
+    if (arg === "--keep-stack") {
+      keepStack = true;
+      continue;
+    }
+    if (arg === "--help" || arg === "-h") {
+      console.log("Usage: bun scripts/harness_smoke.ts [--run-id <id>] [--keep-stack]");
+      process.exit(0);
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return { runId, keepStack };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function applyStackToConfig(baseConfig: AgentConfig, stack: LocalObservabilityStack): AgentConfig {
+  return {
+    ...baseConfig,
+    observabilityEnabled: true,
+    observability: {
+      ...baseConfig.observability,
+      mode: "local_docker",
+      otlpHttpEndpoint: stack.endpoints.otlpHttpEndpoint,
+      queryApi: {
+        logsBaseUrl: stack.endpoints.logsBaseUrl,
+        metricsBaseUrl: stack.endpoints.metricsBaseUrl,
+        tracesBaseUrl: stack.endpoints.tracesBaseUrl,
+      },
+      defaultWindowSec: 60,
+    },
+    harness: {
+      ...baseConfig.harness,
+      reportOnly: true,
+      strictMode: false,
+    },
+  };
+}
+
+async function waitForPromqlReady(config: AgentConfig, timeoutMs = 60_000): Promise<void> {
+  const startedAt = Date.now();
+  let lastError = "unknown";
+
+  while (Date.now() - startedAt < timeoutMs) {
+    const result = await runObservabilityQuery(config, {
+      queryType: "promql",
+      query: "up",
+      limit: 5,
+    });
+    if (result.status === "ok") return;
+    lastError = result.error ?? "query returned error";
+    await sleep(2_000);
+  }
+
+  throw new Error(`Timed out waiting for observability stack readiness: ${lastError}`);
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const repoDir = process.cwd();
+  const baseConfig = await loadConfig({ cwd: repoDir });
+  const stack = await createLocalObservabilityStack({
+    repoDir,
+    runId: args.runId,
+    composeFile: path.join(repoDir, "config/observability/docker-compose.yml"),
+  });
+
+  let started = false;
+
+  try {
+    console.log(`[harness:smoke] starting stack (${stack.projectName})`);
+    await startLocalObservabilityStack(stack);
+    started = true;
+
+    const config = applyStackToConfig(baseConfig, stack);
+    await waitForPromqlReady(config);
+
+    const query = await runObservabilityQuery(config, {
+      queryType: "promql",
+      query: "1",
+      limit: 1,
+    });
+    if (query.status !== "ok") {
+      throw new Error(`PromQL smoke query failed: ${query.error ?? "unknown error"}`);
+    }
+
+    const checks: HarnessSloCheck[] = [
+      {
+        id: "smoke_constant_one",
+        type: "custom",
+        queryType: "promql",
+        query: "1",
+        op: "==",
+        threshold: 1,
+        windowSec: 60,
+      },
+    ];
+    const slo = await evaluateHarnessSlo(config, checks);
+    if (!slo.passed) {
+      const firstFailure = slo.checks.find((check) => !check.pass);
+      throw new Error(
+        `SLO smoke check failed: ${firstFailure?.id ?? "unknown"} ${firstFailure?.reason ?? ""}`.trim()
+      );
+    }
+
+    console.log(
+      JSON.stringify(
+        {
+          ok: true,
+          runId: args.runId,
+          stack: {
+            projectName: stack.projectName,
+            metricsBaseUrl: stack.endpoints.metricsBaseUrl,
+          },
+          queryStatus: query.status,
+          sloPassed: slo.passed,
+        },
+        null,
+        2
+      )
+    );
+  } finally {
+    if (started && !args.keepStack) {
+      console.log(`[harness:smoke] stopping stack (${stack.projectName})`);
+      await stopLocalObservabilityStack(stack);
+    } else if (started) {
+      console.log(`[harness:smoke] keeping stack up (${stack.projectName})`);
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error(`[harness:smoke] ${String(err)}`);
+  process.exitCode = 1;
+});

--- a/scripts/observability_stack.ts
+++ b/scripts/observability_stack.ts
@@ -1,0 +1,146 @@
+#!/usr/bin/env bun
+
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import {
+  createLocalObservabilityStack,
+  getLocalObservabilityStackStatus,
+  startLocalObservabilityStack,
+  stopLocalObservabilityStack,
+  type LocalObservabilityStack,
+} from "../src/observability/runtime";
+
+type Command = "up" | "down" | "status" | "endpoints";
+
+type CliArgs = {
+  command: Command;
+  runId: string;
+  json: boolean;
+};
+
+type SavedStack = {
+  runId: string;
+  cwd: string;
+  stack: LocalObservabilityStack;
+  createdAt: string;
+};
+
+function printUsage() {
+  console.log("Usage: bun scripts/observability_stack.ts <up|down|status|endpoints> [--run-id <id>] [--json]");
+}
+
+function parseArgs(argv: string[]): CliArgs {
+  const first = argv[0];
+  if (first !== "up" && first !== "down" && first !== "status" && first !== "endpoints") {
+    throw new Error(`Unknown or missing command: ${String(first)}`);
+  }
+
+  let runId = "default";
+  let json = false;
+
+  for (let i = 1; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--run-id") {
+      const value = argv[i + 1];
+      if (!value) throw new Error("Missing value for --run-id");
+      runId = value;
+      i++;
+      continue;
+    }
+    if (arg === "--json") {
+      json = true;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return { command: first, runId, json };
+}
+
+function stateFilePath(cwd: string, runId: string): string {
+  return path.join(cwd, ".agent", "observability-stack", `${runId}.json`);
+}
+
+async function readState(cwd: string, runId: string): Promise<SavedStack | null> {
+  const file = stateFilePath(cwd, runId);
+  try {
+    const raw = await fs.readFile(file, "utf-8");
+    return JSON.parse(raw) as SavedStack;
+  } catch {
+    return null;
+  }
+}
+
+async function writeState(cwd: string, runId: string, stack: LocalObservabilityStack) {
+  const file = stateFilePath(cwd, runId);
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  const state: SavedStack = { cwd, runId, stack, createdAt: new Date().toISOString() };
+  await fs.writeFile(file, JSON.stringify(state, null, 2), "utf-8");
+}
+
+async function deleteState(cwd: string, runId: string) {
+  await fs.rm(stateFilePath(cwd, runId), { force: true });
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const cwd = process.cwd();
+
+  if (args.command === "up") {
+    const stack = await createLocalObservabilityStack({ repoDir: cwd, runId: args.runId });
+    await startLocalObservabilityStack(stack);
+    await writeState(cwd, args.runId, stack);
+    const out = {
+      command: "up",
+      runId: args.runId,
+      endpoints: stack.endpoints,
+      composeFile: stack.composeFile,
+      projectName: stack.projectName,
+    };
+    if (args.json) console.log(JSON.stringify(out, null, 2));
+    else console.log(`[obs] started ${stack.projectName} (${stack.endpoints.otlpHttpEndpoint})`);
+    return;
+  }
+
+  const saved = await readState(cwd, args.runId);
+  if (!saved) throw new Error(`No observability stack state found for runId=${args.runId}`);
+
+  if (args.command === "down") {
+    await stopLocalObservabilityStack(saved.stack);
+    await deleteState(cwd, args.runId);
+    if (args.json) {
+      console.log(JSON.stringify({ command: "down", runId: args.runId, stopped: true }, null, 2));
+    } else {
+      console.log(`[obs] stopped ${saved.stack.projectName}`);
+    }
+    return;
+  }
+
+  if (args.command === "status") {
+    const statusText = await getLocalObservabilityStackStatus(saved.stack);
+    if (args.json) {
+      console.log(JSON.stringify({ command: "status", runId: args.runId, status: statusText }, null, 2));
+    } else {
+      console.log(statusText.trim() || "(no status output)");
+    }
+    return;
+  }
+
+  const out = {
+    command: "endpoints",
+    runId: args.runId,
+    endpoints: saved.stack.endpoints,
+  };
+  if (args.json) console.log(JSON.stringify(out, null, 2));
+  else console.log(JSON.stringify(out.endpoints, null, 2));
+}
+
+if (import.meta.main) {
+  main().catch((err) => {
+    if (String(err).includes("Unknown or missing command")) printUsage();
+    console.error(err);
+    process.exitCode = 1;
+  });
+}
+

--- a/src/harness/contextStore.ts
+++ b/src/harness/contextStore.ts
@@ -1,0 +1,42 @@
+import type { HarnessContextPayload, HarnessContextState } from "../types";
+
+function cloneContext(context: HarnessContextState): HarnessContextState {
+  return {
+    runId: context.runId,
+    taskId: context.taskId,
+    objective: context.objective,
+    acceptanceCriteria: [...context.acceptanceCriteria],
+    constraints: [...context.constraints],
+    metadata: context.metadata ? { ...context.metadata } : undefined,
+    updatedAt: context.updatedAt,
+  };
+}
+
+export class HarnessContextStore {
+  private readonly bySessionId = new Map<string, HarnessContextState>();
+
+  get(sessionId: string): HarnessContextState | null {
+    const found = this.bySessionId.get(sessionId);
+    return found ? cloneContext(found) : null;
+  }
+
+  set(sessionId: string, context: HarnessContextPayload): HarnessContextState {
+    const next: HarnessContextState = {
+      runId: context.runId.trim(),
+      taskId: context.taskId?.trim() || undefined,
+      objective: context.objective.trim(),
+      acceptanceCriteria: context.acceptanceCriteria.map((item) => item.trim()).filter(Boolean),
+      constraints: context.constraints.map((item) => item.trim()).filter(Boolean),
+      metadata: context.metadata ? { ...context.metadata } : undefined,
+      updatedAt: new Date().toISOString(),
+    };
+
+    this.bySessionId.set(sessionId, next);
+    return cloneContext(next);
+  }
+
+  clear(sessionId: string) {
+    this.bySessionId.delete(sessionId);
+  }
+}
+

--- a/src/observability/otel.ts
+++ b/src/observability/otel.ts
@@ -1,0 +1,98 @@
+import { randomBytes } from "node:crypto";
+
+import type { AgentConfig } from "../types";
+
+export interface ObservabilityEvent {
+  name: string;
+  at: string;
+  status?: "ok" | "error";
+  durationMs?: number;
+  attributes?: Record<string, string | number | boolean>;
+}
+
+function toAnyValue(v: string | number | boolean): Record<string, unknown> {
+  if (typeof v === "number") return { doubleValue: v };
+  if (typeof v === "boolean") return { boolValue: v };
+  return { stringValue: v };
+}
+
+function randomHex(bytes: number): string {
+  return randomBytes(bytes).toString("hex");
+}
+
+function computeSpanWindow(atIso: string, durationMs: number | undefined): { startNs: string; endNs: string } {
+  const parsedMs = Date.parse(atIso);
+  const endMs = Number.isFinite(parsedMs) ? parsedMs : Date.now();
+  const spanDurationMs = typeof durationMs === "number" && Number.isFinite(durationMs) && durationMs > 0 ? durationMs : 1;
+  const startMs = Math.max(0, endMs - spanDurationMs);
+  return {
+    startNs: String(BigInt(Math.floor(startMs)) * 1_000_000n),
+    endNs: String(BigInt(Math.floor(endMs)) * 1_000_000n),
+  };
+}
+
+export async function emitObservabilityEvent(
+  config: AgentConfig,
+  event: ObservabilityEvent,
+  deps?: { fetchImpl?: typeof fetch }
+): Promise<void> {
+  if (!config.observabilityEnabled || !config.observability) return;
+
+  const fetchImpl = deps?.fetchImpl ?? fetch;
+  const attributes = Object.entries(event.attributes ?? {}).map(([key, value]) => ({
+    key,
+    value: toAnyValue(value),
+  }));
+  const { startNs, endNs } = computeSpanWindow(event.at, event.durationMs);
+  const traceId = randomHex(16);
+  const spanId = randomHex(8);
+
+  const body = {
+    resourceSpans: [
+      {
+        resource: {
+          attributes: [
+            { key: "service.name", value: { stringValue: "agent-coworker" } },
+            { key: "service.version", value: { stringValue: "0.1.0" } },
+          ],
+        },
+        scopeSpans: [
+          {
+            scope: { name: "agent-coworker" },
+            spans: [
+              {
+                traceId,
+                spanId,
+                name: event.name,
+                kind: 1,
+                startTimeUnixNano: startNs,
+                endTimeUnixNano: endNs,
+                attributes: [
+                  ...attributes,
+                  { key: "event.at", value: { stringValue: event.at } },
+                  ...(event.durationMs !== undefined
+                    ? [{ key: "duration.ms", value: { doubleValue: event.durationMs } }]
+                    : []),
+                ],
+                status: {
+                  code: event.status === "error" ? 2 : 1,
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+  const tracesInsertUrl = `${config.observability.queryApi.tracesBaseUrl.replace(/\/$/, "")}/insert/opentelemetry/v1/traces`;
+
+  try {
+    await fetchImpl(tracesInsertUrl, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  } catch {
+    // best-effort export; failures should not affect core runtime
+  }
+}

--- a/src/observability/query.ts
+++ b/src/observability/query.ts
@@ -1,0 +1,191 @@
+import type { AgentConfig, ObservabilityQueryRequest, ObservabilityQueryResult, ObservabilityQueryType } from "../types";
+
+const DEFAULT_QUERY_TIMEOUT_MS = 10_000;
+
+function clampLimit(limit: number | undefined): number {
+  if (typeof limit !== "number" || !Number.isFinite(limit)) return 200;
+  return Math.max(1, Math.min(10_000, Math.floor(limit)));
+}
+
+function appendQuery(url: string, params: Record<string, string | number | undefined>): string {
+  const parsed = new URL(url);
+  for (const [k, v] of Object.entries(params)) {
+    if (v === undefined) continue;
+    parsed.searchParams.set(k, String(v));
+  }
+  return parsed.toString();
+}
+
+function parseAnyResponse(text: string): unknown {
+  if (!text.trim()) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+function computeWindow(config: AgentConfig, req: ObservabilityQueryRequest): { fromMs: number; toMs: number } {
+  const toMs = typeof req.toMs === "number" && Number.isFinite(req.toMs) ? Math.floor(req.toMs) : Date.now();
+  const defaultWindowMs = Math.max(1, config.observability?.defaultWindowSec ?? 300) * 1000;
+  const fromMs =
+    typeof req.fromMs === "number" && Number.isFinite(req.fromMs) ? Math.floor(req.fromMs) : toMs - defaultWindowMs;
+  return { fromMs, toMs };
+}
+
+function buildCandidates(
+  queryType: ObservabilityQueryType,
+  baseUrl: string,
+  query: string,
+  fromMs: number,
+  toMs: number,
+  limit: number
+): Array<{ url: string; method: "GET" | "POST"; body?: string }> {
+  const startSec = Math.floor(fromMs / 1000);
+  const endSec = Math.floor(toMs / 1000);
+  const stepSec = Math.max(1, Math.floor((toMs - fromMs) / 1000 / 60));
+
+  if (queryType === "promql") {
+    return [
+      {
+        url: appendQuery(`${baseUrl.replace(/\/$/, "")}/api/v1/query_range`, {
+          query,
+          start: startSec,
+          end: endSec,
+          step: stepSec,
+        }),
+        method: "GET",
+      },
+      {
+        url: appendQuery(`${baseUrl.replace(/\/$/, "")}/api/v1/query`, { query, time: endSec }),
+        method: "GET",
+      },
+    ];
+  }
+
+  if (queryType === "logql") {
+    return [
+      {
+        url: appendQuery(`${baseUrl.replace(/\/$/, "")}/select/logsql/query`, {
+          query,
+          start: fromMs,
+          end: toMs,
+          limit,
+        }),
+        method: "GET",
+      },
+      {
+        url: `${baseUrl.replace(/\/$/, "")}/select/logsql/query`,
+        method: "POST",
+        body: JSON.stringify({ query, start: fromMs, end: toMs, limit }),
+      },
+    ];
+  }
+
+  return [
+    {
+      url: appendQuery(`${baseUrl.replace(/\/$/, "")}/select/traceql/query`, {
+        query,
+        start: fromMs,
+        end: toMs,
+        limit,
+      }),
+      method: "GET",
+    },
+    {
+      url: `${baseUrl.replace(/\/$/, "")}/select/traceql/query`,
+      method: "POST",
+      body: JSON.stringify({ query, start: fromMs, end: toMs, limit }),
+    },
+    {
+      // VictoriaTraces v0.7.x exposes span search over /select/logsql/query.
+      // Keep this fallback so trace querying works across endpoint variants.
+      url: appendQuery(`${baseUrl.replace(/\/$/, "")}/select/logsql/query`, {
+        query,
+        start: fromMs,
+        end: toMs,
+        limit,
+      }),
+      method: "GET",
+    },
+    {
+      url: `${baseUrl.replace(/\/$/, "")}/select/logsql/query`,
+      method: "POST",
+      body: JSON.stringify({ query, start: fromMs, end: toMs, limit }),
+    },
+  ];
+}
+
+export async function runObservabilityQuery(
+  config: AgentConfig,
+  req: ObservabilityQueryRequest,
+  deps?: { fetchImpl?: typeof fetch; timeoutMs?: number }
+): Promise<ObservabilityQueryResult> {
+  const query = req.query.trim();
+  const { fromMs, toMs } = computeWindow(config, req);
+  const timeoutMs = deps?.timeoutMs ?? DEFAULT_QUERY_TIMEOUT_MS;
+  const fetchImpl = deps?.fetchImpl ?? fetch;
+
+  if (!config.observabilityEnabled || !config.observability) {
+    return {
+      queryType: req.queryType,
+      query,
+      fromMs,
+      toMs,
+      status: "error",
+      data: null,
+      error: "Observability is disabled for this session.",
+    };
+  }
+
+  const baseUrl =
+    req.queryType === "logql"
+      ? config.observability.queryApi.logsBaseUrl
+      : req.queryType === "promql"
+        ? config.observability.queryApi.metricsBaseUrl
+        : config.observability.queryApi.tracesBaseUrl;
+
+  const limit = clampLimit(req.limit);
+  const candidates = buildCandidates(req.queryType, baseUrl, query, fromMs, toMs, limit);
+  let lastError: string | null = null;
+
+  for (const candidate of candidates) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const res = await fetchImpl(candidate.url, {
+        method: candidate.method,
+        headers: candidate.body ? { "content-type": "application/json" } : undefined,
+        body: candidate.body,
+        signal: controller.signal,
+      });
+      clearTimeout(timer);
+      const text = await res.text();
+      if (!res.ok) {
+        lastError = `HTTP ${res.status}: ${text.slice(0, 400)}`;
+        continue;
+      }
+      return {
+        queryType: req.queryType,
+        query,
+        fromMs,
+        toMs,
+        status: "ok",
+        data: parseAnyResponse(text),
+      };
+    } catch (err) {
+      clearTimeout(timer);
+      lastError = String(err);
+    }
+  }
+
+  return {
+    queryType: req.queryType,
+    query,
+    fromMs,
+    toMs,
+    status: "error",
+    data: null,
+    error: lastError ?? "Unknown observability query failure",
+  };
+}

--- a/src/observability/runtime.ts
+++ b/src/observability/runtime.ts
@@ -1,0 +1,124 @@
+import net from "node:net";
+import path from "node:path";
+import { spawn } from "node:child_process";
+
+export interface LocalObservabilityStackPorts {
+  vectorOtlpHttp: number;
+  victoriaLogs: number;
+  victoriaMetrics: number;
+  victoriaTraces: number;
+}
+
+export interface LocalObservabilityStack {
+  projectName: string;
+  composeFile: string;
+  env: Record<string, string>;
+  ports: LocalObservabilityStackPorts;
+  endpoints: {
+    otlpHttpEndpoint: string;
+    logsBaseUrl: string;
+    metricsBaseUrl: string;
+    tracesBaseUrl: string;
+  };
+}
+
+function sanitizeName(v: string): string {
+  const cleaned = v.replace(/[^a-zA-Z0-9_-]+/g, "-").replace(/^-+|-+$/g, "");
+  return cleaned || "obs";
+}
+
+async function isPortAvailable(port: number): Promise<boolean> {
+  return await new Promise<boolean>((resolve) => {
+    const server = net.createServer();
+    server.once("error", () => resolve(false));
+    server.once("listening", () => {
+      server.close(() => resolve(true));
+    });
+    server.listen(port, "127.0.0.1");
+  });
+}
+
+async function findAvailablePort(start: number): Promise<number> {
+  for (let port = start; port < start + 500; port++) {
+    if (await isPortAvailable(port)) return port;
+  }
+  throw new Error(`Unable to find available port near ${start}`);
+}
+
+async function runCommand(cmd: string, args: string[], env?: Record<string, string>): Promise<{ stdout: string; stderr: string }> {
+  return await new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, {
+      env: env ? { ...process.env, ...env } : process.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (buf) => {
+      stdout += String(buf);
+    });
+    child.stderr.on("data", (buf) => {
+      stderr += String(buf);
+    });
+    child.on("error", (err) => reject(err));
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve({ stdout, stderr });
+        return;
+      }
+      reject(new Error(`${cmd} ${args.join(" ")} failed (${code}): ${stderr || stdout}`));
+    });
+  });
+}
+
+function composeArgs(stack: LocalObservabilityStack, args: string[]): string[] {
+  return ["compose", "-p", stack.projectName, "-f", stack.composeFile, ...args];
+}
+
+export async function createLocalObservabilityStack(opts: {
+  repoDir: string;
+  runId: string;
+  composeFile?: string;
+}): Promise<LocalObservabilityStack> {
+  const composeFile = opts.composeFile ?? path.join(opts.repoDir, "config/observability/docker-compose.yml");
+  const projectName = sanitizeName(`cowork-obs-${opts.runId.toLowerCase()}`);
+  const ports: LocalObservabilityStackPorts = {
+    vectorOtlpHttp: await findAvailablePort(14318),
+    victoriaLogs: await findAvailablePort(19428),
+    victoriaMetrics: await findAvailablePort(18428),
+    victoriaTraces: await findAvailablePort(10428),
+  };
+
+  const env = {
+    VECTOR_OTLP_HTTP_PORT: String(ports.vectorOtlpHttp),
+    VICTORIA_LOGS_PORT: String(ports.victoriaLogs),
+    VICTORIA_METRICS_PORT: String(ports.victoriaMetrics),
+    VICTORIA_TRACES_PORT: String(ports.victoriaTraces),
+  };
+
+  return {
+    projectName,
+    composeFile,
+    env,
+    ports,
+    endpoints: {
+      otlpHttpEndpoint: `http://127.0.0.1:${ports.vectorOtlpHttp}`,
+      logsBaseUrl: `http://127.0.0.1:${ports.victoriaLogs}`,
+      metricsBaseUrl: `http://127.0.0.1:${ports.victoriaMetrics}`,
+      tracesBaseUrl: `http://127.0.0.1:${ports.victoriaTraces}`,
+    },
+  };
+}
+
+export async function startLocalObservabilityStack(stack: LocalObservabilityStack) {
+  await runCommand("docker", composeArgs(stack, ["up", "-d"]), stack.env);
+}
+
+export async function stopLocalObservabilityStack(stack: LocalObservabilityStack) {
+  await runCommand("docker", composeArgs(stack, ["down", "-v"]), stack.env);
+}
+
+export async function getLocalObservabilityStackStatus(stack: LocalObservabilityStack): Promise<string> {
+  const { stdout } = await runCommand("docker", composeArgs(stack, ["ps"]), stack.env);
+  return stdout;
+}
+

--- a/src/observability/slo.ts
+++ b/src/observability/slo.ts
@@ -1,0 +1,131 @@
+import type {
+  AgentConfig,
+  HarnessSloCheck,
+  HarnessSloCheckResult,
+  HarnessSloOperator,
+  HarnessSloResult,
+  ObservabilityQueryResult,
+} from "../types";
+import { runObservabilityQuery } from "./query";
+
+function compare(actual: number, op: HarnessSloOperator, threshold: number): boolean {
+  switch (op) {
+    case "<":
+      return actual < threshold;
+    case "<=":
+      return actual <= threshold;
+    case ">":
+      return actual > threshold;
+    case ">=":
+      return actual >= threshold;
+    case "==":
+      return actual === threshold;
+    case "!=":
+      return actual !== threshold;
+  }
+}
+
+function extractNumeric(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+    return null;
+  }
+  if (Array.isArray(value)) {
+    // Prometheus often encodes samples as [unixTimestamp, sampleValue].
+    if (value.length === 2) {
+      const sampleValue = extractNumeric(value[1]);
+      if (sampleValue !== null) return sampleValue;
+    }
+    for (const item of value) {
+      const nested = extractNumeric(item);
+      if (nested !== null) return nested;
+    }
+    return null;
+  }
+  if (typeof value === "object" && value !== null) {
+    for (const nested of Object.values(value)) {
+      const n = extractNumeric(nested);
+      if (n !== null) return n;
+    }
+  }
+  return null;
+}
+
+function toCheckResult(check: HarnessSloCheck, queryResult: ObservabilityQueryResult): HarnessSloCheckResult {
+  if (queryResult.status !== "ok") {
+    return {
+      id: check.id,
+      type: check.type,
+      queryType: check.queryType,
+      query: check.query,
+      op: check.op,
+      threshold: check.threshold,
+      windowSec: check.windowSec,
+      actual: null,
+      pass: false,
+      reason: queryResult.error ?? "Observability query failed",
+    };
+  }
+
+  const actual = extractNumeric(queryResult.data);
+  if (actual === null) {
+    return {
+      id: check.id,
+      type: check.type,
+      queryType: check.queryType,
+      query: check.query,
+      op: check.op,
+      threshold: check.threshold,
+      windowSec: check.windowSec,
+      actual: null,
+      pass: false,
+      reason: "Unable to derive numeric value from query result",
+    };
+  }
+
+  return {
+    id: check.id,
+    type: check.type,
+    queryType: check.queryType,
+    query: check.query,
+    op: check.op,
+    threshold: check.threshold,
+    windowSec: check.windowSec,
+    actual,
+    pass: compare(actual, check.op, check.threshold),
+  };
+}
+
+export async function evaluateHarnessSlo(
+  config: AgentConfig,
+  checks: HarnessSloCheck[],
+  deps?: { fetchImpl?: typeof fetch; nowMs?: number }
+): Promise<HarnessSloResult> {
+  const nowMs = deps?.nowMs ?? Date.now();
+  const results: HarnessSloCheckResult[] = [];
+
+  for (const check of checks) {
+    const queryResult = await runObservabilityQuery(
+      config,
+      {
+        queryType: check.queryType,
+        query: check.query,
+        fromMs: nowMs - check.windowSec * 1000,
+        toMs: nowMs,
+      },
+      { fetchImpl: deps?.fetchImpl }
+    );
+    results.push(toCheckResult(check, queryResult));
+  }
+
+  return {
+    reportOnly: config.harness?.reportOnly ?? true,
+    strictMode: config.harness?.strictMode ?? false,
+    passed: results.every((result) => result.pass),
+    fromMs: checks.length > 0 ? nowMs - Math.max(...checks.map((check) => check.windowSec)) * 1000 : nowMs,
+    toMs: nowMs,
+    checks: results,
+  };
+}

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -1,5 +1,14 @@
 import { isProviderName } from "../types";
-import type { AgentConfig, SkillEntry, TodoItem } from "../types";
+import type {
+  AgentConfig,
+  HarnessContextPayload,
+  HarnessSloCheck,
+  HarnessSloOperator,
+  ObservabilityQueryRequest,
+  ObservabilityQueryType,
+  SkillEntry,
+  TodoItem,
+} from "../types";
 import type { ProviderStatus } from "../providerStatus";
 import type { SessionBackupPublicState } from "./sessionBackup";
 
@@ -24,6 +33,10 @@ export type ClientMessage =
   | { type: "session_backup_checkpoint"; sessionId: string }
   | { type: "session_backup_restore"; sessionId: string; checkpointId?: string }
   | { type: "session_backup_delete_checkpoint"; sessionId: string; checkpointId: string }
+  | { type: "harness_context_get"; sessionId: string }
+  | { type: "harness_context_set"; sessionId: string; context: HarnessContextPayload }
+  | { type: "observability_query"; sessionId: string; query: ObservabilityQueryRequest }
+  | { type: "harness_slo_evaluate"; sessionId: string; checks: HarnessSloCheck[] }
   | { type: "reset"; sessionId: string };
 
 export type ServerEvent =
@@ -63,8 +76,58 @@ export type ServerEvent =
       reason: "requested" | "auto_checkpoint" | "manual_checkpoint" | "restore" | "delete";
       backup: SessionBackupPublicState;
     }
+  | { type: "observability_status"; sessionId: string; enabled: boolean; observability?: AgentConfig["observability"] }
+  | { type: "harness_context"; sessionId: string; context: (HarnessContextPayload & { updatedAt: string }) | null }
+  | {
+      type: "observability_query_result";
+      sessionId: string;
+      result: {
+        queryType: ObservabilityQueryType;
+        query: string;
+        fromMs: number;
+        toMs: number;
+        status: "ok" | "error";
+        data: unknown;
+        error?: string;
+      };
+    }
+  | {
+      type: "harness_slo_result";
+      sessionId: string;
+      result: {
+        reportOnly: boolean;
+        strictMode: boolean;
+        passed: boolean;
+        fromMs: number;
+        toMs: number;
+        checks: Array<{
+          id: string;
+          type: "latency" | "error_rate" | "custom";
+          queryType: ObservabilityQueryType;
+          query: string;
+          op: HarnessSloOperator;
+          threshold: number;
+          windowSec: number;
+          actual: number | null;
+          pass: boolean;
+          reason?: string;
+        }>;
+      };
+    }
   | { type: "error"; sessionId: string; message: string }
   | { type: "pong"; sessionId: "" };
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function isQueryType(v: unknown): v is ObservabilityQueryType {
+  return v === "logql" || v === "promql" || v === "traceql";
+}
+
+function isSloOperator(v: unknown): v is HarnessSloOperator {
+  return v === "<" || v === "<=" || v === ">" || v === ">=" || v === "==" || v === "!=";
+}
 
 export function safeParseClientMessage(raw: string): { ok: true; msg: ClientMessage } | { ok: false; error: string } {
   let parsed: unknown;
@@ -121,6 +184,77 @@ export function safeParseClientMessage(raw: string): { ok: true; msg: ClientMess
       if (typeof obj.sessionId !== "string") return { ok: false, error: "set_enable_mcp missing sessionId" };
       if (typeof obj.enableMcp !== "boolean") {
         return { ok: false, error: "set_enable_mcp missing/invalid enableMcp" };
+      }
+      return { ok: true, msg: obj as ClientMessage };
+    }
+    case "harness_context_get": {
+      if (typeof obj.sessionId !== "string") return { ok: false, error: "harness_context_get missing sessionId" };
+      return { ok: true, msg: obj as ClientMessage };
+    }
+    case "harness_context_set": {
+      if (typeof obj.sessionId !== "string") return { ok: false, error: "harness_context_set missing sessionId" };
+      if (!isPlainObject(obj.context)) return { ok: false, error: "harness_context_set missing/invalid context" };
+      if (typeof obj.context.runId !== "string" || !obj.context.runId.trim()) {
+        return { ok: false, error: "harness_context_set invalid context.runId" };
+      }
+      if (typeof obj.context.objective !== "string" || !obj.context.objective.trim()) {
+        return { ok: false, error: "harness_context_set invalid context.objective" };
+      }
+      if (!Array.isArray(obj.context.acceptanceCriteria) || !obj.context.acceptanceCriteria.every((x: unknown) => typeof x === "string")) {
+        return { ok: false, error: "harness_context_set invalid context.acceptanceCriteria" };
+      }
+      if (!Array.isArray(obj.context.constraints) || !obj.context.constraints.every((x: unknown) => typeof x === "string")) {
+        return { ok: false, error: "harness_context_set invalid context.constraints" };
+      }
+      if (obj.context.taskId !== undefined && typeof obj.context.taskId !== "string") {
+        return { ok: false, error: "harness_context_set invalid context.taskId" };
+      }
+      if (obj.context.metadata !== undefined) {
+        if (!isPlainObject(obj.context.metadata)) {
+          return { ok: false, error: "harness_context_set invalid context.metadata" };
+        }
+        for (const v of Object.values(obj.context.metadata)) {
+          if (typeof v !== "string") {
+            return { ok: false, error: "harness_context_set invalid context.metadata values" };
+          }
+        }
+      }
+      return { ok: true, msg: obj as ClientMessage };
+    }
+    case "observability_query": {
+      if (typeof obj.sessionId !== "string") return { ok: false, error: "observability_query missing sessionId" };
+      if (!isPlainObject(obj.query)) return { ok: false, error: "observability_query missing/invalid query" };
+      if (!isQueryType(obj.query.queryType)) return { ok: false, error: "observability_query invalid query.queryType" };
+      if (typeof obj.query.query !== "string") return { ok: false, error: "observability_query invalid query.query" };
+      if (obj.query.fromMs !== undefined && typeof obj.query.fromMs !== "number") {
+        return { ok: false, error: "observability_query invalid query.fromMs" };
+      }
+      if (obj.query.toMs !== undefined && typeof obj.query.toMs !== "number") {
+        return { ok: false, error: "observability_query invalid query.toMs" };
+      }
+      if (obj.query.limit !== undefined && (typeof obj.query.limit !== "number" || !Number.isFinite(obj.query.limit))) {
+        return { ok: false, error: "observability_query invalid query.limit" };
+      }
+      return { ok: true, msg: obj as ClientMessage };
+    }
+    case "harness_slo_evaluate": {
+      if (typeof obj.sessionId !== "string") return { ok: false, error: "harness_slo_evaluate missing sessionId" };
+      if (!Array.isArray(obj.checks)) return { ok: false, error: "harness_slo_evaluate missing/invalid checks" };
+      for (const check of obj.checks) {
+        if (!isPlainObject(check)) return { ok: false, error: "harness_slo_evaluate invalid check object" };
+        if (typeof check.id !== "string" || !check.id.trim()) return { ok: false, error: "harness_slo_evaluate invalid check.id" };
+        if (check.type !== "latency" && check.type !== "error_rate" && check.type !== "custom") {
+          return { ok: false, error: "harness_slo_evaluate invalid check.type" };
+        }
+        if (!isQueryType(check.queryType)) return { ok: false, error: "harness_slo_evaluate invalid check.queryType" };
+        if (typeof check.query !== "string") return { ok: false, error: "harness_slo_evaluate invalid check.query" };
+        if (!isSloOperator(check.op)) return { ok: false, error: "harness_slo_evaluate invalid check.op" };
+        if (typeof check.threshold !== "number" || !Number.isFinite(check.threshold)) {
+          return { ok: false, error: "harness_slo_evaluate invalid check.threshold" };
+        }
+        if (typeof check.windowSec !== "number" || !Number.isFinite(check.windowSec) || check.windowSec <= 0) {
+          return { ok: false, error: "harness_slo_evaluate invalid check.windowSec" };
+        }
       }
       return { ok: true, msg: obj as ClientMessage };
     }

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -6,11 +6,15 @@ import { connectProvider as connectModelProvider, getAiCoworkerPaths } from "../
 import { getProviderStatuses } from "../providerStatus";
 import { discoverSkills, stripSkillFrontMatter } from "../skills";
 import { isProviderName } from "../types";
-import type { AgentConfig, TodoItem } from "../types";
+import type { AgentConfig, HarnessContextPayload, HarnessSloCheck, ObservabilityQueryRequest, TodoItem } from "../types";
 import { runTurn } from "../agent";
 import { loadSystemPromptWithSkills } from "../prompt";
 import { createTools } from "../tools";
 import { classifyCommand } from "../utils/approval";
+import { HarnessContextStore } from "../harness/contextStore";
+import { emitObservabilityEvent } from "../observability/otel";
+import { runObservabilityQuery } from "../observability/query";
+import { evaluateHarnessSlo } from "../observability/slo";
 
 import type { ServerEvent } from "./protocol";
 import {
@@ -57,6 +61,9 @@ export class AgentSession {
   private readonly getAiCoworkerPathsImpl: typeof getAiCoworkerPaths;
   private readonly getProviderStatusesImpl: typeof getProviderStatuses;
   private readonly sessionBackupFactory: SessionBackupFactory;
+  private readonly harnessContextStore: HarnessContextStore;
+  private readonly runObservabilityQueryImpl: typeof runObservabilityQuery;
+  private readonly evaluateHarnessSloImpl: typeof evaluateHarnessSlo;
 
   private messages: ModelMessage[] = [];
   private running = false;
@@ -82,6 +89,9 @@ export class AgentSession {
     getAiCoworkerPathsImpl?: typeof getAiCoworkerPaths;
     getProviderStatusesImpl?: typeof getProviderStatuses;
     sessionBackupFactory?: SessionBackupFactory;
+    harnessContextStore?: HarnessContextStore;
+    runObservabilityQueryImpl?: typeof runObservabilityQuery;
+    evaluateHarnessSloImpl?: typeof evaluateHarnessSlo;
   }) {
     this.id = makeId();
     this.config = opts.config;
@@ -92,9 +102,11 @@ export class AgentSession {
     this.connectProviderImpl = opts.connectProviderImpl ?? connectModelProvider;
     this.getAiCoworkerPathsImpl = opts.getAiCoworkerPathsImpl ?? getAiCoworkerPaths;
     this.getProviderStatusesImpl = opts.getProviderStatusesImpl ?? getProviderStatuses;
-    this.getProviderStatusesImpl = opts.getProviderStatusesImpl ?? getProviderStatuses;
     this.sessionBackupFactory =
       opts.sessionBackupFactory ?? (async (factoryOpts) => await SessionBackupManager.create(factoryOpts));
+    this.harnessContextStore = opts.harnessContextStore ?? new HarnessContextStore();
+    this.runObservabilityQueryImpl = opts.runObservabilityQueryImpl ?? runObservabilityQuery;
+    this.evaluateHarnessSloImpl = opts.evaluateHarnessSloImpl ?? evaluateHarnessSlo;
     this.sessionBackupState = {
       status: "initializing",
       sessionId: this.id,
@@ -118,6 +130,15 @@ export class AgentSession {
 
   getEnableMcp() {
     return this.config.enableMcp ?? false;
+  }
+
+  getObservabilityStatusEvent(): Extract<ServerEvent, { type: "observability_status" }> {
+    return {
+      type: "observability_status",
+      sessionId: this.id,
+      enabled: this.config.observabilityEnabled ?? false,
+      observability: this.config.observability,
+    };
   }
 
   reset() {
@@ -318,6 +339,29 @@ export class AgentSession {
     this.emit({ type: "session_settings", sessionId: this.id, enableMcp });
   }
 
+  getHarnessContext() {
+    this.emit({
+      type: "harness_context",
+      sessionId: this.id,
+      context: this.harnessContextStore.get(this.id),
+    });
+  }
+
+  setHarnessContext(context: HarnessContextPayload) {
+    const next = this.harnessContextStore.set(this.id, context);
+    this.emit({ type: "harness_context", sessionId: this.id, context: next });
+  }
+
+  async queryObservability(query: ObservabilityQueryRequest) {
+    const result = await this.runObservabilityQueryImpl(this.config, query);
+    this.emit({ type: "observability_query_result", sessionId: this.id, result });
+  }
+
+  async evaluateHarnessSloChecks(checks: HarnessSloCheck[]) {
+    const result = await this.evaluateHarnessSloImpl(this.config, checks);
+    this.emit({ type: "harness_slo_result", sessionId: this.id, result });
+  }
+
   async setModel(modelIdRaw: string, providerRaw?: AgentConfig["provider"]) {
     const modelId = modelIdRaw.trim();
     if (!modelId) {
@@ -476,6 +520,7 @@ export class AgentSession {
       d.reject(new Error(`Session disposed (${reason})`));
       this.pendingApproval.delete(id);
     }
+    this.harnessContextStore.clear(this.id);
 
     void this.closeSessionBackup();
   }
@@ -610,9 +655,20 @@ export class AgentSession {
 
     this.running = true;
     this.abortController = new AbortController();
+    const turnStartedAt = Date.now();
     try {
       this.emit({ type: "user_message", sessionId: this.id, text, clientMessageId });
       this.emit({ type: "session_busy", sessionId: this.id, busy: true });
+      await emitObservabilityEvent(this.config, {
+        name: "agent.turn.started",
+        at: new Date().toISOString(),
+        status: "ok",
+        attributes: {
+          sessionId: this.id,
+          provider: this.config.provider,
+          model: this.config.model,
+        },
+      });
       await this.sessionBackupInit;
       this.messages.push({ role: "user", content: text });
 
@@ -647,12 +703,35 @@ export class AgentSession {
 
       const out = (res.text || "").trim();
       if (out) this.emit({ type: "assistant_message", sessionId: this.id, text: out });
+      await emitObservabilityEvent(this.config, {
+        name: "agent.turn.completed",
+        at: new Date().toISOString(),
+        status: "ok",
+        durationMs: Date.now() - turnStartedAt,
+        attributes: {
+          sessionId: this.id,
+          provider: this.config.provider,
+          model: this.config.model,
+        },
+      });
     } catch (err) {
       const msg = String(err);
       // Don't emit error for user-initiated cancellation.
       if (!msg.includes("abort") && !msg.includes("cancel")) {
         this.emit({ type: "error", sessionId: this.id, message: msg });
       }
+      await emitObservabilityEvent(this.config, {
+        name: "agent.turn.failed",
+        at: new Date().toISOString(),
+        status: "error",
+        durationMs: Date.now() - turnStartedAt,
+        attributes: {
+          sessionId: this.id,
+          provider: this.config.provider,
+          model: this.config.model,
+          error: msg,
+        },
+      });
     } finally {
       await this.takeAutomaticSessionCheckpoint();
       this.emit({ type: "session_busy", sessionId: this.id, busy: false });

--- a/src/server/startServer.ts
+++ b/src/server/startServer.ts
@@ -91,6 +91,8 @@ export async function startAgentServer(
             enableMcp: session.getEnableMcp(),
           };
           ws.send(JSON.stringify(settings));
+
+          ws.send(JSON.stringify(session.getObservabilityStatusEvent()));
         },
         message(ws, raw) {
           const session = ws.data.session;
@@ -205,6 +207,26 @@ export async function startAgentServer(
 
           if (msg.type === "set_enable_mcp") {
             session.setEnableMcp(msg.enableMcp);
+            return;
+          }
+
+          if (msg.type === "harness_context_get") {
+            session.getHarnessContext();
+            return;
+          }
+
+          if (msg.type === "harness_context_set") {
+            session.setHarnessContext(msg.context);
+            return;
+          }
+
+          if (msg.type === "observability_query") {
+            void session.queryObservability(msg.query);
+            return;
+          }
+
+          if (msg.type === "harness_slo_evaluate") {
+            void session.evaluateHarnessSloChecks(msg.checks);
             return;
           }
 

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -52,9 +52,17 @@ type FeedItem =
       result?: any;
     }
   | { id: string; type: "todos"; todos: TodoItem[] }
+  | { id: string; type: "observability_status"; enabled: boolean; summary: string }
+  | { id: string; type: "harness_context"; context: HarnessContextPayload | null }
+  | { id: string; type: "observability_query_result"; result: ObservabilityQueryResultPayload }
+  | { id: string; type: "harness_slo_result"; result: HarnessSloResultPayload }
   | { id: string; type: "system"; line: string }
   | { id: string; type: "log"; line: string }
   | { id: string; type: "error"; message: string };
+
+type HarnessContextPayload = Extract<ServerEvent, { type: "harness_context" }>["context"];
+type ObservabilityQueryResultPayload = Extract<ServerEvent, { type: "observability_query_result" }>["result"];
+type HarnessSloResultPayload = Extract<ServerEvent, { type: "harness_slo_result" }>["result"];
 
 type ParsedToolLog = { sub?: string; dir: ">" | "<"; name: string; payload: any };
 
@@ -74,7 +82,7 @@ type Theme = {
   cursor: string;
 };
 
-type SlashCommandId = "help" | "new" | "status" | "models" | "connect" | "clear" | "exit";
+type SlashCommandId = "help" | "new" | "status" | "models" | "connect" | "hctx" | "slo" | "clear" | "exit";
 
 type ConnectService = ProviderName;
 
@@ -168,6 +176,26 @@ const SLASH_COMMANDS: readonly SlashCommand[] = [
     ],
   },
   {
+    id: "hctx",
+    name: "hctx",
+    aliases: ["context"],
+    summary: "Get or set harness context for this session.",
+    usage: "/hctx [set]",
+    details:
+      "With no args, fetches current harness context. Use /hctx set to write a default context payload for this session.",
+    examples: ["/hctx", "/hctx set"],
+  },
+  {
+    id: "slo",
+    name: "slo",
+    aliases: ["checks"],
+    summary: "Run default harness SLO checks.",
+    usage: "/slo",
+    details:
+      "Runs default PromQL/LogQL checks through harness_slo_evaluate and shows pass/fail results in the feed.",
+    examples: ["/slo"],
+  },
+  {
     id: "clear",
     name: "clear",
     aliases: ["cls"],
@@ -241,6 +269,25 @@ function parseModelChoiceArg(raw: string, currentProvider?: string): ModelChoice
 function truncateUiText(s: string, maxChars: number): string {
   if (s.length <= maxChars) return s;
   return s.slice(0, maxChars) + `\n… (${s.length - maxChars} more chars)`;
+}
+
+function jsonPreview(value: unknown, maxChars = 12_000): string {
+  let raw: string;
+  if (typeof value === "string") raw = value;
+  else {
+    try {
+      raw = JSON.stringify(value, null, 2) ?? String(value);
+    } catch {
+      raw = String(value);
+    }
+  }
+  return truncateUiText(raw, maxChars);
+}
+
+function formatSloActual(value: number | null): string {
+  if (value === null || Number.isNaN(value)) return "n/a";
+  if (!Number.isFinite(value)) return String(value);
+  return Number(value.toFixed(4)).toString();
 }
 
 function parseToolLogLine(line: string): ParsedToolLog | null {
@@ -935,6 +982,83 @@ function App(props: { serverUrl: string }) {
     setConnectFocus("select");
   };
 
+  const requestHarnessContext = () => {
+    const sid = sessionIdRef.current;
+    if (!sid) {
+      appendFeed({ id: nextFeedId(), type: "system", line: "not connected: cannot request harness context yet" });
+      return false;
+    }
+    const ok = send({ type: "harness_context_get", sessionId: sid });
+    if (!ok) {
+      appendFeed({ id: nextFeedId(), type: "error", message: "failed to request harness context" });
+      return false;
+    }
+    appendFeed({ id: nextFeedId(), type: "system", line: "requesting harness context..." });
+    return true;
+  };
+
+  const setDefaultHarnessContext = () => {
+    const sid = sessionIdRef.current;
+    if (!sid) {
+      appendFeed({ id: nextFeedId(), type: "system", line: "not connected: cannot set harness context yet" });
+      return false;
+    }
+    const context = {
+      runId: `tui-${Date.now()}`,
+      objective: `Ship requested changes for ${cwd || "current workspace"}.`,
+      acceptanceCriteria: ["Requested behavior is implemented.", "Affected tests and docs are updated as needed."],
+      constraints: ["Keep scope limited to requested work.", "Use websocket protocol controls for runtime actions."],
+      taskId: sid,
+      metadata: {
+        source: "tui",
+      },
+    };
+    const ok = send({ type: "harness_context_set", sessionId: sid, context });
+    if (!ok) {
+      appendFeed({ id: nextFeedId(), type: "error", message: "failed to set harness context" });
+      return false;
+    }
+    appendFeed({ id: nextFeedId(), type: "system", line: `harness context set (${context.runId})` });
+    return true;
+  };
+
+  const runDefaultSloChecks = () => {
+    const sid = sessionIdRef.current;
+    if (!sid) {
+      appendFeed({ id: nextFeedId(), type: "system", line: "not connected: cannot run SLO checks yet" });
+      return false;
+    }
+
+    const checks = [
+      {
+        id: "vector_errors",
+        type: "custom" as const,
+        queryType: "promql" as const,
+        query: "sum(rate(vector_component_errors_total[5m]))",
+        op: "<=" as const,
+        threshold: 0,
+        windowSec: 300,
+      },
+      {
+        id: "log_errors",
+        type: "error_rate" as const,
+        queryType: "logql" as const,
+        query: "_time:[now-5m, now] level:error",
+        op: "==" as const,
+        threshold: 0,
+        windowSec: 300,
+      },
+    ];
+
+    const ok = send({ type: "harness_slo_evaluate", sessionId: sid, checks });
+    if (!ok) {
+      appendFeed({ id: nextFeedId(), type: "error", message: "failed to run harness SLO checks" });
+      return false;
+    }
+    appendFeed({ id: nextFeedId(), type: "system", line: `running SLO checks (${checks.length})...` });
+    return true;
+  };
+
   const executeSlashCommand = (raw: string, fallback?: SlashCommand | null) => {
     const trimmed = raw.trim();
     if (!trimmed.startsWith("/")) return false;
@@ -1011,6 +1135,13 @@ function App(props: { serverUrl: string }) {
         openConnectWindow();
         return true;
       }
+      case "hctx":
+        if (args.toLowerCase() === "set") setDefaultHarnessContext();
+        else requestHarnessContext();
+        return true;
+      case "slo":
+        runDefaultSloChecks();
+        return true;
       case "clear":
         clearComposer();
         return true;
@@ -1190,6 +1321,7 @@ function App(props: { serverUrl: string }) {
         setProvider(parsed.config.provider);
         setModel(parsed.config.model);
         setCwd(parsed.config.workingDirectory);
+        ws.send(JSON.stringify({ type: "harness_context_get", sessionId: parsed.sessionId } satisfies ClientMessage));
         appendSessionLog(`connected session=${parsed.sessionId} model=${parsed.config.model}`);
         void updateSessionStateFile({
           sessionId: parsed.sessionId,
@@ -1324,6 +1456,40 @@ function App(props: { serverUrl: string }) {
             line: `model updated: ${parsed.config.provider}/${parsed.config.model}`,
           });
           break;
+        case "observability_status": {
+          const summary =
+            parsed.enabled && parsed.observability
+              ? `logs=${parsed.observability.queryApi.logsBaseUrl} metrics=${parsed.observability.queryApi.metricsBaseUrl} traces=${parsed.observability.queryApi.tracesBaseUrl}`
+              : "disabled";
+          appendFeed({
+            id: nextFeedId(),
+            type: "observability_status",
+            enabled: parsed.enabled,
+            summary,
+          });
+          break;
+        }
+        case "harness_context":
+          appendFeed({
+            id: nextFeedId(),
+            type: "harness_context",
+            context: parsed.context,
+          });
+          break;
+        case "observability_query_result":
+          appendFeed({
+            id: nextFeedId(),
+            type: "observability_query_result",
+            result: parsed.result,
+          });
+          break;
+        case "harness_slo_result":
+          appendFeed({
+            id: nextFeedId(),
+            type: "harness_slo_result",
+            result: parsed.result,
+          });
+          break;
         case "error":
           appendFeed({ id: nextFeedId(), type: "error", message: parsed.message });
           break;
@@ -1452,6 +1618,122 @@ function App(props: { serverUrl: string }) {
               {active.activeForm}...
             </text>
           ) : null}
+        </box>
+      );
+    }
+
+    if (item.type === "observability_status") {
+      return (
+        <box
+          key={item.id}
+          border
+          borderStyle="single"
+          borderColor={item.enabled ? theme.borderDim : theme.warn}
+          backgroundColor={theme.panelBg}
+          padding={1}
+          flexDirection="column"
+          gap={0}
+          marginBottom={1}
+        >
+          <text fg={theme.muted}>
+            <strong>observability</strong> {item.enabled ? "enabled" : "disabled"}
+          </text>
+          <text fg={theme.text}>{item.summary}</text>
+        </box>
+      );
+    }
+
+    if (item.type === "harness_context") {
+      if (!item.context) {
+        return (
+          <box
+            key={item.id}
+            border
+            borderStyle="single"
+            borderColor={theme.warn}
+            backgroundColor={theme.panelBg}
+            padding={1}
+            flexDirection="column"
+            gap={0}
+            marginBottom={1}
+          >
+            <text fg={theme.warn}>
+              <strong>harness context</strong> none
+            </text>
+            <text fg={theme.muted}>Run /hctx set to create default context for this session.</text>
+          </box>
+        );
+      }
+
+      return (
+        <box
+          key={item.id}
+          border
+          borderStyle="single"
+          borderColor={theme.borderDim}
+          backgroundColor={theme.panelBg}
+          padding={1}
+          flexDirection="column"
+          gap={0}
+          marginBottom={1}
+        >
+          <text fg={theme.muted}>
+            <strong>harness context</strong>
+          </text>
+          <text fg={theme.text}>runId: {item.context.runId}</text>
+          <text fg={theme.text}>objective: {item.context.objective}</text>
+          <text fg={theme.text}>acceptance: {item.context.acceptanceCriteria.length}</text>
+          <text fg={theme.text}>constraints: {item.context.constraints.length}</text>
+          <text fg={theme.muted}>updated: {item.context.updatedAt}</text>
+        </box>
+      );
+    }
+
+    if (item.type === "observability_query_result") {
+      return (
+        <box
+          key={item.id}
+          border
+          borderStyle="single"
+          borderColor={item.result.status === "ok" ? theme.borderDim : theme.danger}
+          backgroundColor={theme.panelBg}
+          padding={1}
+          flexDirection="column"
+          gap={0}
+          marginBottom={1}
+        >
+          <text fg={theme.muted}>
+            <strong>query</strong> {item.result.queryType} ({item.result.status})
+          </text>
+          <text fg={theme.text}>{truncateUiText(item.result.query, 500)}</text>
+          {item.result.error ? <text fg={theme.danger}>{item.result.error}</text> : null}
+          <text fg={theme.text}>{jsonPreview(item.result.data, 10_000)}</text>
+        </box>
+      );
+    }
+
+    if (item.type === "harness_slo_result") {
+      const passCount = item.result.checks.filter((check) => check.pass).length;
+      return (
+        <box
+          key={item.id}
+          border
+          borderStyle="single"
+          borderColor={item.result.passed ? theme.borderDim : theme.danger}
+          backgroundColor={theme.panelBg}
+          padding={1}
+          flexDirection="column"
+          gap={0}
+          marginBottom={1}
+        >
+          <text fg={item.result.passed ? theme.agent : theme.danger}>
+            <strong>slo</strong> {item.result.passed ? "pass" : "fail"} ({passCount}/{item.result.checks.length})
+          </text>
+          {item.result.checks.map((check) => (
+            <text key={check.id} fg={check.pass ? theme.text : theme.danger}>
+              {check.pass ? "[pass]" : "[fail]"} {check.id} {formatSloActual(check.actual)} {check.op} {check.threshold}
+            </text>
+          ))}
         </box>
       );
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,6 +47,22 @@ export interface AgentConfig {
    * Defaults to true when not specified.
    */
   enableMcp?: boolean;
+
+  /**
+   * Whether local observability integration is enabled for this session/run.
+   * Defaults to false when not specified.
+   */
+  observabilityEnabled?: boolean;
+
+  /**
+   * Optional observability endpoint and runtime settings.
+   */
+  observability?: ObservabilityConfig;
+
+  /**
+   * Optional harness policy flags.
+   */
+  harness?: HarnessConfig;
 }
 
 export interface SkillEntry {
@@ -70,6 +86,95 @@ export interface TodoItem {
   content: string;
   status: "pending" | "in_progress" | "completed";
   activeForm: string;
+}
+
+export type ObservabilityQueryType = "logql" | "promql" | "traceql";
+
+export interface ObservabilityQueryApi {
+  logsBaseUrl: string;
+  metricsBaseUrl: string;
+  tracesBaseUrl: string;
+}
+
+export interface ObservabilityConfig {
+  mode: "local_docker";
+  otlpHttpEndpoint: string;
+  queryApi: ObservabilityQueryApi;
+  defaultWindowSec: number;
+}
+
+export interface HarnessConfig {
+  reportOnly: boolean;
+  strictMode: boolean;
+}
+
+export interface HarnessContextMetadata {
+  [key: string]: string;
+}
+
+export interface HarnessContextPayload {
+  runId: string;
+  taskId?: string;
+  objective: string;
+  acceptanceCriteria: string[];
+  constraints: string[];
+  metadata?: HarnessContextMetadata;
+}
+
+export interface HarnessContextState extends HarnessContextPayload {
+  updatedAt: string;
+}
+
+export type HarnessSloOperator = "<" | "<=" | ">" | ">=" | "==" | "!=";
+
+export interface HarnessSloCheck {
+  id: string;
+  type: "latency" | "error_rate" | "custom";
+  queryType: ObservabilityQueryType;
+  query: string;
+  op: HarnessSloOperator;
+  threshold: number;
+  windowSec: number;
+}
+
+export interface ObservabilityQueryRequest {
+  queryType: ObservabilityQueryType;
+  query: string;
+  fromMs?: number;
+  toMs?: number;
+  limit?: number;
+}
+
+export interface ObservabilityQueryResult {
+  queryType: ObservabilityQueryType;
+  query: string;
+  fromMs: number;
+  toMs: number;
+  status: "ok" | "error";
+  data: unknown;
+  error?: string;
+}
+
+export interface HarnessSloCheckResult {
+  id: string;
+  type: HarnessSloCheck["type"];
+  queryType: ObservabilityQueryType;
+  query: string;
+  op: HarnessSloOperator;
+  threshold: number;
+  windowSec: number;
+  actual: number | null;
+  pass: boolean;
+  reason?: string;
+}
+
+export interface HarnessSloResult {
+  reportOnly: boolean;
+  strictMode: boolean;
+  passed: boolean;
+  fromMs: number;
+  toMs: number;
+  checks: HarnessSloCheckResult[];
 }
 
 export type AgentMessages = ModelMessage[];

--- a/test/observability.otel.test.ts
+++ b/test/observability.otel.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test } from "bun:test";
+
+import type { AgentConfig } from "../src/types";
+import { emitObservabilityEvent } from "../src/observability/otel";
+
+function makeConfig(): AgentConfig {
+  return {
+    provider: "openai",
+    model: "gpt-5.2",
+    subAgentModel: "gpt-5.2",
+    workingDirectory: "/tmp/work",
+    outputDirectory: "/tmp/out",
+    uploadsDirectory: "/tmp/uploads",
+    userName: "",
+    knowledgeCutoff: "unknown",
+    projectAgentDir: "/tmp/work/.agent",
+    userAgentDir: "/tmp/home/.agent",
+    builtInDir: "/tmp/built-in",
+    builtInConfigDir: "/tmp/built-in/config",
+    skillsDirs: [],
+    memoryDirs: [],
+    configDirs: [],
+    enableMcp: false,
+    observabilityEnabled: true,
+    observability: {
+      mode: "local_docker",
+      otlpHttpEndpoint: "http://127.0.0.1:4318",
+      queryApi: {
+        logsBaseUrl: "http://127.0.0.1:9428",
+        metricsBaseUrl: "http://127.0.0.1:8428",
+        tracesBaseUrl: "http://127.0.0.1:10428",
+      },
+      defaultWindowSec: 300,
+    },
+    harness: {
+      reportOnly: true,
+      strictMode: false,
+    },
+  };
+}
+
+describe("emitObservabilityEvent", () => {
+  test("does nothing when observability is disabled", async () => {
+    const cfg = { ...makeConfig(), observabilityEnabled: false };
+    const calls: Array<{ url: string; init: RequestInit | undefined }> = [];
+    const fetchImpl: typeof fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      calls.push({ url: String(input), init });
+      return new Response("", { status: 200 });
+    }) as any;
+
+    await emitObservabilityEvent(
+      cfg,
+      {
+        name: "agent.turn.started",
+        at: "2026-02-11T18:00:00.000Z",
+        status: "ok",
+      },
+      { fetchImpl }
+    );
+
+    expect(calls).toHaveLength(0);
+  });
+
+  test("emits an OTLP trace span to VictoriaTraces insert endpoint", async () => {
+    const cfg = makeConfig();
+    const calls: Array<{ url: string; init: RequestInit | undefined }> = [];
+    const fetchImpl: typeof fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      calls.push({ url: String(input), init });
+      return new Response("", { status: 200 });
+    }) as any;
+
+    await emitObservabilityEvent(
+      cfg,
+      {
+        name: "agent.turn.completed",
+        at: "2026-02-11T18:00:00.000Z",
+        status: "ok",
+        durationMs: 250,
+        attributes: {
+          sessionId: "session-123",
+          provider: "openai",
+        },
+      },
+      { fetchImpl }
+    );
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.url).toBe("http://127.0.0.1:10428/insert/opentelemetry/v1/traces");
+
+    const body = JSON.parse(String(calls[0]?.init?.body));
+    const span = body.resourceSpans?.[0]?.scopeSpans?.[0]?.spans?.[0];
+    expect(span?.name).toBe("agent.turn.completed");
+    expect(span?.traceId).toMatch(/^[0-9a-f]{32}$/);
+    expect(span?.spanId).toMatch(/^[0-9a-f]{16}$/);
+    expect(span?.status?.code).toBe(1);
+    expect(Array.isArray(span?.attributes)).toBe(true);
+    expect(span?.attributes.some((attr: any) => attr.key === "sessionId")).toBe(true);
+    expect(span?.attributes.some((attr: any) => attr.key === "duration.ms")).toBe(true);
+  });
+
+  test("marks error spans with error status code", async () => {
+    const cfg = makeConfig();
+    let payload: any = null;
+    const fetchImpl: typeof fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      payload = JSON.parse(String(init?.body ?? "{}"));
+      return new Response("", { status: 200 });
+    }) as any;
+
+    await emitObservabilityEvent(
+      cfg,
+      {
+        name: "agent.turn.failed",
+        at: "2026-02-11T18:00:00.000Z",
+        status: "error",
+      },
+      { fetchImpl }
+    );
+
+    const span = payload.resourceSpans?.[0]?.scopeSpans?.[0]?.spans?.[0];
+    expect(span?.status?.code).toBe(2);
+  });
+});

--- a/test/observability.slo.test.ts
+++ b/test/observability.slo.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, test } from "bun:test";
+
+import type { AgentConfig } from "../src/types";
+import { runObservabilityQuery } from "../src/observability/query";
+import { evaluateHarnessSlo } from "../src/observability/slo";
+
+function makeConfig(): AgentConfig {
+  return {
+    provider: "openai",
+    model: "gpt-5.2",
+    subAgentModel: "gpt-5.2",
+    workingDirectory: "/tmp/work",
+    outputDirectory: "/tmp/out",
+    uploadsDirectory: "/tmp/uploads",
+    userName: "",
+    knowledgeCutoff: "unknown",
+    projectAgentDir: "/tmp/work/.agent",
+    userAgentDir: "/tmp/home/.agent",
+    builtInDir: "/tmp/built-in",
+    builtInConfigDir: "/tmp/built-in/config",
+    skillsDirs: [],
+    memoryDirs: [],
+    configDirs: [],
+    enableMcp: false,
+    observabilityEnabled: true,
+    observability: {
+      mode: "local_docker",
+      otlpHttpEndpoint: "http://127.0.0.1:4318",
+      queryApi: {
+        logsBaseUrl: "http://127.0.0.1:9428",
+        metricsBaseUrl: "http://127.0.0.1:8428",
+        tracesBaseUrl: "http://127.0.0.1:10428",
+      },
+      defaultWindowSec: 300,
+    },
+    harness: {
+      reportOnly: true,
+      strictMode: false,
+    },
+  };
+}
+
+describe("runObservabilityQuery", () => {
+  test("returns disabled error when observability is off", async () => {
+    const cfg = { ...makeConfig(), observabilityEnabled: false };
+    const result = await runObservabilityQuery(cfg, { queryType: "promql", query: "up" });
+    expect(result.status).toBe("error");
+    expect(result.error).toContain("disabled");
+  });
+
+  test("returns parsed response data on success", async () => {
+    const cfg = makeConfig();
+    const fetchImpl: typeof fetch = (async () =>
+      new Response(JSON.stringify({ status: "success", data: { result: [{ value: [123, "0"] }] } }), {
+        status: 200,
+      })) as any;
+    const result = await runObservabilityQuery(cfg, { queryType: "promql", query: "up" }, { fetchImpl });
+    expect(result.status).toBe("ok");
+    expect((result.data as any).status).toBe("success");
+  });
+
+  test("traceql falls back to logsql endpoint when traceql path is unsupported", async () => {
+    const cfg = makeConfig();
+    const calls: string[] = [];
+    const fetchImpl: typeof fetch = (async (input: RequestInfo | URL) => {
+      const url = String(input);
+      calls.push(url);
+      if (url.includes("/select/traceql/query")) {
+        return new Response("unsupported", { status: 400 });
+      }
+      if (url.includes("/select/logsql/query")) {
+        return new Response(JSON.stringify([{ name: "agent.turn.completed", trace_id: "abc" }]), {
+          status: 200,
+        });
+      }
+      return new Response("not found", { status: 404 });
+    }) as any;
+
+    const result = await runObservabilityQuery(
+      cfg,
+      { queryType: "traceql", query: "_time:[now-5m, now]" },
+      { fetchImpl }
+    );
+
+    expect(result.status).toBe("ok");
+    expect(calls.some((url) => url.includes("/select/traceql/query"))).toBe(true);
+    expect(calls.some((url) => url.includes("/select/logsql/query"))).toBe(true);
+  });
+});
+
+describe("evaluateHarnessSlo", () => {
+  test("passes when check operator condition is met", async () => {
+    const cfg = makeConfig();
+    const fetchImpl: typeof fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          status: "success",
+          data: { resultType: "vector", result: [{ metric: {}, value: [1738736700, "0"] }] },
+        }),
+        { status: 200 }
+      )) as any;
+
+    const result = await evaluateHarnessSlo(
+      cfg,
+      [
+        {
+          id: "vector_errors",
+          type: "custom",
+          queryType: "promql",
+          query: "sum(rate(vector_component_errors_total[5m]))",
+          op: "<=",
+          threshold: 0,
+          windowSec: 300,
+        },
+      ],
+      { fetchImpl, nowMs: 1738736700000 }
+    );
+
+    expect(result.passed).toBe(true);
+    expect(result.checks[0]?.pass).toBe(true);
+    expect(result.checks[0]?.actual).toBe(0);
+  });
+
+  test("fails when no numeric value can be extracted", async () => {
+    const cfg = makeConfig();
+    const fetchImpl: typeof fetch = (async () =>
+      new Response(JSON.stringify({ status: "success", data: { result: [{ value: ["x", "NaN"] }] } }), {
+        status: 200,
+      })) as any;
+
+    const result = await evaluateHarnessSlo(
+      cfg,
+      [
+        {
+          id: "bad",
+          type: "custom",
+          queryType: "promql",
+          query: "up",
+          op: "<=",
+          threshold: 1,
+          windowSec: 60,
+        },
+      ],
+      { fetchImpl, nowMs: 1738736700000 }
+    );
+
+    expect(result.passed).toBe(false);
+    expect(result.checks[0]?.reason).toContain("numeric");
+  });
+});

--- a/test/server.connect.test.ts
+++ b/test/server.connect.test.ts
@@ -56,7 +56,7 @@ function sendConnectAndCollect(
         return;
       }
 
-      if (msg.type === "session_settings") return;
+      if (msg.type === "session_settings" || msg.type === "observability_status") return;
 
       responses.push(msg);
       if (responses.length >= responseCount) {

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -25,6 +25,7 @@ function serverOpts(tmpDir: string, overrides?: Partial<StartAgentServerOptions>
     cwd: tmpDir,
     hostname: "127.0.0.1",
     port: 0,
+    homedir: tmpDir,
     env: {
       AGENT_WORKING_DIR: tmpDir,
       AGENT_PROVIDER: "google",
@@ -104,7 +105,7 @@ function sendAndCollect(
         return;
       }
 
-      if (msg.type === "session_settings") return;
+      if (msg.type === "session_settings" || msg.type === "observability_status") return;
 
       responses.push(msg);
       if (responses.length >= responseCount) {
@@ -321,6 +322,19 @@ describe("WebSocket Lifecycle", () => {
     }
   });
 
+  test("connect emits observability_status", async () => {
+    const tmpDir = await makeTmpProject();
+    const { server, url } = await startAgentServer(serverOpts(tmpDir));
+    try {
+      const messages = await collectMessages(url, 3);
+      const status = messages.find((msg: any) => msg.type === "observability_status");
+      expect(status).toBeDefined();
+      expect(typeof status.enabled).toBe("boolean");
+    } finally {
+      server.stop();
+    }
+  });
+
   test("each connection gets a unique sessionId", async () => {
     const tmpDir = await makeTmpProject();
     const { server, url } = await startAgentServer(serverOpts(tmpDir));
@@ -369,7 +383,7 @@ describe("WebSocket Lifecycle", () => {
             ws.send("this is not valid json {{{");
             return;
           }
-          if (msg.type === "session_settings") return;
+          if (msg.type === "session_settings" || msg.type === "observability_status") return;
           clearTimeout(timer);
           ws.close();
           resolve(msg);
@@ -488,6 +502,51 @@ describe("WebSocket Lifecycle", () => {
     }
   });
 
+  test("harness_context_set returns harness_context", async () => {
+    const tmpDir = await makeTmpProject();
+    const { server, url } = await startAgentServer(serverOpts(tmpDir));
+    try {
+      const { responses } = await sendAndCollect(
+        url,
+        (sessionId) => ({
+          type: "harness_context_set",
+          sessionId,
+          context: {
+            runId: "run-01",
+            objective: "Improve startup reliability",
+            acceptanceCriteria: ["startup < 800ms"],
+            constraints: ["no API changes"],
+          },
+        }),
+        1
+      );
+      expect(responses[0].type).toBe("harness_context");
+      expect(responses[0].context.runId).toBe("run-01");
+    } finally {
+      server.stop();
+    }
+  });
+
+  test("observability_query returns result envelope", async () => {
+    const tmpDir = await makeTmpProject();
+    const { server, url } = await startAgentServer(serverOpts(tmpDir));
+    try {
+      const { responses } = await sendAndCollect(
+        url,
+        (sessionId) => ({
+          type: "observability_query",
+          sessionId,
+          query: { queryType: "promql", query: "up" },
+        }),
+        1
+      );
+      expect(responses[0].type).toBe("observability_query_result");
+      expect(responses[0].result.status).toBe("error");
+    } finally {
+      server.stop();
+    }
+  });
+
   test("sending a non-object JSON value receives error", async () => {
     const tmpDir = await makeTmpProject();
     const { server, url } = await startAgentServer(serverOpts(tmpDir));
@@ -507,7 +566,7 @@ describe("WebSocket Lifecycle", () => {
             ws.send(JSON.stringify("just a string"));
             return;
           }
-          if (msg.type === "session_settings") return;
+          if (msg.type === "session_settings" || msg.type === "observability_status") return;
           clearTimeout(timer);
           ws.close();
           resolve(msg);
@@ -540,7 +599,7 @@ describe("WebSocket Lifecycle", () => {
             ws.send("null");
             return;
           }
-          if (msg.type === "session_settings") return;
+          if (msg.type === "session_settings" || msg.type === "observability_status") return;
           clearTimeout(timer);
           ws.close();
           resolve(msg);
@@ -573,7 +632,7 @@ describe("WebSocket Lifecycle", () => {
             ws.send(JSON.stringify([1, 2, 3]));
             return;
           }
-          if (msg.type === "session_settings") return;
+          if (msg.type === "session_settings" || msg.type === "observability_status") return;
           clearTimeout(timer);
           ws.close();
           resolve(msg);


### PR DESCRIPTION
## Summary
- add harness observability stack plumbing (context, query, SLO, runtime, smoke/full runners)
- add custom Next.js realtime portal in `apps/portal` for aggregated run + observability views
- add verbose harness docs/runbook including CLI/TUI target-dir + live trace walkthrough
- wire CI for docs/tests/smoke plus full harness run in GitHub environment `Testing`

## CI / Env
- workflow: `.github/workflows/ci.yml`
- full harness job reads environment secrets from `Testing`
- required secrets: `OPENAI_API_KEY`, `GOOGLE_GENERATIVE_AI_API_KEY`, `ANTHROPIC_API_KEY`

## Validation done locally
- `bun run docs:check`
- `bun test`
- `bun run portal:build`
- `bun run harness:smoke`
- one live model probe via SDK call

## Notes
- `desktop` branch did not exist remotely, so it was created from `origin/main` before opening this PR.
