### PR TITLE
Sync PRD with implementation and harden protocol safety

### DIFF
--- a/Cowork_Agent_PRD.md
+++ b/Cowork_Agent_PRD.md
@@ -1,6 +1,6 @@
 # Cowork Agent — Product Requirements Document
 
-An open-source, model-agnostic desktop AI agent built from scratch on the Vercel AI SDK.
+An open-source, model-agnostic coworker agent built on Bun + TypeScript with a websocket-first server and thin TUI/CLI clients.
 
 **Version:** 1.0
 **Date:** February 2026
@@ -9,30 +9,58 @@ An open-source, model-agnostic desktop AI agent built from scratch on the Vercel
 
 ## 1. Overview
 
-This document defines the architecture, tools, system prompt, and implementation plan for building an open-source AI agent modeled after Anthropic's Cowork mode. The agent is built from scratch on the Vercel AI SDK, is fully model-agnostic, and designed to run as a local process on the user's machine with access to their filesystem, a shell, web search, and extensible MCP integrations.
+This PRD is now aligned to the implemented `agent-coworker` architecture in this repository (Bun + TypeScript, websocket-first server, thin TUI/CLI clients, MCP integration, observability + harness, and session backup).
 
-The goal is a functional agent core — not a UI. The agent should be usable from a CLI, a script, or as a backend for any frontend you build later.
+The project goal is release-readiness and behavioral safety for the existing product surface, with additive protocol evolution only.
 
 ### 1.1 Design Principles
 
-- **Model-agnostic:** Swap providers by changing one line. The system prompt and tools are provider-independent.
-- **Tool-first:** The agent's capabilities come from its tools, not the model. Any model that supports tool calling works.
-- **MCP-native:** External integrations plug in via MCP servers, not custom code.
-- **Single-file tools:** Each tool is one TypeScript file with a Zod schema and execute function.
-- **Minimal dependencies:** Vercel AI SDK + Zod + a few utility packages. No frameworks, no ORMs, no build steps beyond TypeScript.
+- **Websocket-first core:** business logic lives in `src/server/session.ts`; clients are transport/rendering layers.
+- **Thin clients:** `src/tui/index.tsx` and `src/cli/repl.ts` consume `ServerEvent` and emit `ClientMessage` only.
+- **Provider-runtime flexibility:** model/provider switching is runtime-configurable (`connect_provider`, `set_model`) without restarting the server.
+- **Safety-first execution:** command approval, path permissions, and explicit risky-action handling remain mandatory defaults.
+- **Observability for operations:** local OTEL + query APIs + harness checks are first-class runtime controls, not post-hoc add-ons.
+- **Resilience and continuity:** per-session backup/checkpoint/restore is part of core behavior.
 
 ### 1.2 Tech Stack
 
-| Layer | Technology | Why |
-|-------|-----------|-----|
-| Runtime | Node.js / Bun | Native FS access, child_process for bash, fast startup |
-| Agent Framework | Vercel AI SDK (`ai`) | `generateText` + `maxSteps` or `ToolLoopAgent` for the agent loop |
-| Schema Validation | Zod | Type-safe tool parameter definitions, required by AI SDK |
-| Model Providers | `@ai-sdk/anthropic`, `@ai-sdk/openai`, `@ai-sdk/google`, etc. | Swap providers without changing tool code |
-| MCP Integration | `@ai-sdk/mcp` | Native MCP client for connecting external tool servers |
-| File Utilities | `fast-glob`, Node `fs/path` | Glob pattern matching, file operations |
-| Search Backend | Brave Search API or Exa | Web search tool backend (API key required) |
-| HTML Processing | `@mozilla/readability` + `turndown` | WebFetch: HTML → markdown conversion |
+| Layer | Current Implementation |
+|---|---|
+| Runtime | Bun + TypeScript (ESM, strict mode) |
+| Core loop | AI SDK-driven tool loop in `src/agent.ts` |
+| Server transport | WebSocket server in `src/server/startServer.ts` |
+| Session orchestration | `src/server/session.ts` |
+| Protocol contract | `src/server/protocol.ts` + `docs/websocket-protocol.md` |
+| Clients | OpenTUI React client (`src/tui/index.tsx`), CLI REPL (`src/cli/repl.ts`) |
+| Providers | `google`, `openai`, `anthropic`, `gemini-cli`, `codex-cli`, `claude-code` |
+| MCP | Runtime-discovered and namespaced via `src/mcp/index.ts` |
+| Observability/Harness | `src/observability/*`, `src/harness/contextStore.ts`, `docs/harness/index.md` |
+| Continuity | Session backup/checkpoints in `src/server/sessionBackup.ts` |
+
+### 1.3 Implementation Status vs PRD
+
+| Area | Status | Notes |
+|---|---|---|
+| Websocket server + per-connection session lifecycle | `implemented` | `startServer` creates `AgentSession`, emits `server_hello`, settings, observability status. |
+| Thin TUI/CLI consuming server protocol | `implemented` | UI logic is protocol-driven; server holds business logic. |
+| Provider runtime switching (`connect_provider`, `set_model`) | `implemented` | Works across API-key and CLI OAuth provider modes. |
+| MCP lifecycle + namespacing + enable/disable at runtime | `implemented with divergence` | More complete than original PRD baseline; includes dynamic lifecycle controls. |
+| Observability + harness query/evaluation surface | `implemented with divergence` | Added after original baseline; now part of public API surface. |
+| Session backup/checkpoint/restore/delete | `implemented with divergence` | Not in initial baseline; now integrated into core session behavior. |
+| Approval gating for risky commands | `implemented` | Command classifier + approval event flow are active. |
+| Structured protocol error codes/sources | `implemented` | Additive `error.code`/`error.source` fields introduced for deterministic handling. |
+| Protocol version field (`server_hello.protocolVersion`) | `implemented` | Additive handshake metadata introduced. |
+| Protocol-doc parity regression checks | `implemented` | Integration tests verify docs headings and executable flows. |
+| Typed approval risk codes across all risky actions | `planned` | Incremental hardening work remains for broader policy coverage. |
+| Concurrency stress suite (5 parallel sessions mixed traffic) | `pending` | Planned for reliability sprint milestone. |
+
+### 1.4 Legacy Assumptions (Historical)
+
+The following earlier PRD assumptions are retained as historical context, not current architecture:
+
+- CLI-only or “UI later” framing is obsolete; websocket + TUI/CLI clients are shipped.
+- Vercel AI SDK examples showing single-process interactive loops are historical; production path is `AgentSession` over websocket.
+- Minimal dependency assumptions changed: observability, harness, backup, provider status, and MCP lifecycle expanded the system surface.
 
 ---
 
@@ -40,587 +68,103 @@ The goal is a functional agent core — not a UI. The agent should be usable fro
 
 ### 2.1 Project Structure
 
-```
-cowork-agent/
-├── package.json
-├── tsconfig.json
+```text
+agent-coworker/
 ├── src/
-│   ├── index.ts              # Entry point — CLI or programmatic
-│   ├── agent.ts              # Main agent definition and loop
-│   ├── config.ts             # Provider config, model selection
-│   ├── prompt.ts             # System prompt loader with template injection
-│   ├── types.ts              # Shared TypeScript types
-│   ├── tools/
-│   │   ├── index.ts          # Barrel export of all tools
-│   │   ├── bash.ts           # Shell command execution
-│   │   ├── read.ts           # Read files
-│   │   ├── write.ts          # Write/create files
-│   │   ├── edit.ts           # String replacement in files
-│   │   ├── glob.ts           # File pattern matching
-│   │   ├── grep.ts           # Content search (ripgrep)
-│   │   ├── webSearch.ts      # Web search via API
-│   │   ├── webFetch.ts       # Fetch URL + convert to markdown
-│   │   ├── ask.ts            # Pause and ask user for input
-│   │   ├── todoWrite.ts      # Progress tracking todo list
-│   │   └── spawnAgent.ts     # Launch a sub-agent
+│   ├── agent.ts
+│   ├── config.ts
+│   ├── types.ts
+│   ├── server/
+│   │   ├── startServer.ts
+│   │   ├── session.ts
+│   │   ├── protocol.ts
+│   │   └── sessionBackup.ts
+│   ├── cli/
+│   │   ├── args.ts
+│   │   └── repl.ts
+│   ├── tui/
+│   │   └── index.tsx
+│   ├── providers/
 │   ├── mcp/
-│   │   └── index.ts          # MCP client setup and tool loading
+│   ├── tools/
+│   ├── observability/
+│   ├── harness/
+│   ├── skills/
 │   └── utils/
-│       ├── sandbox.ts        # Optional: file operation sandboxing
-│       └── permissions.ts    # Tool approval logic
-├── prompts/
-│   ├── system.md             # Main system prompt (markdown source)
-│   └── sub-agents/
-│       ├── explore.md        # Explore sub-agent prompt
-│       └── research.md       # Research sub-agent prompt
-└── config/
-    └── mcp-servers.json      # MCP server definitions
+├── config/
+├── docs/
+│   ├── websocket-protocol.md
+│   └── harness/index.md
+└── test/
 ```
 
-### 2.2 Agent Loop
+### 2.2 Runtime Topology
 
-The agent uses the AI SDK's `generateText` with `maxSteps` (v4 pattern) or `ToolLoopAgent` (v6 pattern). Both accomplish the same thing: model receives messages → decides to call a tool → tool executes → result fed back → model decides next action → repeat until done.
-
-#### v4 Pattern (generateText + maxSteps)
-
-```typescript
-import { generateText } from "ai";
-import { anthropic } from "@ai-sdk/anthropic";
-import { tools } from "./tools";
-import { systemPrompt } from "./prompt";
-
-const { text, steps } = await generateText({
-  model: anthropic("claude-opus-4-6-20250116"),
-  system: systemPrompt,
-  tools,
-  maxSteps: 100,
-  messages: conversationHistory,
-  onStepFinish({ text, toolCalls, toolResults }) {
-    // Log progress, update UI, etc.
-  },
-});
-```
-
-#### v6 Pattern (ToolLoopAgent)
-
-```typescript
-import { ToolLoopAgent, stepCountIs } from "ai";
-
-const agent = new ToolLoopAgent({
-  model: anthropic("claude-opus-4-6-20250116"),
-  system: systemPrompt,
-  tools,
-  stopWhen: stepCountIs(100),
-});
-
-const result = await agent.run({ messages: conversationHistory });
-```
-
-Both patterns are equivalent. Use whichever matches your AI SDK version. The tools and system prompt are identical either way.
+1. `startAgentServer()` loads config + prompt + discovered skills.
+2. Each websocket connection gets one `AgentSession` instance.
+3. Server emits `server_hello`, `session_settings`, and `observability_status` immediately.
+4. Client sends `ClientMessage` payloads; server validates with `safeParseClientMessage()`.
+5. Session routes messages to provider/runtime/tool execution, MCP, harness, and backup subsystems.
+6. Session emits protocol events (`ServerEvent`) that all clients consume uniformly.
 
 ### 2.3 Model Configuration
 
-> **Note:** Section 16.3 has the full config with layered directory resolution (project → user → built-in). This section shows the minimal starting point.
+Model/provider behavior is runtime-configurable and no longer tied to static boot-time examples.
 
-The agent is model-agnostic. Provider selection is isolated to a single config file:
+- Provider set: `google`, `openai`, `anthropic`, `gemini-cli`, `codex-cli`, `claude-code`.
+- Default models are defined in `src/providers/catalog.ts` and resolved per provider.
+- Config resolution is layered (`config/defaults.json` → `~/.agent/config.json` → `<cwd>/.agent/config.json` → env overrides).
+- Runtime switches:
+  - `connect_provider` for auth/connect flows.
+  - `set_model` for active provider/model changes.
+  - `refresh_provider_status` for deterministic client-side provider health/status UI.
+- Current examples should use active catalog values (for example `openai: gpt-5.2`, `anthropic: claude-opus-4-6`, `google: gemini-3-flash-preview`) instead of legacy placeholders.
 
-```typescript
-// src/config.ts
-import { anthropic } from "@ai-sdk/anthropic";
-import { openai } from "@ai-sdk/openai";
-import { google } from "@ai-sdk/google";
-import path from "path";
+### 2.4 Public Protocol Capabilities (Canonical Contract)
 
