### PR TITLE
🧪 Testing Improvement: Handle empty oldString

### DIFF
--- a/src/tools/edit.ts
+++ b/src/tools/edit.ts
@@ -19,6 +19,7 @@ export function createEditTool(ctx: ToolContext) {
     }),
     execute: async ({ filePath, oldString, newString, replaceAll }) => {
       ctx.log(`tool> edit ${JSON.stringify({ filePath, replaceAll })}`);
+      if (oldString === "") throw new Error("oldString cannot be empty");
 
       const abs = resolveMaybeRelative(filePath, ctx.config.workingDirectory);
       if (!isWritePathAllowed(abs, ctx.config)) {

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -325,6 +325,17 @@ describe("edit tool", () => {
     expect(content).toBe("hello");
   });
 
+  test("throws when oldString is empty", async () => {
+    const dir = await tmpDir();
+    const p = path.join(dir, "file.txt");
+    await fs.writeFile(p, "content", "utf-8");
+
+    const t: any = createEditTool(makeCtx(dir));
+    await expect(
+      t.execute({ filePath: p, oldString: "", newString: "new", replaceAll: false })
+    ).rejects.toThrow("oldString cannot be empty");
+  });
+
   test("case-sensitive matching", async () => {
     const dir = await tmpDir();
     const p = path.join(dir, "file.txt");


### PR DESCRIPTION
Fixes weird behavior in edit tool when oldString is empty by explicitly throwing an error. Adds a regression test.

---
*PR created automatically by Jules for task [18444855393722263920](https://jules.google.com/task/18444855393722263920) started by @mweinbach*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small input-validation change plus a unit test; low blast radius and no security-sensitive logic changes.
> 
> **Overview**
> Prevents `edit` from performing a replacement when `oldString` is empty by explicitly throwing `oldString cannot be empty` before any file reads/writes.
> 
> Adds a regression test asserting the tool rejects empty `oldString` inputs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc1614bb2907cd82e3e806eef6fca47e252d8afe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->