### PR TITLE
Refactor desktop UI into modular layout components and enable Tailwind v4

### DIFF
--- a/apps/desktop/bun.lock
+++ b/apps/desktop/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "desktop",
@@ -14,6 +13,7 @@
       },
       "devDependencies": {
         "@react-grab/mcp": "^0.1.13",
+        "@tailwindcss/vite": "^4.1.18",
         "@types/node": "^24.3.0",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
@@ -22,6 +22,7 @@
         "electron-builder": "^24.13.3",
         "electron-vite": "^5.0.0",
         "react-grab": "^0.1.13",
+        "tailwindcss": "^4.1.18",
         "typescript": "~5.8.3",
         "vite": "^7.0.4",
       },
@@ -213,6 +214,36 @@
     "@sindresorhus/is": ["@sindresorhus/is@4.6.0", "", {}, "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw=="],
 
     "@szmarczak/http-timer": ["@szmarczak/http-timer@4.0.6", "", { "dependencies": { "defer-to-connect": "^2.0.0" } }, "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w=="],
+
+    "@tailwindcss/node": ["@tailwindcss/node@4.1.18", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "enhanced-resolve": "^5.18.3", "jiti": "^2.6.1", "lightningcss": "1.30.2", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.1.18" } }, "sha512-DoR7U1P7iYhw16qJ49fgXUlry1t4CpXeErJHnQ44JgTSKMaZUdf17cfn5mHchfJ4KRBZRFA/Coo+MUF5+gOaCQ=="],
+
+    "@tailwindcss/oxide": ["@tailwindcss/oxide@4.1.18", "", { "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.1.18", "@tailwindcss/oxide-darwin-arm64": "4.1.18", "@tailwindcss/oxide-darwin-x64": "4.1.18", "@tailwindcss/oxide-freebsd-x64": "4.1.18", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.1.18", "@tailwindcss/oxide-linux-arm64-gnu": "4.1.18", "@tailwindcss/oxide-linux-arm64-musl": "4.1.18", "@tailwindcss/oxide-linux-x64-gnu": "4.1.18", "@tailwindcss/oxide-linux-x64-musl": "4.1.18", "@tailwindcss/oxide-wasm32-wasi": "4.1.18", "@tailwindcss/oxide-win32-arm64-msvc": "4.1.18", "@tailwindcss/oxide-win32-x64-msvc": "4.1.18" } }, "sha512-EgCR5tTS5bUSKQgzeMClT6iCY3ToqE1y+ZB0AKldj809QXk1Y+3jB0upOYZrn9aGIzPtUsP7sX4QQ4XtjBB95A=="],
+
+    "@tailwindcss/oxide-android-arm64": ["@tailwindcss/oxide-android-arm64@4.1.18", "", { "os": "android", "cpu": "arm64" }, "sha512-dJHz7+Ugr9U/diKJA0W6N/6/cjI+ZTAoxPf9Iz9BFRF2GzEX8IvXxFIi/dZBloVJX/MZGvRuFA9rqwdiIEZQ0Q=="],
+
+    "@tailwindcss/oxide-darwin-arm64": ["@tailwindcss/oxide-darwin-arm64@4.1.18", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Gc2q4Qhs660bhjyBSKgq6BYvwDz4G+BuyJ5H1xfhmDR3D8HnHCmT/BSkvSL0vQLy/nkMLY20PQ2OoYMO15Jd0A=="],
+
+    "@tailwindcss/oxide-darwin-x64": ["@tailwindcss/oxide-darwin-x64@4.1.18", "", { "os": "darwin", "cpu": "x64" }, "sha512-FL5oxr2xQsFrc3X9o1fjHKBYBMD1QZNyc1Xzw/h5Qu4XnEBi3dZn96HcHm41c/euGV+GRiXFfh2hUCyKi/e+yw=="],
+
+    "@tailwindcss/oxide-freebsd-x64": ["@tailwindcss/oxide-freebsd-x64@4.1.18", "", { "os": "freebsd", "cpu": "x64" }, "sha512-Fj+RHgu5bDodmV1dM9yAxlfJwkkWvLiRjbhuO2LEtwtlYlBgiAT4x/j5wQr1tC3SANAgD+0YcmWVrj8R9trVMA=="],
+
+    "@tailwindcss/oxide-linux-arm-gnueabihf": ["@tailwindcss/oxide-linux-arm-gnueabihf@4.1.18", "", { "os": "linux", "cpu": "arm" }, "sha512-Fp+Wzk/Ws4dZn+LV2Nqx3IilnhH51YZoRaYHQsVq3RQvEl+71VGKFpkfHrLM/Li+kt5c0DJe/bHXK1eHgDmdiA=="],
+
+    "@tailwindcss/oxide-linux-arm64-gnu": ["@tailwindcss/oxide-linux-arm64-gnu@4.1.18", "", { "os": "linux", "cpu": "arm64" }, "sha512-S0n3jboLysNbh55Vrt7pk9wgpyTTPD0fdQeh7wQfMqLPM/Hrxi+dVsLsPrycQjGKEQk85Kgbx+6+QnYNiHalnw=="],
+
+    "@tailwindcss/oxide-linux-arm64-musl": ["@tailwindcss/oxide-linux-arm64-musl@4.1.18", "", { "os": "linux", "cpu": "arm64" }, "sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg=="],
+
+    "@tailwindcss/oxide-linux-x64-gnu": ["@tailwindcss/oxide-linux-x64-gnu@4.1.18", "", { "os": "linux", "cpu": "x64" }, "sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g=="],
+
+    "@tailwindcss/oxide-linux-x64-musl": ["@tailwindcss/oxide-linux-x64-musl@4.1.18", "", { "os": "linux", "cpu": "x64" }, "sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ=="],
+
+    "@tailwindcss/oxide-wasm32-wasi": ["@tailwindcss/oxide-wasm32-wasi@4.1.18", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@emnapi/wasi-threads": "^1.1.0", "@napi-rs/wasm-runtime": "^1.1.0", "@tybys/wasm-util": "^0.10.1", "tslib": "^2.4.0" }, "cpu": "none" }, "sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA=="],
+
+    "@tailwindcss/oxide-win32-arm64-msvc": ["@tailwindcss/oxide-win32-arm64-msvc@4.1.18", "", { "os": "win32", "cpu": "arm64" }, "sha512-HjSA7mr9HmC8fu6bdsZvZ+dhjyGCLdotjVOgLA2vEqxEBZaQo9YTX4kwgEvPCpRh8o4uWc4J/wEoFzhEmjvPbA=="],
+
+    "@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.1.18", "", { "os": "win32", "cpu": "x64" }, "sha512-bJWbyYpUlqamC8dpR7pfjA0I7vdF6t5VpUGMWRkXVE3AXgIZjYUYAK7II1GNaxR8J1SSrSrppRar8G++JekE3Q=="],
+
+    "@tailwindcss/vite": ["@tailwindcss/vite@4.1.18", "", { "dependencies": { "@tailwindcss/node": "4.1.18", "@tailwindcss/oxide": "4.1.18", "tailwindcss": "4.1.18" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7" } }, "sha512-jVA+/UpKL1vRLg6Hkao5jldawNmRo7mQYrZtNHMIVpLfLhDml5nMRUo/8MwoX2vNXvnaXNNMedrMfMugAVX1nA=="],
 
     "@tootallnate/once": ["@tootallnate/once@2.0.0", "", {}, "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A=="],
 
@@ -442,6 +473,8 @@
 
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
     "detect-node": ["detect-node@2.1.0", "", {}, "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="],
 
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
@@ -481,6 +514,8 @@
     "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
     "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
+
+    "enhanced-resolve": ["enhanced-resolve@5.19.0", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.0" } }, "sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg=="],
 
     "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
 
@@ -662,6 +697,8 @@
 
     "jake": ["jake@10.9.4", "", { "dependencies": { "async": "^3.2.6", "filelist": "^1.0.4", "picocolors": "^1.1.1" }, "bin": { "jake": "bin/cli.js" } }, "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA=="],
 
+    "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
+
     "jose": ["jose@6.1.3", "", {}, "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
@@ -687,6 +724,30 @@
     "lazy-val": ["lazy-val@1.0.5", "", {}, "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q=="],
 
     "lazystream": ["lazystream@1.0.1", "", { "dependencies": { "readable-stream": "^2.0.5" } }, "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw=="],
+
+    "lightningcss": ["lightningcss@1.30.2", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.30.2", "lightningcss-darwin-arm64": "1.30.2", "lightningcss-darwin-x64": "1.30.2", "lightningcss-freebsd-x64": "1.30.2", "lightningcss-linux-arm-gnueabihf": "1.30.2", "lightningcss-linux-arm64-gnu": "1.30.2", "lightningcss-linux-arm64-musl": "1.30.2", "lightningcss-linux-x64-gnu": "1.30.2", "lightningcss-linux-x64-musl": "1.30.2", "lightningcss-win32-arm64-msvc": "1.30.2", "lightningcss-win32-x64-msvc": "1.30.2" } }, "sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ=="],
+
+    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.30.2", "", { "os": "android", "cpu": "arm64" }, "sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A=="],
+
+    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.30.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-ylTcDJBN3Hp21TdhRT5zBOIi73P6/W0qwvlFEk22fkdXchtNTOU4Qc37SkzV+EKYxLouZ6M4LG9NfZ1qkhhBWA=="],
+
+    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.30.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-oBZgKchomuDYxr7ilwLcyms6BCyLn0z8J0+ZZmfpjwg9fRVZIR5/GMXd7r9RH94iDhld3UmSjBM6nXWM2TfZTQ=="],
+
+    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.30.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-c2bH6xTrf4BDpK8MoGG4Bd6zAMZDAXS569UxCAGcA7IKbHNMlhGQ89eRmvpIUGfKWNVdbhSbkQaWhEoMGmGslA=="],
+
+    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.30.2", "", { "os": "linux", "cpu": "arm" }, "sha512-eVdpxh4wYcm0PofJIZVuYuLiqBIakQ9uFZmipf6LF/HRj5Bgm0eb3qL/mr1smyXIS1twwOxNWndd8z0E374hiA=="],
+
+    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.30.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-UK65WJAbwIJbiBFXpxrbTNArtfuznvxAJw4Q2ZGlU8kPeDIWEX1dg3rn2veBVUylA2Ezg89ktszWbaQnxD/e3A=="],
+
+    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.30.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA=="],
+
+    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.30.2", "", { "os": "linux", "cpu": "x64" }, "sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w=="],
+
+    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.30.2", "", { "os": "linux", "cpu": "x64" }, "sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA=="],
+
+    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.30.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ=="],
+
+    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.30.2", "", { "os": "win32", "cpu": "x64" }, "sha512-5g1yc73p+iAkid5phb4oVFMB45417DkRevRbt/El/gKXJk4jid+vPFF/AXbxn05Aky8PapwzZrdJShv5C0avjw=="],
 
     "lodash": ["lodash@4.17.23", "", {}, "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="],
 
@@ -1036,6 +1097,10 @@
 
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
+    "tailwindcss": ["tailwindcss@4.1.18", "", {}, "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw=="],
+
+    "tapable": ["tapable@2.3.0", "", {}, "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg=="],
+
     "tar": ["tar@6.2.1", "", { "dependencies": { "chownr": "^2.0.0", "fs-minipass": "^2.0.0", "minipass": "^5.0.0", "minizlib": "^2.1.1", "mkdirp": "^1.0.3", "yallist": "^4.0.0" } }, "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A=="],
 
     "tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
@@ -1153,6 +1218,18 @@
     "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
 
     "@malept/flatpak-bundler/fs-extra": ["fs-extra@9.1.0", "", { "dependencies": { "at-least-node": "^1.0.0", "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.8.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.1.0", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.1", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@tybys/wasm-util": "^0.10.1" }, "bundled": true }, "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "ajv-keywords/ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
 

--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -3,6 +3,7 @@ import { fileURLToPath } from "node:url";
 
 import { defineConfig, externalizeDepsPlugin } from "electron-vite";
 import react from "@vitejs/plugin-react";
+import tailwindcss from "@tailwindcss/vite";
 
 const appRoot = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(appRoot, "../..");
@@ -33,7 +34,7 @@ export default defineConfig({
   renderer: {
     root: appRoot,
     base: "./",
-    plugins: [react()],
+    plugins: [react(), tailwindcss()],
     resolve: {
       alias: {
         "@cowork": path.resolve(repoRoot, "src"),

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "@react-grab/mcp": "^0.1.13",
+    "@tailwindcss/vite": "^4.1.18",
     "@types/node": "^24.3.0",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
@@ -31,6 +32,7 @@
     "electron-builder": "^24.13.3",
     "electron-vite": "^5.0.0",
     "react-grab": "^0.1.13",
+    "tailwindcss": "^4.1.18",
     "typescript": "~5.8.3",
     "vite": "^7.0.4"
   }

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1,60 +1,13 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo } from "react";
 
 import { useAppStore } from "./app/store";
-import type { ProviderName } from "./lib/wsProtocol";
-import { MODEL_CHOICES, UI_DISABLED_PROVIDERS } from "./lib/modelChoices";
-import { defaultModelForProvider } from "@cowork/providers/catalog";
-
-import { Sidebar } from "./ui/Sidebar";
-import { ChatView } from "./ui/ChatView";
-import { SkillsView } from "./ui/SkillsView";
-import { SettingsShell } from "./ui/settings/SettingsShell";
 import { PromptModal } from "./ui/PromptModal";
+import { Sidebar } from "./ui/Sidebar";
 import { TitleBar } from "./ui/TitleBar";
-
-function SidebarResizer() {
-  const sidebarWidth = useAppStore((s) => s.sidebarWidth);
-  const setSidebarWidth = useAppStore((s) => s.setSidebarWidth);
-  const [dragging, setDragging] = useState(false);
-
-  const startXRef = useRef(0);
-  const startWidthRef = useRef(0);
-
-  const handleMouseDown = useCallback((e: React.MouseEvent) => {
-    e.preventDefault();
-    startXRef.current = e.clientX;
-    startWidthRef.current = sidebarWidth;
-    setDragging(true);
-  }, [sidebarWidth]);
-
-  useEffect(() => {
-    if (!dragging) return;
-
-    const handleMouseMove = (e: MouseEvent) => {
-      const delta = e.clientX - startXRef.current;
-      setSidebarWidth(startWidthRef.current + delta);
-    };
-
-    const handleMouseUp = () => {
-      setDragging(false);
-    };
-
-    window.addEventListener("mousemove", handleMouseMove);
-    window.addEventListener("mouseup", handleMouseUp);
-
-    return () => {
-      window.removeEventListener("mousemove", handleMouseMove);
-      window.removeEventListener("mouseup", handleMouseUp);
-    };
-  }, [dragging, setSidebarWidth]);
-
-  return (
-    <div
-      className={"sidebarResizer" + (dragging ? " sidebarResizerActive" : "")}
-      onMouseDown={handleMouseDown}
-    />
-  );
-}
+import { AppTopBar } from "./ui/layout/AppTopBar";
+import { PrimaryContent } from "./ui/layout/PrimaryContent";
+import { SettingsContent } from "./ui/layout/SettingsContent";
+import { SidebarResizer } from "./ui/layout/SidebarResizer";
 
 export default function App() {
   const ready = useAppStore((s) => s.ready);
@@ -62,9 +15,7 @@ export default function App() {
   const init = useAppStore((s) => s.init);
 
   const view = useAppStore((s) => s.view);
-  const workspaces = useAppStore((s) => s.workspaces);
   const threads = useAppStore((s) => s.threads);
-  const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId);
   const selectedThreadId = useAppStore((s) => s.selectedThreadId);
   const threadRuntimeById = useAppStore((s) => s.threadRuntimeById);
   const sidebarCollapsed = useAppStore((s) => s.sidebarCollapsed);
@@ -81,20 +32,20 @@ export default function App() {
   }, [init, ready]);
 
   useEffect(() => {
-    function handleKeyDown(e: KeyboardEvent) {
-      if ((e.metaKey || e.ctrlKey) && e.key === "n") {
-        e.preventDefault();
+    function handleKeyDown(event: KeyboardEvent) {
+      if ((event.metaKey || event.ctrlKey) && event.key === "n") {
+        event.preventDefault();
         void newThread();
         return;
       }
 
-      if ((e.metaKey || e.ctrlKey) && e.key === "b") {
-        e.preventDefault();
+      if ((event.metaKey || event.ctrlKey) && event.key === "b") {
+        event.preventDefault();
         toggleSidebar();
         return;
       }
 
-      if (e.key === "Escape") {
+      if (event.key === "Escape") {
         const state = useAppStore.getState();
         if (state.promptModal) {
           state.dismissPrompt();
@@ -105,33 +56,25 @@ export default function App() {
           return;
         }
         if (state.selectedThreadId) {
-          const rt = state.threadRuntimeById[state.selectedThreadId];
-          if (rt?.busy) {
+          const runtime = state.threadRuntimeById[state.selectedThreadId];
+          if (runtime?.busy) {
             state.cancelThread(state.selectedThreadId);
             return;
           }
         }
       }
     }
+
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [newThread, toggleSidebar]);
 
   const activeThread = useMemo(
-    () => threads.find((t) => t.id === selectedThreadId) ?? null,
-    [selectedThreadId, threads]
+    () => threads.find((thread) => thread.id === selectedThreadId) ?? null,
+    [selectedThreadId, threads],
   );
-  const activeWorkspaceId = activeThread?.workspaceId ?? selectedWorkspaceId;
-  const activeWorkspace = useMemo(
-    () => workspaces.find((w) => w.id === activeWorkspaceId) ?? null,
-    [activeWorkspaceId, workspaces]
-  );
-
-  const rt = activeThread ? threadRuntimeById[activeThread.id] : null;
-  const busy = rt?.busy === true;
-
-  const provider = (activeWorkspace?.defaultProvider ?? "google") as ProviderName;
-  const model = activeWorkspace?.defaultModel ?? "";
+  const runtime = activeThread ? threadRuntimeById[activeThread.id] : null;
+  const busy = runtime?.busy === true;
 
   const title = view === "skills" ? "Skills" : activeThread?.title || "New thread";
 
@@ -140,23 +83,7 @@ export default function App() {
       <div className="settingsRoot">
         <TitleBar />
         <div className="appContent">
-          {!ready ? (
-            <div className="hero">
-              <div className="heroTitle">Starting…</div>
-            </div>
-          ) : (
-            <>
-              {startupError ? (
-                <div style={{ margin: 12, padding: 10, border: "1px solid var(--border)", borderRadius: 6, background: "var(--danger-bg)" }}>
-                  <div>Running with fresh state due to an error.</div>
-                  <button className="iconButton" type="button" onClick={() => void init()} style={{ marginTop: 8 }}>
-                    Retry
-                  </button>
-                </div>
-              ) : null}
-              <SettingsShell />
-            </>
-          )}
+          <SettingsContent init={init} ready={ready} startupError={startupError} />
         </div>
         <PromptModal />
       </div>
@@ -176,46 +103,17 @@ export default function App() {
         </div>
 
         <main className="main">
-          <div className="topbar">
-            <div className="topbarLeft">
-              <button
-                className="sidebarToggle"
-                type="button"
-                onClick={toggleSidebar}
-                title={sidebarCollapsed ? "Show sidebar (⌘B)" : "Hide sidebar (⌘B)"}
-              >
-                {sidebarCollapsed ? "☰" : "☰"}
-              </button>
-              <div className="topbarTitle">{title}</div>
-            </div>
-            <div className="topbarRight">
-              {busy && <span className="pill pillBusy">busy</span>}
-              {view === "chat" && (
-                <button className="iconButton" type="button" onClick={() => void newThread()}>
-                  New
-                </button>
-              )}
-            </div>
-          </div>
+          <AppTopBar
+            busy={busy}
+            onCreateThread={() => void newThread()}
+            onToggleSidebar={toggleSidebar}
+            sidebarCollapsed={sidebarCollapsed}
+            title={title}
+            view={view}
+          />
 
           <div className="content">
-            {!ready ? (
-              <div className="hero">
-                <div className="heroTitle">Starting…</div>
-              </div>
-            ) : startupError ? (
-              <div className="hero">
-                <div className="heroTitle">Recovered</div>
-                <div className="heroSub">{startupError}</div>
-                <button className="iconButton" type="button" onClick={() => void init()}>
-                  Retry
-                </button>
-              </div>
-            ) : view === "skills" ? (
-              <SkillsView />
-            ) : (
-              <ChatView />
-            )}
+            <PrimaryContent init={init} ready={ready} startupError={startupError} view={view} />
           </div>
         </main>
       </div>

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1,3 +1,6 @@
+@import "tailwindcss/theme";
+@import "tailwindcss/utilities";
+
 :root {
   --app-bg: #e7dfd4;
   --sidebar-bg: #eee3d4;
@@ -64,6 +67,14 @@ a { color: inherit; text-decoration: none; }
   min-height: 0;
 }
 
+
+.startupErrorCard {
+  margin: 12px;
+  padding: 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--danger-bg);
+}
 .titleBar {
   height: 38px;
   display: flex;

--- a/apps/desktop/src/ui/layout/AppTopBar.tsx
+++ b/apps/desktop/src/ui/layout/AppTopBar.tsx
@@ -1,0 +1,41 @@
+interface AppTopBarProps {
+  busy: boolean;
+  onCreateThread: () => void;
+  onToggleSidebar: () => void;
+  sidebarCollapsed: boolean;
+  title: string;
+  view: "chat" | "skills";
+}
+
+export function AppTopBar({
+  busy,
+  onCreateThread,
+  onToggleSidebar,
+  sidebarCollapsed,
+  title,
+  view,
+}: AppTopBarProps) {
+  return (
+    <div className="topbar">
+      <div className="topbarLeft">
+        <button
+          className="sidebarToggle"
+          type="button"
+          onClick={onToggleSidebar}
+          title={sidebarCollapsed ? "Show sidebar (⌘B)" : "Hide sidebar (⌘B)"}
+        >
+          ☰
+        </button>
+        <div className="topbarTitle">{title}</div>
+      </div>
+      <div className="topbarRight">
+        {busy && <span className="pill pillBusy">busy</span>}
+        {view === "chat" && (
+          <button className="iconButton" type="button" onClick={onCreateThread}>
+            New
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/ui/layout/PrimaryContent.tsx
+++ b/apps/desktop/src/ui/layout/PrimaryContent.tsx
@@ -1,0 +1,33 @@
+import { ChatView } from "../ChatView";
+import { SkillsView } from "../SkillsView";
+
+interface PrimaryContentProps {
+  init: () => Promise<void>;
+  ready: boolean;
+  startupError: string | null;
+  view: "chat" | "skills";
+}
+
+export function PrimaryContent({ init, ready, startupError, view }: PrimaryContentProps) {
+  if (!ready) {
+    return (
+      <div className="hero">
+        <div className="heroTitle">Starting…</div>
+      </div>
+    );
+  }
+
+  if (startupError) {
+    return (
+      <div className="hero">
+        <div className="heroTitle">Recovered</div>
+        <div className="heroSub">{startupError}</div>
+        <button className="iconButton" type="button" onClick={() => void init()}>
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  return view === "skills" ? <SkillsView /> : <ChatView />;
+}

--- a/apps/desktop/src/ui/layout/SettingsContent.tsx
+++ b/apps/desktop/src/ui/layout/SettingsContent.tsx
@@ -1,0 +1,31 @@
+import { SettingsShell } from "../settings/SettingsShell";
+
+interface SettingsContentProps {
+  init: () => Promise<void>;
+  ready: boolean;
+  startupError: string | null;
+}
+
+export function SettingsContent({ init, ready, startupError }: SettingsContentProps) {
+  if (!ready) {
+    return (
+      <div className="hero">
+        <div className="heroTitle">Starting…</div>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {startupError ? (
+        <div className="startupErrorCard">
+          <div>Running with fresh state due to an error.</div>
+          <button className="iconButton mt-2" type="button" onClick={() => void init()}>
+            Retry
+          </button>
+        </div>
+      ) : null}
+      <SettingsShell />
+    </>
+  );
+}

--- a/apps/desktop/src/ui/layout/SidebarResizer.tsx
+++ b/apps/desktop/src/ui/layout/SidebarResizer.tsx
@@ -1,0 +1,51 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { MouseEvent as ReactMouseEvent } from "react";
+
+import { useAppStore } from "../../app/store";
+
+export function SidebarResizer() {
+  const sidebarWidth = useAppStore((s) => s.sidebarWidth);
+  const setSidebarWidth = useAppStore((s) => s.setSidebarWidth);
+  const [dragging, setDragging] = useState(false);
+
+  const startXRef = useRef(0);
+  const startWidthRef = useRef(0);
+
+  const handleMouseDown = useCallback(
+    (event: ReactMouseEvent) => {
+      event.preventDefault();
+      startXRef.current = event.clientX;
+      startWidthRef.current = sidebarWidth;
+      setDragging(true);
+    },
+    [sidebarWidth],
+  );
+
+  useEffect(() => {
+    if (!dragging) return;
+
+    const handleMouseMove = (event: MouseEvent) => {
+      const delta = event.clientX - startXRef.current;
+      setSidebarWidth(startWidthRef.current + delta);
+    };
+
+    const handleMouseUp = () => {
+      setDragging(false);
+    };
+
+    window.addEventListener("mousemove", handleMouseMove);
+    window.addEventListener("mouseup", handleMouseUp);
+
+    return () => {
+      window.removeEventListener("mousemove", handleMouseMove);
+      window.removeEventListener("mouseup", handleMouseUp);
+    };
+  }, [dragging, setSidebarWidth]);
+
+  return (
+    <div
+      className={"sidebarResizer" + (dragging ? " sidebarResizerActive" : "")}
+      onMouseDown={handleMouseDown}
+    />
+  );
+}


### PR DESCRIPTION
### Motivation
- Improve maintainability by splitting the top-level App layout into small, focused React components while preserving existing UI design and behavior.
- Prepare the renderer for modern utility-driven styling by adding Tailwind tooling so future UI changes can follow best practices without touching logic.

### Description
- Extracted layout pieces from `apps/desktop/src/App.tsx` into new components: `AppTopBar`, `PrimaryContent`, `SettingsContent`, and `SidebarResizer` under `apps/desktop/src/ui/layout/` and updated `App.tsx` to compose them.
- Moved an inline settings error card into a reusable `.startupErrorCard` CSS rule in `apps/desktop/src/styles.css` and imported Tailwind theme/utilities at the top of the stylesheet.
- Added Tailwind v4 tooling as dev deps (`tailwindcss`, `@tailwindcss/vite`) and wired the `@tailwindcss/vite` plugin into `apps/desktop/electron.vite.config.ts` to enable Tailwind processing in the renderer build.
- Kept existing behavior and state orchestration intact; only structural/component and build-tooling changes were introduced.

### Testing
- Ran the unit tests with `cd apps/desktop && bun run test`, which passed (19 tests, 0 failures).
- Verified production build and packaging with `cd apps/desktop && bun run build:dir`, which completed successfully and produced renderer/main/preload outputs.
- Captured a renderer screenshot via an automated Playwright run to verify the app renders after the refactor (artifact: `artifacts/desktop-refactor.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69925c431d548326ac35c2ecbd07c590)