-const providers: Record<string, (id: string) => any> = {
-  anthropic: (id: string) => anthropic(id),
-  openai: (id: string) => openai(id),
-  google: (id: string) => google(id),
-};
+`docs/websocket-protocol.md` is the public API contract and UI integration source of truth. `src/server/protocol.ts` is the typed implementation contract.
 
-export const config = {
-  // --- Model ---
-  provider: "anthropic",
-  model: "claude-opus-4-6-20250116",
-  subAgentModel: "claude-haiku-4-5-20251001",
+Protocol references in this PRD must use the exact message names and payload shapes from those files, including:
 
-  // --- Directories (injected into system prompt as {{variables}}) ---
-  workingDirectory: process.env.AGENT_WORKING_DIR || process.cwd(),
-  outputDirectory: process.env.AGENT_OUTPUT_DIR || path.join(process.cwd(), "output"),
-  uploadsDirectory: process.env.AGENT_UPLOADS_DIR || path.join(process.cwd(), "uploads"),
-  skillsDirectory: process.env.AGENT_SKILLS_DIR || path.join(process.cwd(), "skills"),
-
-  // --- User ---
-  userName: process.env.AGENT_USER_NAME || "",
-
-  // --- Knowledge ---
-  knowledgeCutoff: "End of May 2025",  // Update when switching models
-};
-
-export function getModel(id?: string) {
-  const p = providers[config.provider];
-  if (!p) throw new Error(`Unknown provider: ${config.provider}`);
-  return p(id || config.model);
-}
-```
-
-The config sources directory paths from environment variables (`AGENT_WORKING_DIR`, `AGENT_OUTPUT_DIR`, etc.) with sensible defaults. The host application sets these at launch. The prompt loader reads these values and injects them into every `{{variable}}` in the system prompt.
+- Handshake and session metadata: `server_hello` (`sessionId`, `protocolVersion`, `config`), `session_settings`.
+- Human loop controls: `ask`/`ask_response`, `approval`/`approval_response`.
+- Errors: `error` with required `message` and additive optional `code`/`source`.
+- Keepalive: `ping`/`pong`.
 
 ---
 
 ## 3. Tool Specifications
 
-Each tool is a single TypeScript file exporting a Vercel AI SDK `tool()` definition. All tools follow the same pattern: a description the model reads, an `inputSchema` defined with Zod, and an `execute` function.
-
-### 3.1 bash
-
-Execute shell commands. This is the most powerful tool — it gives the agent access to the full system.
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `command` | string | Yes | The shell command to execute |
-| `timeout` | number | No | Timeout in ms (default: 120000, max: 600000) |
-
-**Approval:** `needsApproval: true`. Every bash command should be surfaced to the user for approval before execution. Your approval handler can auto-approve safe patterns (`ls`, `cat`, `echo`) and require confirmation for destructive ones (`rm`, `mv`, `chmod`).
-
-```typescript
-// src/tools/bash.ts
-import { tool } from "ai";
-import { z } from "zod";
-import { exec } from "child_process";
-
-export const bash = tool({
-  description: "Execute a shell command. Use for git, npm, system operations, listing directories, running scripts. Always quote paths with spaces.",
-  inputSchema: z.object({
-    command: z.string().describe("The bash command to execute"),
-    timeout: z.number().optional().default(120000).describe("Timeout in ms"),
-  }),
-  needsApproval: true,
-  execute: async ({ command, timeout }) => {
-    return new Promise((resolve) => {
-      exec(command, { timeout, maxBuffer: 1024 * 1024 * 10 }, (err, stdout, stderr) => {
-        resolve({
-          stdout: stdout.slice(0, 30000),
-          stderr: stderr.slice(0, 10000),
-          exitCode: err?.code || 0,
-        });
-      });
-    });
-  },
-});
-```
-
-### 3.2 read
-
-Read file contents. Returns text with line numbers. Supports offset/limit for large files.
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `filePath` | string | Yes | Absolute path to the file |
-| `offset` | number | No | Line number to start reading from (1-indexed) |
-| `limit` | number | No | Max lines to read (default: 2000) |
-
-```typescript
-// src/tools/read.ts
-import { tool } from "ai";
-import { z } from "zod";
-import fs from "fs/promises";
-
-export const read = tool({
-  description: "Read a file from the filesystem. Returns content with line numbers. Use offset/limit for large files.",
-  inputSchema: z.object({
-    filePath: z.string().describe("Absolute path to the file"),
-    offset: z.number().optional().describe("Start line (1-indexed)"),
-    limit: z.number().optional().default(2000).describe("Max lines to return"),
-  }),
-  execute: async ({ filePath, offset, limit }) => {
-    const content = await fs.readFile(filePath, "utf-8");
-    const lines = content.split("\n");
-    const start = (offset || 1) - 1;
-    const sliced = lines.slice(start, start + limit);
-    const numbered = sliced.map((line, i) => `${start + i + 1}\t${line}`);
-    return numbered.join("\n");
-  },
-});
-```
-
-### 3.3 write
-
-Write content to a file. Creates the file if it doesn't exist, overwrites if it does.
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `filePath` | string | Yes | Absolute path to the file |
-| `content` | string | Yes | Content to write |
-
-```typescript
-// src/tools/write.ts
-import { tool } from "ai";
-import { z } from "zod";
-import fs from "fs/promises";
-import path from "path";
-
-export const write = tool({
-  description: "Write content to a file. Creates parent directories if needed. Overwrites existing files.",
-  inputSchema: z.object({
-    filePath: z.string().describe("Absolute file path to write"),
-    content: z.string().describe("Content to write"),
-  }),
-  execute: async ({ filePath, content }) => {
-    await fs.mkdir(path.dirname(filePath), { recursive: true });
-    await fs.writeFile(filePath, content, "utf-8");
-    return `Wrote ${content.length} chars to ${filePath}`;
-  },
-});
-```
-
-### 3.4 edit
-
-Perform exact string replacement in a file. Fails if the old string isn't found or isn't unique (unless `replaceAll` is true).
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `filePath` | string | Yes | Absolute path to the file |
-| `oldString` | string | Yes | Exact text to find and replace |
-| `newString` | string | Yes | Text to replace it with |
-| `replaceAll` | boolean | No | Replace all occurrences (default: false) |
-
-```typescript
-// src/tools/edit.ts
-import { tool } from "ai";
-import { z } from "zod";
-import fs from "fs/promises";
-
-export const edit = tool({
-  description: "Replace exact text in a file. The oldString must exist in the file. Use replaceAll to replace every occurrence.",
-  inputSchema: z.object({
-    filePath: z.string().describe("Absolute file path"),
-    oldString: z.string().describe("Exact text to replace"),
-    newString: z.string().describe("Replacement text"),
-    replaceAll: z.boolean().optional().default(false).describe("Replace all occurrences"),
-  }),
-  execute: async ({ filePath, oldString, newString, replaceAll }) => {
-    let content = await fs.readFile(filePath, "utf-8");
-    if (!content.includes(oldString)) throw new Error(`oldString not found in ${filePath}`);
-    if (!replaceAll) {
-      const count = content.split(oldString).length - 1;
-      if (count > 1) throw new Error(`oldString found ${count} times. Provide more context or set replaceAll.`);
-    }
-    content = replaceAll ? content.replaceAll(oldString, newString) : content.replace(oldString, newString);
-    await fs.writeFile(filePath, content, "utf-8");
-    return "Edit applied.";
-  },
-});
-```
-
-### 3.5 glob
-
-Find files matching a glob pattern. Returns paths sorted by modification time.
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `pattern` | string | Yes | Glob pattern (e.g. `**/*.ts`) |
-| `cwd` | string | No | Directory to search from (default: workspace root) |
-
-```typescript
-// src/tools/glob.ts
-import { tool } from "ai";
-import { z } from "zod";
-import fg from "fast-glob";
-
-export const glob = tool({
-  description: "Find files matching a glob pattern. Returns file paths sorted by modification time.",
-  inputSchema: z.object({
-    pattern: z.string().describe("Glob pattern to match"),
-    cwd: z.string().optional().describe("Directory to search from"),
-  }),
-  execute: async ({ pattern, cwd }) => {
-    const files = await fg(pattern, { cwd: cwd || process.cwd(), stats: true, dot: false });
-    files.sort((a, b) => (b.stats?.mtimeMs || 0) - (a.stats?.mtimeMs || 0));
-    return files.map(f => f.path).join("\n") || "No files found.";
-  },
-});
-```
-
-### 3.6 grep
-
-Search file contents using regex patterns. Wraps ripgrep for speed.
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `pattern` | string | Yes | Regex pattern to search for |
-| `path` | string | No | File or directory to search |
-| `fileGlob` | string | No | Filter files (e.g. `*.ts`) |
-| `contextLines` | number | No | Lines of context around matches |
-| `caseSensitive` | boolean | No | Case sensitive (default: true) |
-
-```typescript
-// src/tools/grep.ts
-import { tool } from "ai";
-import { z } from "zod";
-import { execSync } from "child_process";
-
-export const grep = tool({
-  description: "Search file contents for a regex pattern. Uses ripgrep. Returns matching lines with filenames and line numbers.",
-  inputSchema: z.object({
-    pattern: z.string().describe("Regex pattern"),
-    path: z.string().optional().describe("File or directory to search"),
-    fileGlob: z.string().optional().describe("Glob to filter files"),
-    contextLines: z.number().optional().describe("Context lines around matches"),
-    caseSensitive: z.boolean().optional().default(true),
-  }),
-  execute: async ({ pattern, path: searchPath, fileGlob, contextLines, caseSensitive }) => {
-    let cmd = "rg --line-number";
-    if (!caseSensitive) cmd += " -i";
-    if (contextLines) cmd += ` -C ${contextLines}`;
-    if (fileGlob) cmd += ` --glob '${fileGlob}'`;
-    cmd += ` '${pattern}' ${searchPath || "."}`;
-    try {
-      return execSync(cmd, { maxBuffer: 1024 * 1024 * 5 }).toString().slice(0, 30000);
-    } catch {
-      return "No matches found.";
-    }
-  },
-});
-```
-
-### 3.7 webSearch
-
-Search the web. Backed by Brave Search API, Exa, or any search provider you configure.
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `query` | string | Yes | Search query |
-| `maxResults` | number | No | Maximum results (default: 10) |
-
-```typescript
-// src/tools/webSearch.ts
-import { tool } from "ai";
-import { z } from "zod";
-
-export const webSearch = tool({
-  description: "Search the web for current information. Use for anything beyond the knowledge cutoff or for up-to-date info.",
-  inputSchema: z.object({
-    query: z.string().describe("Search query"),
-    maxResults: z.number().optional().default(10),
-  }),
-  execute: async ({ query, maxResults }) => {
-    // Swap this implementation for your preferred search API
-    const res = await fetch(
-      `https://api.search.brave.com/res/v1/web/search?q=${encodeURIComponent(query)}&count=${maxResults}`,
-      { headers: { "X-Subscription-Token": process.env.BRAVE_API_KEY! } }
-    );
-    const data = await res.json();
-    return (
-      data.web?.results
-        ?.map((r: any) => `${r.title}\n${r.url}\n${r.description}`)
-        .join("\n\n") || "No results"
-    );
-  },
-});
-```
-
-### 3.8 webFetch
-
-Fetch a URL and convert the HTML to clean markdown for the model to read.
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `url` | string | Yes | URL to fetch |
-| `maxLength` | number | No | Max characters to return (default: 50000) |
-
-```typescript
-// src/tools/webFetch.ts
-// Requires: npm install @mozilla/readability jsdom turndown
-import { tool } from "ai";
-import { z } from "zod";
-
-export const webFetch = tool({
-  description: "Fetch a URL and return its content as markdown. Use to read documentation, articles, or any web page.",
-  inputSchema: z.object({
-    url: z.string().url().describe("The URL to fetch"),
-    maxLength: z.number().optional().default(50000),
-  }),
-  execute: async ({ url, maxLength }) => {
-    const { Readability } = require("@mozilla/readability");
-    const { JSDOM } = require("jsdom");
-    const TurndownService = require("turndown");
-    const res = await fetch(url);
-    const html = await res.text();
-    const dom = new JSDOM(html, { url });
-    const article = new Readability(dom.window.document).parse();
-    const turndown = new TurndownService();
-    const md = article
-      ? turndown.turndown(article.content)
-      : turndown.turndown(html);
-    return md.slice(0, maxLength);
-  },
-});
-```
-
-### 3.9 ask
-
-Pause execution and ask the user a question. The agent loop stops, the question is surfaced to the user, and their response is fed back as the tool result.
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `question` | string | Yes | The question to ask the user |
-| `options` | string[] | No | Multiple-choice options (user can always type a custom answer) |
-
-**Implementation note:** This tool has **no execute function**. When the model calls it, the agent loop pauses (`generateText` returns with a tool call but no result). Your host application handles prompting the user and resuming the loop with their answer.
-
-```typescript
-// src/tools/ask.ts
-import { tool } from "ai";
-import { z } from "zod";
-
-export const ask = tool({
-  description: "Ask the user a clarifying question. Use when the request is ambiguous or you need a decision. Provide options when possible.",
-  inputSchema: z.object({
-    question: z.string().describe("The question to ask"),
-    options: z.array(z.string()).optional().describe("Multiple-choice options"),
-  }),
-  // No execute function — this pauses the loop.
-  // The host application handles user input and resumes.
-});
-```
-
-### 3.10 todoWrite
-
-Track progress on multi-step tasks. The host application renders the todo list as a widget. This tool updates the entire list each time it's called (overwrite, not append).
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `todos` | array | Yes | Full list of todos with content, status, and activeForm |
-
-Each todo item has:
-- `content` (string): Imperative description — "Run tests"
-- `status` (string): `"pending"`, `"in_progress"`, or `"completed"`
-- `activeForm` (string): Present continuous — "Running tests"
-
-```typescript
-// src/tools/todoWrite.ts
-import { tool } from "ai";
-import { z } from "zod";
-
-const todoSchema = z.object({
-  content: z.string().describe("Imperative description (e.g. 'Run tests')"),
-  status: z.enum(["pending", "in_progress", "completed"]),
-  activeForm: z.string().describe("Present continuous form (e.g. 'Running tests')"),
-});
-
-// Shared state — the host can read this to render the widget
-export let currentTodos: z.infer<typeof todoSchema>[] = [];
-
-export const todoWrite = tool({
-  description: "Update the todo list to track progress on multi-step tasks. Overwrites the full list each call.",
-  inputSchema: z.object({
-    todos: z.array(todoSchema).describe("The complete updated todo list"),
-  }),
-  execute: async ({ todos }) => {
-    currentTodos = todos;
-    const summary = todos.map(t => `[${t.status}] ${t.content}`).join("\n");
-    return `Todo list updated:\n${summary}`;
-  },
-});
-```
-
-### 3.11 spawnAgent
-
-Launch a sub-agent for a specific task. Sub-agents run with their own system prompt and tool subset, can use a cheaper/faster model, and return their result to the parent agent.
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `task` | string | Yes | Description of what the sub-agent should do |
-| `agentType` | string | No | Agent type: `explore`, `research`, or `general` (default: `general`) |
-
-```typescript
-// src/tools/spawnAgent.ts
-import { tool, generateText } from "ai";
-import { z } from "zod";
-import { getModel, config } from "../config";
-import { subAgentPrompts, subAgentTools } from "../prompt";
-
-export const spawnAgent = tool({
-  description:
-    "Launch a sub-agent for a specific task. Use for parallel work, research, or isolating a complex sub-task.",
-  inputSchema: z.object({
-    task: z.string().describe("What the sub-agent should accomplish"),
-    agentType: z
-      .enum(["explore", "research", "general"])
-      .optional()
-      .default("general"),
-  }),
-  execute: async ({ task, agentType }) => {
-    const { text } = await generateText({
-      model: getModel(config.subAgentModel),
-      system: subAgentPrompts[agentType],
-      tools: subAgentTools[agentType],
-      maxSteps: 50,
-      prompt: task,
-    });
-    return text;
-  },
-});
-```
-
-### 3.12 MCP Server Integration
-
-External tools connect via MCP servers. The `@ai-sdk/mcp` package handles discovery and execution:
-
-```typescript
-// src/mcp/index.ts
-import { createMCPClient } from "@ai-sdk/mcp";
-
-export async function loadMCPTools(servers: MCPServerConfig[]) {
-  const allTools = {};
-  for (const server of servers) {
-    const client = await createMCPClient({
-      name: server.name,
-      transport: server.transport,
-      // transport: { type: "stdio", command: "npx", args: [...] }
-      // or: { type: "http", url: "https://..." }
-    });
-    const tools = await client.tools();
-    Object.assign(allTools, tools);
-  }
-  return allTools;
-}
-```
-
-MCP servers are defined in `config/mcp-servers.json` and loaded at startup. Their tools are merged with the built-in tools and passed to `generateText` together. No code changes needed to add new integrations — just add a server to the JSON.
-
-### 3.13 Tool Barrel Export
-
-```typescript
-// src/tools/index.ts
-import { bash } from "./bash";
-import { read } from "./read";
-import { write } from "./write";
-import { edit } from "./edit";
-import { glob } from "./glob";
-import { grep } from "./grep";
-import { webSearch } from "./webSearch";
-import { webFetch } from "./webFetch";
-import { ask } from "./ask";
-import { todoWrite } from "./todoWrite";
-import { spawnAgent } from "./spawnAgent";
-
-export const tools = {
-  bash,
-  read,
-  write,
-  edit,
-  glob,
-  grep,
-  webSearch,
-  webFetch,
-  ask,
-  todoWrite,
-  spawnAgent,
-};
-```
-
----
+Tools are implemented in `src/tools/*` and assembled by `src/tools/index.ts`. Execution policy lives in server/session orchestration, not in UI.
+
+### 3.1 Current Built-In Tool Surface
+
+| Tool | Purpose | Safety/Policy Notes |
+|---|---|---|
+| `bash` | Shell execution | Classified by `src/utils/approval.ts`; emits `approval` when not auto-approved. |
+| `read` | Read files with bounds | Path permission checks enforced by permission utilities. |
+| `write` | Create/overwrite files | Guarded by permission checks and workspace policy. |
+| `edit` | In-place text edits | Guarded write path + deterministic replacement behavior. |
+| `notebookEdit` | Notebook cell/file edits | Follows write/edit permission boundaries. |
+| `glob` / `grep` | Workspace discovery/search | Read-oriented; permission bounded. |
+| `webSearch` / `webFetch` | External search/fetch | Subject to safety and fetch restrictions. |
+| `ask` | Pause for user input | Mapped to websocket `ask` event + `ask_response`. |
+| `todoWrite` | Progress/task state | Emitted as `todos` server events for clients. |
+| `spawnAgent` | Sub-agent delegation | Uses constrained sub-agent prompts and tool scope. |
+| `skill` / `memory` | Knowledge/skill reads | Resolved from layered directories; permission bounded. |
+
+### 3.2 Protocol Mapping Requirements
+
+Any tool behavior surfaced to clients must map to documented websocket message contracts:
+
+- Approval path: `approval` event + `approval_response` requestId pairing.
+- User clarification path: `ask` event + `ask_response` pairing.
+- Failures: `error` event; include machine-readable `code` when available.
+- Progress updates: `todos`, `log`, `reasoning`, `assistant_message`.
+
+### 3.3 Legacy Sections in This Document
+
+Detailed code snippets in later legacy sections are historical examples unless they match current `src/*` behavior. When in conflict, repository code and `docs/websocket-protocol.md` take precedence.
 
 ## 4. System Prompt
 
@@ -1379,547 +923,141 @@ process.on("SIGINT", async () => {
 
 ## 14. Approval Flow
 
-The `needsApproval` mechanism on the bash tool (and any other destructive tool) requires the host application to implement an approval handler. Without it, the agent loop stalls.
+Approval behavior is implemented in production via command classification + websocket approval events, not via standalone CLI prompt snippets.
 
-### 14.1 How It Works
+### 14.1 Current Behavior
 
-When the AI SDK encounters a tool call with `needsApproval: true`, the `generateText` loop pauses. The incomplete step is returned with the tool call but no result. The host must:
+- Command classification is handled in `src/utils/approval.ts`.
+- `AUTO_APPROVE_PATTERNS` allow deterministic low-risk commands.
+- `ALWAYS_WARN_PATTERNS` force explicit approval for high-risk commands.
+- Shell control operators (pipes, chaining, redirection, subshells) disable auto-approval.
+- `AgentSession.approveCommand()` emits `approval` events with `requestId`, `command`, and `dangerous`, then blocks until `approval_response`.
+- `--yolo` bypasses approval in local/explicit bypass mode only.
 
-1. Present the pending action to the user.
-2. Get approval or rejection.
-3. If approved, execute the tool and feed the result back.
-4. If rejected, feed a rejection message back and the model will adjust.
+### 14.2 Protocol Contract
 
-### 14.2 CLI Implementation
+Approval events and replies are part of the public websocket API:
 
-```typescript
-// src/utils/approval.ts
-import readline from "readline";
+```json
+// server -> client
+{
+  "type": "approval",
+  "sessionId": "...",
+  "requestId": "req-approval-001",
+  "command": "rm -rf /tmp/old-builds",
+  "dangerous": true
+}
 
-const AUTO_APPROVE_PATTERNS = [
-  /^ls\b/, /^pwd$/, /^echo\b/, /^cat\b/, /^head\b/, /^tail\b/,
-  /^git\s+(status|log|diff|branch)\b/, /^node\s+--version/,
-  /^which\b/, /^type\b/, /^man\b/,
-];
-
-const ALWAYS_WARN_PATTERNS = [
-  /\brm\s+-rf\b/, /\bgit\s+push\s+--force\b/, /\bgit\s+reset\s+--hard\b/,
-  /\bchmod\b/, /\bchown\b/, /\bsudo\b/, /\bcurl\b.*\|\s*bash/,
-  /\bdrop\s+table\b/i, /\bdelete\s+from\b/i,
-];
-
-export async function approveCommand(command: string): Promise<boolean> {
-  // Auto-approve safe read-only commands
-  if (AUTO_APPROVE_PATTERNS.some(p => p.test(command))) return true;
-
-  // Always warn on dangerous commands
-  const dangerous = ALWAYS_WARN_PATTERNS.some(p => p.test(command));
-
-  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
-  const prefix = dangerous ? "⚠️  DANGEROUS: " : "Run: ";
-
-  return new Promise((resolve) => {
-    rl.question(`${prefix}${command}\nApprove? [y/N] `, (answer) => {
-      rl.close();
-      resolve(answer.toLowerCase() === "y");
-    });
-  });
+// client -> server
+{
+  "type": "approval_response",
+  "sessionId": "...",
+  "requestId": "req-approval-001",
+  "approved": false
 }
 ```
 
-### 14.3 Wiring Into the Agent Loop
+### 14.3 Historical Assumptions
 
-```typescript
-// In agent.ts
-import { generateText } from "ai";
-import { approveCommand } from "./utils/approval";
+The older `onToolCall` examples using inline CLI `readline` approval remain historical reference only. The actual host integration point is websocket `approval`/`approval_response`.
 
-const result = await generateText({
-  model: getModel(),
-  system: systemPrompt,
-  tools,
-  maxSteps: 100,
-  messages: conversationHistory,
+### 14.4 Planned Hardening
 
-  // Handle tool approval
-  async onToolCall({ toolCall }) {
-    if (toolCall.toolName === "bash") {
-      const approved = await approveCommand(toolCall.args.command);
-      if (!approved) {
-        return { error: "User rejected this command." };
-      }
-    }
-    // Return undefined to proceed with normal execution
-    return undefined;
-  },
-});
-```
-
-### 14.4 Extending Approval
-
-The approval pattern can be extended beyond bash:
-
-- **File deletion**: Require approval for write/edit operations that reduce file size significantly.
-- **Web requests**: Require approval for webFetch to domains the user hasn't pre-approved.
-- **Messages**: If MCP tools can send messages (email, Slack, iMessage), require approval for all sends.
-- **Purchases**: Any tool that involves financial transactions.
-
-The `needsApproval` flag can be set on any tool, or the `onToolCall` handler can implement custom logic.
+- Expand machine-readable error/approval reason codes across all risky action categories.
+- Ensure every risky action path emits deterministic approval intent without silent fallback.
+- Keep policy logic centralized and test-covered.
 
 ---
 
 ## 15. Plan Mode
 
-For complex tasks, the agent should plan before implementing. Plan mode lets it explore the codebase, design an approach, and get user approval before writing code.
+Plan mode exists as an interaction pattern, but not as a protocol-level session mode enum in the current server API.
 
-### 15.1 Workflow
+### 15.1 Current State
 
-```
-User request → Agent enters plan mode → Explores codebase → Writes plan →
-User reviews → Approved? → Agent implements
-                          → Rejected? → Agent revises plan
-```
+- Planning behavior is driven by prompts/instructions and tool usage (`ask`, `todoWrite`, exploratory reads/search) during a turn.
+- No dedicated websocket message like `set_plan_mode` currently exists.
+- Client applications should treat planning as content-level behavior, not a separate transport state.
 
-### 15.2 Implementation
+### 15.2 Historical vs Current
 
-Plan mode is implemented as agent state, not a separate tool. The agent tracks whether it's planning or implementing:
+Historical pseudo-code that modeled plan mode as explicit internal state (`normal | planning`) is not the source of truth today. Current behavior is implemented through normal turns and existing tool contracts.
 
-```typescript
-// src/agent.ts
-interface AgentState {
-  mode: "normal" | "planning";
-  planFile?: string;
-}
+### 15.3 Planned Direction
 
-// The system prompt tells the agent when to enter plan mode.
-// The agent writes its plan to a file and asks for approval via the ask tool.
-```
+If explicit plan-mode controls are added later, they must:
 
-In the system prompt, plan mode guidance tells the agent:
-
-**When to plan** (enter plan mode):
-- New feature implementation (multiple valid approaches)
-- Multi-file changes (3+ files)
-- Architectural decisions
-- Unclear requirements (need to explore first)
-
-**When NOT to plan** (just do it):
-- Single-line fixes, typos
-- Adding a single function with clear requirements
-- Pure research tasks
-
-**How to plan**:
-1. Use read/glob/grep to explore the relevant code.
-2. Write a plan file (markdown) in the working directory.
-3. Use the ask tool to present the plan and get approval.
-4. On approval, implement. On rejection, revise.
+1. Be additive to `ClientMessage` / `ServerEvent`.
+2. Be documented in `docs/websocket-protocol.md`.
+3. Include validation coverage in `test/protocol.test.ts` and integration coverage in `test/server.test.ts`.
 
 ---
 
 ## 16. Directory Conventions & Resolution
 
-The agent uses a three-tier directory system similar to git or npm. Settings, skills, memory, and MCP configs resolve in a layered hierarchy: **project → user → built-in**, where project-level always wins.
+### 16.1 Active Directory Layers
 
-### 16.1 The Three Tiers
+Configuration and resources resolve across three tiers:
 
-```
-┌─────────────────────────────────────────────────────────────┐
-│  Tier 1 — Project-level  (.agent/ in working directory)     │
-│  Highest priority. Per-project overrides.                   │
-│                                                             │
-│  .agent/                                                    │
-│  ├── config.json         # Project model, provider, MCP     │
-│  ├── AGENT.md            # Project-specific hot cache        │
-│  ├── skills/             # Project-specific skills           │
-│  │   └── my-api/SKILL.md                                    │
-│  ├── memory/             # Project-specific memory           │
-│  │   ├── glossary.md                                        │
-│  │   └── people/                                            │
-│  └── mcp-servers.json    # Project MCP servers               │
-├─────────────────────────────────────────────────────────────┤
-│  Tier 2 — User-level  (~/.agent/)                           │
-│  User's global defaults. Shared across all projects.        │
-│                                                             │
-│  ~/.agent/                                                  │
-│  ├── config.json         # Default model, provider, API keys│
-│  ├── AGENT.md            # Global hot cache (contacts, prefs)│
-│  ├── skills/             # User's custom skills              │
-│  │   └── my-style/SKILL.md                                  │
-│  ├── memory/             # Global memory                     │
-│  │   ├── glossary.md                                        │
-│  │   └── people/                                            │
-│  └── mcp-servers.json    # Global MCP servers (Slack, etc.)  │
-├─────────────────────────────────────────────────────────────┤
-│  Tier 3 — Built-in  (shipped with agent)                    │
-│  Lowest priority. Defaults and bundled skills.              │
-│                                                             │
-│  <agent-install>/                                           │
-│  ├── skills/             # Bundled skills (xlsx, pptx, etc.)│
-│  ├── prompts/system.md   # System prompt                     │
-│  └── config/defaults.json                                    │
-└─────────────────────────────────────────────────────────────┘
-```
+1. Project: `<cwd>/.agent/*`
+2. User: `~/.agent/*`
+3. Built-in: repository defaults (for example `config/defaults.json`)
 
-### 16.2 Resolution Rules
+### 16.2 Operational State Directories
 
-| Resource | Resolution Order | Merge Behavior |
-|----------|-----------------|----------------|
-| **config.json** | project → user → built-in | Deep merge. Project overrides user overrides defaults. |
-| **AGENT.md** | project → user | Project-level wins entirely. If no project AGENT.md, use user's. |
-| **skills/** | All three tiers scanned | Union. All discovered skills are available. Project skills override same-named user/built-in skills. |
-| **memory/** | project → user | Project memory searched first. User memory is fallback. |
-| **mcp-servers.json** | project → user | Merge. Project servers added alongside user's global servers. Same-named servers: project wins. |
+Runtime state and connection/auth artifacts use `~/.cowork/*` (via `getAiCoworkerPaths()`), including:
 
-### 16.3 Config Loading
+- `~/.cowork/auth/connections.json`
+- `~/.cowork/sessions/*`
+- `~/.cowork/logs/*`
 
-```typescript
-// src/config.ts (updated with layered resolution)
-import fs from "fs/promises";
-import path from "path";
-import os from "os";
-import { anthropic } from "@ai-sdk/anthropic";
-import { openai } from "@ai-sdk/openai";
-import { google } from "@ai-sdk/google";
+Backward-compatible reads from legacy `~/.ai-coworker/*` locations are supported where implemented.
 
-const providers: Record<string, (id: string) => any> = {
-  anthropic: (id) => anthropic(id),
-  openai: (id) => openai(id),
-  google: (id) => google(id),
-};
+### 16.3 Resolution Rules (Current)
 
-// --- Directory paths ---
-const projectAgentDir = path.join(process.cwd(), ".agent");
-const userAgentDir = path.join(os.homedir(), ".agent");
-const builtInDir = path.resolve(__dirname, "..");
+- Config merge precedence: built-in < user < project < environment variables.
+- Skills are discovered from layered directories and surfaced with source metadata.
+- Memory/config resources use ordered resolution arrays from `loadConfig()`.
+- Output/uploads default to project-relative paths unless overridden.
 
-interface AgentConfig {
-  provider: string;
-  model: string;
-  subAgentModel: string;
-  workingDirectory: string;
-  outputDirectory: string;
-  uploadsDirectory: string;
-  userName: string;
-  knowledgeCutoff: string;
-  // Resolved directory arrays (all tiers, in priority order)
-  skillsDirs: string[];
-  memoryDirs: string[];
-  configDirs: string[];
-}
+### 16.4 Historical Notes
 
-async function loadJsonSafe(filePath: string): Promise<Record<string, any>> {
-  try { return JSON.parse(await fs.readFile(filePath, "utf-8")); }
-  catch { return {}; }
-}
-
-export async function loadConfig(): Promise<AgentConfig> {
-  // Load and merge configs: built-in < user < project < env vars
-  const builtIn = await loadJsonSafe(path.join(builtInDir, "config", "defaults.json"));
-  const user = await loadJsonSafe(path.join(userAgentDir, "config.json"));
-  const project = await loadJsonSafe(path.join(projectAgentDir, "config.json"));
-  const merged = { ...builtIn, ...user, ...project };
-
-  return {
-    provider: process.env.AGENT_PROVIDER || merged.provider || "anthropic",
-    model: process.env.AGENT_MODEL || merged.model || "claude-sonnet-4-5-20250929",
-    subAgentModel: merged.subAgentModel || "claude-haiku-4-5-20251001",
-    workingDirectory: process.env.AGENT_WORKING_DIR || process.cwd(),
-    outputDirectory: process.env.AGENT_OUTPUT_DIR || merged.outputDirectory || path.join(process.cwd(), "output"),
-    uploadsDirectory: process.env.AGENT_UPLOADS_DIR || path.join(process.cwd(), "uploads"),
-    userName: process.env.AGENT_USER_NAME || merged.userName || "",
-    knowledgeCutoff: merged.knowledgeCutoff || "End of May 2025",
-
-    // Skill dirs: project → user → built-in (all scanned, union)
-    skillsDirs: [
-      path.join(projectAgentDir, "skills"),
-      path.join(userAgentDir, "skills"),
-      path.join(builtInDir, "skills"),
-    ],
-    // Memory dirs: project → user (searched in order)
-    memoryDirs: [
-      path.join(projectAgentDir, "memory"),
-      path.join(userAgentDir, "memory"),
-    ],
-    // Config dirs for MCP, sub-agent prompts, etc.
-    configDirs: [
-      projectAgentDir,
-      userAgentDir,
-      path.join(builtInDir, "config"),
-    ],
-  };
-}
-
-export function getModel(config: AgentConfig, id?: string) {
-  const p = providers[config.provider];
-  if (!p) throw new Error(`Unknown provider: ${config.provider}`);
-  return p(id || config.model);
-}
-```
-
-### 16.4 Skill Discovery (Updated for Layered Resolution)
-
-```typescript
-// src/skills/index.ts (updated)
-import fs from "fs/promises";
-import path from "path";
-
-interface SkillEntry {
-  name: string;
-  path: string;
-  source: "project" | "user" | "built-in";
-  triggers: string[];
-  description: string;
-}
-
-export async function discoverSkills(skillsDirs: string[]): Promise<SkillEntry[]> {
-  const seen = new Set<string>();  // Track names to enforce priority
-  const entries: SkillEntry[] = [];
-  const sources: Array<"project" | "user" | "built-in"> = ["project", "user", "built-in"];
-
-  for (let i = 0; i < skillsDirs.length; i++) {
-    const dir = skillsDirs[i];
-    const source = sources[i] || "built-in";
-
-    try {
-      const items = await fs.readdir(dir, { withFileTypes: true });
-      for (const item of items) {
-        if (!item.isDirectory() || seen.has(item.name)) continue;
-
-        const skillPath = path.join(dir, item.name, "SKILL.md");
-        try {
-          const content = await fs.readFile(skillPath, "utf-8");
-          const firstLine = content.split("\n")[0].replace(/^#+\s*/, "");
-          seen.add(item.name);
-          entries.push({
-            name: item.name,
-            path: skillPath,
-            source,
-            triggers: extractTriggers(item.name, content),
-            description: firstLine,
-          });
-        } catch { /* no SKILL.md in this dir */ }
-      }
-    } catch { /* dir doesn't exist */ }
-  }
-
-  return entries;
-}
-
-function extractTriggers(name: string, content: string): string[] {
-  // Check for a TRIGGERS: line in the skill, fall back to defaults
-  const triggerMatch = content.match(/^TRIGGERS?:\s*(.+)$/im);
-  if (triggerMatch) return triggerMatch[1].split(",").map(t => t.trim());
-
-  const defaults: Record<string, string[]> = {
-    xlsx: ["spreadsheet", "excel", ".xlsx", "csv", "data table", "chart"],
-    pptx: ["presentation", "slides", "powerpoint", ".pptx", "deck", "pitch"],
-    pdf:  ["pdf", ".pdf", "form", "merge", "split"],
-    docx: ["document", "word", ".docx", "report", "letter", "memo"],
-  };
-  return defaults[name] || [name];
-}
-```
-
-### 16.5 Memory Resolution (Updated)
-
-```typescript
-// In memory tool — search across tiers
-async function findMemory(key: string, memoryDirs: string[]): Promise<string | null> {
-  for (const dir of memoryDirs) {
-    const filePath = path.join(dir, key.endsWith(".md") ? key : `${key}.md`);
-    try { return await fs.readFile(filePath, "utf-8"); }
-    catch { continue; }
-  }
-  return null;
-}
-
-// Hot cache: check project .agent/AGENT.md, then user ~/.agent/AGENT.md
-async function loadHotCache(configDirs: string[]): Promise<string> {
-  for (const dir of configDirs) {
-    try { return await fs.readFile(path.join(dir, "AGENT.md"), "utf-8"); }
-    catch { continue; }
-  }
-  return "";
-}
-```
-
-### 16.6 MCP Config Resolution
-
-```typescript
-// Load MCP servers from project → user → built-in, merging by name
-async function loadMCPConfig(configDirs: string[]): Promise<MCPServerConfig[]> {
-  const serversByName = new Map<string, MCPServerConfig>();
-
-  // Load in reverse priority so higher-priority overwrites
-  for (const dir of [...configDirs].reverse()) {
-    try {
-      const raw = await fs.readFile(path.join(dir, "mcp-servers.json"), "utf-8");
-      const { servers } = JSON.parse(raw);
-      for (const server of servers) {
-        serversByName.set(server.name, server);
-      }
-    } catch { continue; }
-  }
-
-  return Array.from(serversByName.values());
-}
-```
+Earlier examples that imply single-location config or only `.agent`-based runtime state are historical. Current implementation splits long-lived runtime state (`~/.cowork`) from layered config/skills (`.agent`).
 
 ---
 
 ## 17. TodoWrite — Detailed Behavior
 
-The todoWrite tool is the agent's progress tracker. It renders as a live widget in the host UI, giving the user real-time visibility into what the agent is doing on multi-step tasks.
+`todoWrite` remains the agent progress reporting primitive and is part of the websocket event stream consumed by thin clients.
 
 ### 17.1 Data Model
 
-Each call to todoWrite replaces the entire list (overwrite, not append). This keeps the model's representation simple — it always sends the complete current state.
+The canonical todo item shape remains:
 
 ```typescript
 interface TodoItem {
-  content: string;      // Imperative: "Run the test suite"
+  content: string;
   status: "pending" | "in_progress" | "completed";
-  activeForm: string;   // Present continuous: "Running the test suite"
+  activeForm: string;
 }
 ```
 
-The **two forms** serve different purposes:
-- `content` is shown in the list at rest (like a checklist)
-- `activeForm` is shown in a status line while the task is in_progress (e.g., "Running the test suite..." as a live indicator)
+### 17.2 Runtime Behavior
 
-### 17.2 UX Flow
+- The tool submits full-list state updates (overwrite semantics).
+- Session emits `todos` events to clients on each update.
+- Clients should render the list as the live progress view and avoid deriving hidden state.
 
-Here's how the agent uses todoWrite during a typical multi-step task:
+### 17.3 Behavioral Expectations
 
-```
-User: "Add dark mode to the app and make sure tests pass"
+1. Keep exactly one `in_progress` item during active work.
+2. Mark items `completed` immediately when done.
+3. Include verification tasks for non-trivial changes.
+4. Adjust list dynamically as new constraints or sub-tasks emerge.
 
-Agent thinks: This is multi-step. Create a todo list.
+### 17.4 Historical Assumptions
 
-→ todoWrite([
-    { content: "Analyze current theme system",      status: "in_progress", activeForm: "Analyzing current theme system" },
-    { content: "Implement dark mode toggle",         status: "pending",     activeForm: "Implementing dark mode toggle" },
-    { content: "Update components for theme support", status: "pending",     activeForm: "Updating components" },
-    { content: "Run tests and fix failures",         status: "pending",     activeForm: "Running tests" },
-    { content: "Verify implementation",              status: "pending",     activeForm: "Verifying implementation" },
-  ])
-
-Agent reads files, explores codebase...
-
-→ todoWrite([
-    { content: "Analyze current theme system",      status: "completed",   activeForm: "Analyzing current theme system" },
-    { content: "Implement dark mode toggle",         status: "in_progress", activeForm: "Implementing dark mode toggle" },
-    { content: "Update components for theme support", status: "pending",     activeForm: "Updating components" },
-    { content: "Run tests and fix failures",         status: "pending",     activeForm: "Running tests" },
-    { content: "Verify implementation",              status: "pending",     activeForm: "Verifying implementation" },
-  ])
-
-Agent writes code...
-...and so on, progressing through each item.
-```
-
-### 17.3 Behavioral Rules
-
-These rules should be embedded in both the tool description AND the system prompt:
-
-1. **Default to using it.** Any task involving tool calls should get a todo list, unless it's trivially simple (< 3 steps, purely conversational). Err on the side of creating one — users like seeing progress.
-
-2. **One in_progress at a time.** Exactly one task should be `in_progress`. Not zero (looks stalled), not two (confusing). Complete the current task before starting the next.
-
-3. **Immediate transitions.** Mark a task `completed` the moment you finish it, in the same turn. Don't batch completions at the end. The user is watching the widget update in real time.
-
-4. **Honest completion.** Only mark `completed` when the task is truly done. If tests are failing, the task is still `in_progress`. If you hit an error, add a new task describing what needs to be resolved.
-
-5. **Verification step.** For non-trivial work, include a final "Verify" task. This might mean spawning a sub-agent to review, running tests, or checking the output file.
-
-6. **Dynamic updates.** You can add, remove, or reorder tasks mid-flight. If you discover a task is unnecessary, remove it. If you discover a new subtask, add it. Always send the full updated list.
-
-7. **Task granularity.** Tasks should be meaningful chunks, not individual tool calls. "Read 5 files" is too granular. "Analyze the authentication system" is the right level.
-
-### 17.4 Host Rendering
-
-The host application subscribes to todoWrite state and renders it. A minimal implementation:
-
-```typescript
-// In the host/CLI
-import { currentTodos } from "./tools/todoWrite";
-
-function renderTodos() {
-  if (currentTodos.length === 0) return;
-
-  console.log("\n--- Progress ---");
-  for (const todo of currentTodos) {
-    const icon = todo.status === "completed" ? "✓"
-      : todo.status === "in_progress" ? "→"
-      : "○";
-    const dim = todo.status === "completed" ? "\x1b[2m" : "";
-    const reset = "\x1b[0m";
-    console.log(`${dim}  ${icon} ${todo.content}${reset}`);
-  }
-
-  const active = currentTodos.find(t => t.status === "in_progress");
-  if (active) {
-    console.log(`\n  ${active.activeForm}...`);
-  }
-  console.log("");
-}
-
-// Call renderTodos() after each agent step via onStepFinish
-```
-
-A GUI host would render this as a sidebar checklist widget with animated transitions.
-
-### 17.5 Expanded Tool Implementation
-
-```typescript
-// src/tools/todoWrite.ts
-import { tool } from "ai";
-import { z } from "zod";
-
-const todoSchema = z.object({
-  content: z.string().min(1).describe("Imperative task description (e.g., 'Run the test suite')"),
-  status: z.enum(["pending", "in_progress", "completed"]),
-  activeForm: z.string().min(1).describe("Present continuous form shown during execution (e.g., 'Running the test suite')"),
-});
-
-// Shared state — the host reads this to render the widget
-export let currentTodos: z.infer<typeof todoSchema>[] = [];
-
-// Event emitter for host to subscribe to changes
-type TodoListener = (todos: typeof currentTodos) => void;
-const listeners: TodoListener[] = [];
-export function onTodoChange(fn: TodoListener) { listeners.push(fn); }
-
-export const todoWrite = tool({
-  description: `Update the progress tracker for multi-step tasks. Sends the COMPLETE todo list each call (overwrite, not append).
-
-Use this for virtually any task that involves tool calls. Users see this as a live checklist widget.
-
-Rules:
-- Create the list BEFORE starting work. Include all planned steps.
-- Exactly ONE task should be in_progress at a time.
-- Mark tasks completed IMMEDIATELY when done — don't batch.
-- Only mark completed when truly finished (not if errors remain).
-- Include a verification step as the final task for non-trivial work.
-- Each item needs two forms: content ("Run tests") and activeForm ("Running tests").
-- You can add, remove, or reorder tasks mid-flight as plans change.`,
-  inputSchema: z.object({
-    todos: z.array(todoSchema).describe("The complete, updated todo list"),
-  }),
-  execute: async ({ todos }) => {
-    currentTodos = todos;
-    listeners.forEach(fn => fn(todos));
-
-    const summary = todos.map(t => {
-      const icon = t.status === "completed" ? "✓" : t.status === "in_progress" ? "→" : "○";
-      return `${icon} ${t.content}`;
-    }).join("\n");
-    return `Todo list updated:\n${summary}`;
-  },
-});
-```
-
----
+Prior examples that tied todo rendering to direct host-side mutable globals are historical simplifications. In the current architecture, websocket `todos` events are the integration contract.
 
 ## 18. Updated Project Structure
 

--- a/docs/websocket-protocol.md
+++ b/docs/websocket-protocol.md
@@ -626,7 +626,8 @@ Agent wants to run a command and needs permission. **Blocks the agent** until yo
   "sessionId": "...",
   "requestId": "req-approval-001",
   "command": "rm -rf /tmp/old-builds",
-  "dangerous": true
+  "dangerous": true,
+  "reasonCode": "matches_dangerous_pattern" // optional machine-readable reason
 }
 ```
 

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -46,6 +46,9 @@ export interface RunTurnParams {
   /** Lightweight skill metadata for dynamic tool descriptions. */
   discoveredSkills?: Array<{ name: string; description: string }>;
 
+  /** Sub-agent nesting depth (0 for root session turn). */
+  spawnDepth?: number;
+
   maxSteps?: number;
   enableMcp?: boolean;
   abortSignal?: AbortSignal;
@@ -78,7 +81,15 @@ export function createRunTurn(overrides: Partial<RunTurnDeps> = {}) {
   }> {
     const { config, system, messages, log, askUser, approveCommand, updateTodos, discoveredSkills, abortSignal } = params;
 
-    const toolCtx = { config, log, askUser, approveCommand, updateTodos, availableSkills: discoveredSkills };
+    const toolCtx = {
+      config,
+      log,
+      askUser,
+      approveCommand,
+      updateTodos,
+      spawnDepth: params.spawnDepth ?? 0,
+      availableSkills: discoveredSkills,
+    };
     const builtInTools = deps.createTools(toolCtx);
 
     let mcpTools: Record<string, any> = {};

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -1,5 +1,6 @@
 import { isProviderName } from "../types";
 import type {
+  ApprovalRiskCode,
   AgentConfig,
   HarnessContextPayload,
   HarnessSloCheck,
@@ -62,6 +63,7 @@ export type ServerEvent =
       requestId: string;
       command: string;
       dangerous: boolean;
+      reasonCode?: ApprovalRiskCode;
     }
   | {
       type: "config_updated";

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -10,7 +10,7 @@ import type { AgentConfig, HarnessContextPayload, HarnessSloCheck, Observability
 import { runTurn } from "../agent";
 import { loadSystemPromptWithSkills } from "../prompt";
 import { createTools } from "../tools";
-import { classifyCommand } from "../utils/approval";
+import { classifyCommandDetailed } from "../utils/approval";
 import { HarnessContextStore } from "../harness/contextStore";
 import { emitObservabilityEvent } from "../observability/otel";
 import { runObservabilityQuery } from "../observability/query";
@@ -610,7 +610,7 @@ export class AgentSession {
   private async approveCommand(command: string) {
     if (this.yolo) return true;
 
-    const classification = classifyCommand(command);
+    const classification = classifyCommandDetailed(command);
     if (classification.kind === "auto") return true;
 
     const requestId = makeId();
@@ -623,6 +623,7 @@ export class AgentSession {
       requestId,
       command,
       dangerous: classification.dangerous,
+      reasonCode: classification.riskCode,
     });
 
     return await d.promise;
@@ -760,6 +761,7 @@ export class AgentSession {
         discoveredSkills: this.discoveredSkills,
         maxSteps: 100,
         enableMcp: this.config.enableMcp,
+        spawnDepth: 0,
         abortSignal: this.abortController.signal,
       });
 

--- a/src/tools/context.ts
+++ b/src/tools/context.ts
@@ -11,6 +11,9 @@ export interface ToolContext {
 
   updateTodos?: (todos: TodoItem[]) => void;
 
+  /** Current sub-agent nesting depth (0 = root session). */
+  spawnDepth?: number;
+
   /** Lightweight skill metadata for dynamic tool descriptions. Populated from skill discovery. */
   availableSkills?: Array<{ name: string; description: string }>;
 }

--- a/src/tools/edit.ts
+++ b/src/tools/edit.ts
@@ -5,27 +5,26 @@ import { z } from "zod";
 
 import type { ToolContext } from "./context";
 import { resolveMaybeRelative } from "../utils/paths";
-import { isWritePathAllowed } from "../utils/permissions";
+import { assertWritePathAllowed } from "../utils/permissions";
 
 export function createEditTool(ctx: ToolContext) {
   return tool({
     description:
       "Replace exact text in a file. The oldString must exist and be unique unless replaceAll is true.",
     inputSchema: z.object({
-      filePath: z.string().describe("Path to the file (prefer absolute)"),
-      oldString: z.string().describe("Exact text to replace"),
+      filePath: z.string().min(1).describe("Path to the file (prefer absolute)"),
+      oldString: z.string().min(1).describe("Exact text to replace"),
       newString: z.string().describe("Replacement text"),
       replaceAll: z.boolean().optional().default(false).describe("Replace all occurrences"),
     }),
     execute: async ({ filePath, oldString, newString, replaceAll }) => {
       ctx.log(`tool> edit ${JSON.stringify({ filePath, replaceAll })}`);
 
-      const abs = resolveMaybeRelative(filePath, ctx.config.workingDirectory);
-      if (!isWritePathAllowed(abs, ctx.config)) {
-        throw new Error(
-          `Edit blocked: path is outside workingDirectory/outputDirectory: ${abs}`
-        );
-      }
+      const abs = await assertWritePathAllowed(
+        resolveMaybeRelative(filePath, ctx.config.workingDirectory),
+        ctx.config,
+        "edit"
+      );
       let content = await fs.readFile(abs, "utf-8");
       if (!content.includes(oldString)) throw new Error(`oldString not found in ${abs}`);
 

--- a/src/tools/webFetch.ts
+++ b/src/tools/webFetch.ts
@@ -27,7 +27,7 @@ function assertReadableContentType(contentType: string | null): void {
 }
 
 async function fetchWithSafeRedirects(url: string): Promise<Response> {
-  let current = assertSafeWebUrl(url).toString();
+  let current = (await assertSafeWebUrl(url)).toString();
 
   for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
     const controller = new AbortController();
@@ -47,7 +47,7 @@ async function fetchWithSafeRedirects(url: string): Promise<Response> {
       }
 
       const next = new URL(location, current).toString();
-      current = assertSafeWebUrl(next).toString();
+      current = (await assertSafeWebUrl(next)).toString();
     } finally {
       clearTimeout(timeout);
     }
@@ -74,7 +74,7 @@ export function createWebFetchTool(ctx: ToolContext) {
       assertReadableContentType(res.headers.get("content-type"));
       const html = await res.text();
 
-      const finalUrl = assertSafeWebUrl(res.url || url).toString();
+      const finalUrl = (await assertSafeWebUrl(res.url || url)).toString();
       const dom = new JSDOM(html, { url: finalUrl });
       const article = new Readability(dom.window.document).parse();
 

--- a/src/tools/write.ts
+++ b/src/tools/write.ts
@@ -6,25 +6,24 @@ import { z } from "zod";
 
 import type { ToolContext } from "./context";
 import { resolveMaybeRelative } from "../utils/paths";
-import { isWritePathAllowed } from "../utils/permissions";
+import { assertWritePathAllowed } from "../utils/permissions";
 
 export function createWriteTool(ctx: ToolContext) {
   return tool({
     description:
       "Write content to a file. Creates parent directories if needed. Overwrites existing files.",
     inputSchema: z.object({
-      filePath: z.string().describe("Path to write (prefer absolute)"),
-      content: z.string().describe("Content to write"),
+      filePath: z.string().min(1).describe("Path to write (prefer absolute)"),
+      content: z.string().max(2_000_000).describe("Content to write"),
     }),
     execute: async ({ filePath, content }) => {
       ctx.log(`tool> write ${JSON.stringify({ filePath, chars: content.length })}`);
 
-      const abs = resolveMaybeRelative(filePath, ctx.config.workingDirectory);
-      if (!isWritePathAllowed(abs, ctx.config)) {
-        throw new Error(
-          `Write blocked: path is outside workingDirectory/outputDirectory: ${abs}`
-        );
-      }
+      const abs = await assertWritePathAllowed(
+        resolveMaybeRelative(filePath, ctx.config.workingDirectory),
+        ctx.config,
+        "write"
+      );
       await fs.mkdir(path.dirname(abs), { recursive: true });
       await fs.writeFile(abs, content, "utf-8");
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -88,6 +88,15 @@ export interface TodoItem {
   activeForm: string;
 }
 
+export const APPROVAL_RISK_CODES = [
+  "safe_auto_approved",
+  "matches_dangerous_pattern",
+  "contains_shell_control_operator",
+  "requires_manual_review",
+] as const;
+
+export type ApprovalRiskCode = (typeof APPROVAL_RISK_CODES)[number];
+
 export type ObservabilityQueryType = "logql" | "promql" | "traceql";
 
 export interface ObservabilityQueryApi {

--- a/src/utils/approval.ts
+++ b/src/utils/approval.ts
@@ -1,3 +1,5 @@
+import type { ApprovalRiskCode } from "../types";
+
 export const AUTO_APPROVE_PATTERNS: RegExp[] = [
   /^ls\b/,
   /^pwd$/,
@@ -29,6 +31,14 @@ export type CommandApprovalClassification =
   | { kind: "auto" }
   | { kind: "prompt"; dangerous: boolean };
 
+export type CommandApprovalClassificationDetailed =
+  | { kind: "auto"; dangerous: false; riskCode: "safe_auto_approved" }
+  | {
+      kind: "prompt";
+      dangerous: boolean;
+      riskCode: Exclude<ApprovalRiskCode, "safe_auto_approved">;
+    };
+
 function hasShellControlOperators(command: string): boolean {
   // Conservative: if the command contains obvious shell control operators or
   // redirections, don't auto-approve even if it starts with a "safe" command.
@@ -49,23 +59,38 @@ function hasShellControlOperators(command: string): boolean {
 }
 
 export function classifyCommand(command: string): CommandApprovalClassification {
-  const dangerous = ALWAYS_WARN_PATTERNS.some((p) => p.test(command));
-  if (dangerous) return { kind: "prompt", dangerous: true };
+  const detailed = classifyCommandDetailed(command);
+  if (detailed.kind === "auto") return { kind: "auto" };
+  return { kind: "prompt", dangerous: detailed.dangerous };
+}
 
-  if (!hasShellControlOperators(command) && AUTO_APPROVE_PATTERNS.some((p) => p.test(command))) {
-    return { kind: "auto" };
+export function classifyCommandDetailed(command: string): CommandApprovalClassificationDetailed {
+  const dangerous = ALWAYS_WARN_PATTERNS.some((p) => p.test(command));
+  if (dangerous) {
+    return { kind: "prompt", dangerous: true, riskCode: "matches_dangerous_pattern" };
   }
-  return { kind: "prompt", dangerous };
+
+  if (hasShellControlOperators(command)) {
+    return { kind: "prompt", dangerous: false, riskCode: "contains_shell_control_operator" };
+  }
+
+  if (AUTO_APPROVE_PATTERNS.some((p) => p.test(command))) {
+    return { kind: "auto", dangerous: false, riskCode: "safe_auto_approved" };
+  }
+
+  return { kind: "prompt", dangerous: false, riskCode: "requires_manual_review" };
 }
 
 export async function approveCommand(
   command: string,
   prompt: (message: string) => Promise<string>
 ): Promise<boolean> {
-  const classification = classifyCommand(command);
+  const classification = classifyCommandDetailed(command);
   if (classification.kind === "auto") return true;
 
   const prefix = classification.dangerous ? "DANGEROUS: " : "Run: ";
-  const answer = await prompt(`${prefix}${command}\nApprove? [y/N] `);
+  const answer = await prompt(
+    `${prefix}${command}\nRisk: ${classification.riskCode}\nApprove? [y/N] `
+  );
   return answer.trim().toLowerCase() === "y";
 }

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs/promises";
 import path from "node:path";
 import type { AgentConfig } from "../types";
 import { isPathInside } from "./paths";
@@ -13,4 +14,71 @@ export function isWritePathAllowed(filePath: string, config: AgentConfig): boole
   if (isPathInside(config.outputDirectory, resolved)) return true;
 
   return false;
+}
+
+async function canonicalizeExistingPrefix(targetPath: string): Promise<string> {
+  const resolved = path.resolve(targetPath);
+  const tail: string[] = [];
+  let cursor = resolved;
+
+  while (true) {
+    try {
+      const canonical = await fs.realpath(cursor);
+      return tail.length > 0 ? path.join(canonical, ...tail.reverse()) : canonical;
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException | undefined)?.code;
+      if (code !== "ENOENT") throw err;
+      const parent = path.dirname(cursor);
+      if (parent === cursor) return resolved;
+      tail.push(path.basename(cursor));
+      cursor = parent;
+    }
+  }
+}
+
+async function canonicalizeRoot(rootPath: string): Promise<string> {
+  const resolved = path.resolve(rootPath);
+  try {
+    return await fs.realpath(resolved);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException | undefined)?.code;
+    if (code !== "ENOENT") throw err;
+    return resolved;
+  }
+}
+
+export async function assertWritePathAllowed(
+  filePath: string,
+  config: AgentConfig,
+  action: "write" | "edit" | "notebookEdit"
+): Promise<string> {
+  const resolved = path.resolve(filePath);
+  if (!isWritePathAllowed(resolved, config)) {
+    throw new Error(
+      `${action} blocked: path is outside workingDirectory/outputDirectory/project root: ${resolved}`
+    );
+  }
+
+  // Guard against symlink escapes such as:
+  // <workingDirectory>/link -> /etc and target <workingDirectory>/link/passwd
+  const projectRoot = path.dirname(config.projectAgentDir);
+  const [canonicalTarget, canonicalProjectRoot, canonicalWorkingDirectory, canonicalOutputDirectory] =
+    await Promise.all([
+      canonicalizeExistingPrefix(resolved),
+      canonicalizeRoot(projectRoot),
+      canonicalizeRoot(config.workingDirectory),
+      canonicalizeRoot(config.outputDirectory),
+    ]);
+
+  if (
+    !isPathInside(canonicalProjectRoot, canonicalTarget) &&
+    !isPathInside(canonicalWorkingDirectory, canonicalTarget) &&
+    !isPathInside(canonicalOutputDirectory, canonicalTarget)
+  ) {
+    throw new Error(
+      `${action} blocked: canonical target resolves outside allowed directories: ${canonicalTarget}`
+    );
+  }
+
+  return resolved;
 }

--- a/src/utils/webSafety.ts
+++ b/src/utils/webSafety.ts
@@ -25,9 +25,11 @@ function isPrivateIpv4(host: string): boolean {
   if (a === 0) return true;
   if (a === 10) return true;
   if (a === 127) return true;
+  if (a === 100 && b >= 64 && b <= 127) return true;   // CGNAT 100.64.0.0/10
   if (a === 169 && b === 254) return true;
   if (a === 172 && b >= 16 && b <= 31) return true;
   if (a === 192 && b === 168) return true;
+  if (a === 198 && (b === 18 || b === 19)) return true; // Benchmark 198.18.0.0/15
   if (a >= 224) return true;
   return false;
 }

--- a/src/utils/webSafety.ts
+++ b/src/utils/webSafety.ts
@@ -1,0 +1,67 @@
+import { isIP } from "node:net";
+
+const BLOCKED_HOSTS = new Set([
+  "localhost",
+  "metadata.google.internal",
+  "metadata",
+  "metadata.aws.internal",
+  "host.docker.internal",
+]);
+
+function isPrivateIpv4(host: string): boolean {
+  const parts = host.split(".").map((p) => Number(p));
+  if (parts.length !== 4 || parts.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) return false;
+
+  const [a, b] = parts;
+  if (a === 0) return true;
+  if (a === 10) return true;
+  if (a === 127) return true;
+  if (a === 169 && b === 254) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && b === 168) return true;
+  if (a >= 224) return true;
+  return false;
+}
+
+function isPrivateIpv6(host: string): boolean {
+  const normalized = host.toLowerCase().split("%")[0] || host.toLowerCase();
+  if (normalized === "::" || normalized === "::1") return true;
+  if (normalized.startsWith("fc") || normalized.startsWith("fd")) return true;
+  if (
+    normalized.startsWith("fe8") ||
+    normalized.startsWith("fe9") ||
+    normalized.startsWith("fea") ||
+    normalized.startsWith("feb")
+  ) {
+    return true;
+  }
+  if (normalized.startsWith("ff")) return true;
+  return false;
+}
+
+function isBlockedHost(hostname: string): boolean {
+  const host = hostname.toLowerCase();
+  if (BLOCKED_HOSTS.has(host)) return true;
+  if (host.endsWith(".localhost")) return true;
+  if (host.endsWith(".local")) return true;
+  if (host.endsWith(".internal")) return true;
+
+  const ipKind = isIP(host);
+  if (ipKind === 4) return isPrivateIpv4(host);
+  if (ipKind === 6) return isPrivateIpv6(host);
+  return false;
+}
+
+export function assertSafeWebUrl(urlRaw: string): URL {
+  const parsed = new URL(urlRaw);
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error(`Blocked URL protocol: ${parsed.protocol}`);
+  }
+  if (parsed.username || parsed.password) {
+    throw new Error("Blocked URL credentials in authority");
+  }
+  if (isBlockedHost(parsed.hostname)) {
+    throw new Error(`Blocked private/internal host: ${parsed.hostname}`);
+  }
+  return parsed;
+}

--- a/src/utils/webSafety.ts
+++ b/src/utils/webSafety.ts
@@ -41,14 +41,16 @@ function isPrivateIpv6(host: string): boolean {
 
 function isBlockedHost(hostname: string): boolean {
   const host = hostname.toLowerCase();
+  const hostForIpCheck = host.startsWith("[") && host.endsWith("]") ? host.slice(1, -1) : host;
+
   if (BLOCKED_HOSTS.has(host)) return true;
   if (host.endsWith(".localhost")) return true;
   if (host.endsWith(".local")) return true;
   if (host.endsWith(".internal")) return true;
 
-  const ipKind = isIP(host);
-  if (ipKind === 4) return isPrivateIpv4(host);
-  if (ipKind === 6) return isPrivateIpv6(host);
+  const ipKind = isIP(hostForIpCheck);
+  if (ipKind === 4) return isPrivateIpv4(hostForIpCheck);
+  if (ipKind === 6) return isPrivateIpv6(hostForIpCheck);
   return false;
 }
 

--- a/src/utils/webSafety.ts
+++ b/src/utils/webSafety.ts
@@ -8,6 +8,14 @@ const BLOCKED_HOSTS = new Set([
   "host.docker.internal",
 ]);
 
+function normalizeHost(hostname: string): string {
+  const host = hostname.toLowerCase().replace(/\.+$/, "");
+  if (host.startsWith("[") && host.endsWith("]")) {
+    return host.slice(1, -1);
+  }
+  return host;
+}
+
 function isPrivateIpv4(host: string): boolean {
   const parts = host.split(".").map((p) => Number(p));
   if (parts.length !== 4 || parts.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) return false;
@@ -46,17 +54,15 @@ function isPrivateIpv6(host: string): boolean {
 }
 
 function isBlockedHost(hostname: string): boolean {
-  const host = hostname.toLowerCase().replace(/\.+$/, "");
-  const hostForIpCheck = host.startsWith("[") && host.endsWith("]") ? host.slice(1, -1) : host;
-
+  const host = normalizeHost(hostname);
   if (BLOCKED_HOSTS.has(host)) return true;
   if (host.endsWith(".localhost")) return true;
   if (host.endsWith(".local")) return true;
   if (host.endsWith(".internal")) return true;
 
-  const ipKind = isIP(hostForIpCheck);
-  if (ipKind === 4) return isPrivateIpv4(hostForIpCheck);
-  if (ipKind === 6) return isPrivateIpv6(hostForIpCheck);
+  const ipKind = isIP(host);
+  if (ipKind === 4) return isPrivateIpv4(host);
+  if (ipKind === 6) return isPrivateIpv6(host);
   return false;
 }
 

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -1098,6 +1098,7 @@ describe("AgentSession", () => {
       const approvalEvt = events.find((e) => e.type === "approval") as any;
       expect(approvalEvt).toBeDefined();
       expect(approvalEvt.command).toBe("npm install");
+      expect(approvalEvt.reasonCode).toBe("requires_manual_review");
 
       session.handleApprovalResponse(approvalEvt.requestId, true);
       await sendPromise;
@@ -1167,6 +1168,7 @@ describe("AgentSession", () => {
       const approvalEvt = events.find((e) => e.type === "approval") as any;
       expect(approvalEvt).toBeDefined();
       expect(approvalEvt.dangerous).toBe(true);
+      expect(approvalEvt.reasonCode).toBe("matches_dangerous_pattern");
 
       session.handleApprovalResponse(approvalEvt.requestId, true);
       await sendPromise;

--- a/test/webSafety.test.ts
+++ b/test/webSafety.test.ts
@@ -4,23 +4,38 @@ import { assertSafeWebUrl } from "../src/utils/webSafety";
 
 describe("assertSafeWebUrl", () => {
   test("blocks loopback IPv6 URLs with bracketed hostnames", () => {
-    expect(() => assertSafeWebUrl("http://[::1]/")).toThrow("Blocked private/internal host");
+    expect(() => assertSafeWebUrl("http://[::1]/")).toThrow(/private\/internal host/i);
   });
 
   test("blocks unique-local IPv6 URLs with bracketed hostnames", () => {
-    expect(() => assertSafeWebUrl("http://[fd00::1]/")).toThrow("Blocked private/internal host");
+    expect(() => assertSafeWebUrl("http://[fd00::1]/")).toThrow(/private\/internal host/i);
   });
 
   test("blocks IPv4-mapped IPv6 loopback URLs", () => {
-    expect(() => assertSafeWebUrl("http://[::ffff:127.0.0.1]/")).toThrow("Blocked private/internal host");
+    expect(() => assertSafeWebUrl("http://[::ffff:127.0.0.1]/")).toThrow(/private\/internal host/i);
+    expect(() => assertSafeWebUrl("http://[::ffff:7f00:1]/")).toThrow(/private\/internal host/i);
+  });
+
+  test("blocks IPv4-mapped IPv6 link-local metadata URLs", () => {
+    expect(() => assertSafeWebUrl("http://[::ffff:169.254.169.254]/")).toThrow(
+      /private\/internal host/i
+    );
+    expect(() => assertSafeWebUrl("http://[::ffff:a9fe:a9fe]/")).toThrow(/private\/internal host/i);
+  });
+
+  test("allows IPv4-mapped IPv6 public URLs", () => {
+    expect(assertSafeWebUrl("http://[::ffff:8.8.8.8]/").hostname).toBe("[::ffff:808:808]");
+    expect(assertSafeWebUrl("http://[::ffff:808:808]/").hostname).toBe("[::ffff:808:808]");
   });
 
   test("blocks trailing-dot localhost hostname", () => {
-    expect(() => assertSafeWebUrl("http://localhost./")).toThrow("Blocked private/internal host");
+    expect(() => assertSafeWebUrl("http://localhost./")).toThrow(/private\/internal host/i);
   });
 
   test("blocks trailing-dot internal metadata hostname", () => {
-    expect(() => assertSafeWebUrl("http://metadata.google.internal./")).toThrow("Blocked private/internal host");
+    expect(() => assertSafeWebUrl("http://metadata.google.internal./")).toThrow(
+      /private\/internal host/i
+    );
   });
 
   test("allows public HTTPS URLs", () => {

--- a/test/webSafety.test.ts
+++ b/test/webSafety.test.ts
@@ -11,6 +11,18 @@ describe("assertSafeWebUrl", () => {
     expect(() => assertSafeWebUrl("http://[fd00::1]/")).toThrow("Blocked private/internal host");
   });
 
+  test("blocks IPv4-mapped IPv6 loopback URLs", () => {
+    expect(() => assertSafeWebUrl("http://[::ffff:127.0.0.1]/")).toThrow("Blocked private/internal host");
+  });
+
+  test("blocks trailing-dot localhost hostname", () => {
+    expect(() => assertSafeWebUrl("http://localhost./")).toThrow("Blocked private/internal host");
+  });
+
+  test("blocks trailing-dot internal metadata hostname", () => {
+    expect(() => assertSafeWebUrl("http://metadata.google.internal./")).toThrow("Blocked private/internal host");
+  });
+
   test("allows public HTTPS URLs", () => {
     expect(assertSafeWebUrl("https://example.com/").hostname).toBe("example.com");
   });

--- a/test/webSafety.test.ts
+++ b/test/webSafety.test.ts
@@ -46,6 +46,20 @@ describe("assertSafeWebUrl", () => {
     );
   });
 
+  test("blocks CGNAT range (100.64.x.x)", async () => {
+    await expect(assertSafeWebUrl("http://100.64.0.1/")).rejects.toThrow(/private\/internal host/i);
+    await expect(assertSafeWebUrl("http://100.127.255.254/")).rejects.toThrow(
+      /private\/internal host/i
+    );
+  });
+
+  test("blocks benchmark range (198.18.x.x)", async () => {
+    await expect(assertSafeWebUrl("http://198.18.0.1/")).rejects.toThrow(/private\/internal host/i);
+    await expect(assertSafeWebUrl("http://198.19.255.254/")).rejects.toThrow(
+      /private\/internal host/i
+    );
+  });
+
   test("allows public HTTPS URLs", async () => {
     __internal.setDnsLookup(async () => [{ address: "93.184.216.34", family: 4 }]);
     expect((await assertSafeWebUrl("https://example.com/")).hostname).toBe("example.com");

--- a/test/webSafety.test.ts
+++ b/test/webSafety.test.ts
@@ -1,44 +1,68 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 
-import { assertSafeWebUrl } from "../src/utils/webSafety";
+import { __internal, assertSafeWebUrl } from "../src/utils/webSafety";
+
+afterEach(() => {
+  __internal.resetDnsLookup();
+});
 
 describe("assertSafeWebUrl", () => {
-  test("blocks loopback IPv6 URLs with bracketed hostnames", () => {
-    expect(() => assertSafeWebUrl("http://[::1]/")).toThrow(/private\/internal host/i);
+  test("blocks loopback IPv6 URLs with bracketed hostnames", async () => {
+    await expect(assertSafeWebUrl("http://[::1]/")).rejects.toThrow(/private\/internal host/i);
   });
 
-  test("blocks unique-local IPv6 URLs with bracketed hostnames", () => {
-    expect(() => assertSafeWebUrl("http://[fd00::1]/")).toThrow(/private\/internal host/i);
+  test("blocks unique-local IPv6 URLs with bracketed hostnames", async () => {
+    await expect(assertSafeWebUrl("http://[fd00::1]/")).rejects.toThrow(/private\/internal host/i);
   });
 
-  test("blocks IPv4-mapped IPv6 loopback URLs", () => {
-    expect(() => assertSafeWebUrl("http://[::ffff:127.0.0.1]/")).toThrow(/private\/internal host/i);
-    expect(() => assertSafeWebUrl("http://[::ffff:7f00:1]/")).toThrow(/private\/internal host/i);
+  test("blocks IPv4-mapped IPv6 loopback URLs", async () => {
+    await expect(assertSafeWebUrl("http://[::ffff:127.0.0.1]/")).rejects.toThrow(/private\/internal host/i);
+    await expect(assertSafeWebUrl("http://[::ffff:7f00:1]/")).rejects.toThrow(/private\/internal host/i);
   });
 
-  test("blocks IPv4-mapped IPv6 link-local metadata URLs", () => {
-    expect(() => assertSafeWebUrl("http://[::ffff:169.254.169.254]/")).toThrow(
+  test("blocks IPv4-mapped IPv6 link-local metadata URLs", async () => {
+    await expect(assertSafeWebUrl("http://[::ffff:169.254.169.254]/")).rejects.toThrow(
       /private\/internal host/i
     );
-    expect(() => assertSafeWebUrl("http://[::ffff:a9fe:a9fe]/")).toThrow(/private\/internal host/i);
-  });
-
-  test("allows IPv4-mapped IPv6 public URLs", () => {
-    expect(assertSafeWebUrl("http://[::ffff:8.8.8.8]/").hostname).toBe("[::ffff:808:808]");
-    expect(assertSafeWebUrl("http://[::ffff:808:808]/").hostname).toBe("[::ffff:808:808]");
-  });
-
-  test("blocks trailing-dot localhost hostname", () => {
-    expect(() => assertSafeWebUrl("http://localhost./")).toThrow(/private\/internal host/i);
-  });
-
-  test("blocks trailing-dot internal metadata hostname", () => {
-    expect(() => assertSafeWebUrl("http://metadata.google.internal./")).toThrow(
+    await expect(assertSafeWebUrl("http://[::ffff:a9fe:a9fe]/")).rejects.toThrow(
       /private\/internal host/i
     );
   });
 
-  test("allows public HTTPS URLs", () => {
-    expect(assertSafeWebUrl("https://example.com/").hostname).toBe("example.com");
+  test("allows IPv4-mapped IPv6 public URLs", async () => {
+    expect((await assertSafeWebUrl("http://[::ffff:8.8.8.8]/")).hostname).toBe("[::ffff:808:808]");
+    expect((await assertSafeWebUrl("http://[::ffff:808:808]/")).hostname).toBe(
+      "[::ffff:808:808]"
+    );
+  });
+
+  test("blocks trailing-dot localhost hostname", async () => {
+    await expect(assertSafeWebUrl("http://localhost./")).rejects.toThrow(/private\/internal host/i);
+  });
+
+  test("blocks trailing-dot internal metadata hostname", async () => {
+    await expect(assertSafeWebUrl("http://metadata.google.internal./")).rejects.toThrow(
+      /private\/internal host/i
+    );
+  });
+
+  test("allows public HTTPS URLs", async () => {
+    __internal.setDnsLookup(async () => [{ address: "93.184.216.34", family: 4 }]);
+    expect((await assertSafeWebUrl("https://example.com/")).hostname).toBe("example.com");
+  });
+
+  test("blocks hostnames that resolve to private addresses", async () => {
+    __internal.setDnsLookup(async () => [{ address: "127.0.0.1", family: 4 }]);
+    await expect(assertSafeWebUrl("https://anything.example/")).rejects.toThrow(
+      /private\/internal host/i
+    );
+  });
+
+  test("allows hostnames that resolve only to public addresses", async () => {
+    __internal.setDnsLookup(async () => [
+      { address: "93.184.216.34", family: 4 },
+      { address: "2606:2800:220:1:248:1893:25c8:1946", family: 6 },
+    ]);
+    expect((await assertSafeWebUrl("https://public.example/")).hostname).toBe("public.example");
   });
 });

--- a/test/webSafety.test.ts
+++ b/test/webSafety.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 
-import { __internal, assertSafeWebUrl } from "../src/utils/webSafety";
+import { __internal, assertSafeWebUrl, resolveSafeWebUrl } from "../src/utils/webSafety";
 
 afterEach(() => {
   __internal.resetDnsLookup();
@@ -64,5 +64,19 @@ describe("assertSafeWebUrl", () => {
       { address: "2606:2800:220:1:248:1893:25c8:1946", family: 6 },
     ]);
     expect((await assertSafeWebUrl("https://public.example/")).hostname).toBe("public.example");
+  });
+
+
+  test("returns resolved public addresses for pinned fetch use", async () => {
+    __internal.setDnsLookup(async () => [
+      { address: "93.184.216.34", family: 4 },
+      { address: "2606:2800:220:1:248:1893:25c8:1946", family: 6 },
+    ]);
+    const resolved = await resolveSafeWebUrl("https://public.example/");
+    expect(resolved.url.hostname).toBe("public.example");
+    expect(resolved.addresses).toEqual([
+      { address: "93.184.216.34", family: 4 },
+      { address: "2606:2800:220:1:248:1893:25c8:1946", family: 6 },
+    ]);
   });
 });

--- a/test/webSafety.test.ts
+++ b/test/webSafety.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test";
+
+import { assertSafeWebUrl } from "../src/utils/webSafety";
+
+describe("assertSafeWebUrl", () => {
+  test("blocks loopback IPv6 URLs with bracketed hostnames", () => {
+    expect(() => assertSafeWebUrl("http://[::1]/")).toThrow("Blocked private/internal host");
+  });
+
+  test("blocks unique-local IPv6 URLs with bracketed hostnames", () => {
+    expect(() => assertSafeWebUrl("http://[fd00::1]/")).toThrow("Blocked private/internal host");
+  });
+
+  test("allows public HTTPS URLs", () => {
+    expect(assertSafeWebUrl("https://example.com/").hostname).toBe("example.com");
+  });
+});


### PR DESCRIPTION
## Summary
- synchronize `Cowork_Agent_PRD.md` with the current websocket-first Bun + TypeScript architecture and add implementation-status tracking
- align websocket protocol documentation with runtime message/event contracts and refresh protocol examples
- harden protocol/session/tool safety behavior with additive compatibility changes:
  - typed approval risk reason codes
  - additive `server_hello.protocolVersion`
  - additive structured error fields (`code`, `source`)
  - stronger write/edit/notebook path enforcement (including canonical symlink escape protection)
  - safer web tool URL/content handling and redirect controls
  - sub-agent recursion/task limits and spawn-depth propagation
  - MCP lifecycle resilience (required server failure cleanup, retry clamping, idempotent close)

## Testing
- `bun test`

## Notes
- requested base branch `codex/transition-to-electrion` does not exist in this repo; this PR targets `codex/transition-to-electron`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the public WebSocket protocol and multiple safety-critical tool paths (filesystem writes, web fetching, command approval), so regressions could impact client compatibility or sandboxing behavior despite mostly additive fields.
> 
> **Overview**
> Updates the PRD and `docs/websocket-protocol.md` to match the implemented Bun/WebSocket architecture, explicitly documenting current capabilities (providers, MCP lifecycle, observability/harness, and session backup) and treating the protocol docs as the canonical contract.
> 
> Hardens the runtime protocol surface by adding `server_hello.protocolVersion`, structured `error.code`/`error.source`, and `approval.reasonCode` (typed `ApprovalRiskCode`), plus stricter `safeParseClientMessage()` validation and exported `CLIENT_MESSAGE_TYPES`/`SERVER_EVENT_TYPES` with doc-parity tests.
> 
> Strengthens safety boundaries in tools and session orchestration: symlink-escape-resistant `assertWritePathAllowed()` for `write`/`edit`/`notebookEdit`, SSRF-resistant `webFetch` with DNS-based private-host blocking, pinned-IP fetching + redirect limits + content-type checks, sanitized `webSearch` queries, bounded `spawnAgent` recursion/task size with propagated `spawnDepth`, and more resilient MCP shutdown/retry handling (idempotent close, retry clamping, cleanup on required-server failure).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 40120002de5a5da27e6bd6106193a71dc538c186. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->