### PR TITLE
Gate WebSocket upgrades with per-process auth token

### DIFF
--- a/src/server/startServer.ts
+++ b/src/server/startServer.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { randomBytes } from "node:crypto";
 import { z } from "zod";
 
 import { getAiCoworkerPaths as getAiCoworkerPathsDefault } from "../connect";
@@ -131,6 +132,7 @@ export async function startAgentServer(
     paths: getAiCoworkerPathsImpl({ homedir: opts.homedir }),
   });
   const sessionBindings = new Map<string, SessionBinding>();
+  const wsAuthToken = randomBytes(24).toString("base64url");
 
   const buildSession = (binding: SessionBinding, persistedSessionId?: string): {
     session: AgentSession;
@@ -198,6 +200,10 @@ export async function startAgentServer(
       fetch(req, srv) {
         const url = new URL(req.url);
         if (url.pathname === "/ws") {
+          const providedToken = url.searchParams.get("token")?.trim();
+          if (!providedToken || providedToken !== wsAuthToken) {
+            return new Response("Unauthorized", { status: 401 });
+          }
           const resumeSessionIdRaw = url.searchParams.get("resumeSessionId");
           const resumeSessionId = resumeSessionIdRaw && resumeSessionIdRaw.trim() ? resumeSessionIdRaw.trim() : undefined;
           const upgraded = srv.upgrade(req, { data: { resumeSessionId } });
@@ -382,6 +388,6 @@ export async function startAgentServer(
     return originalStop();
   };
 
-  const url = `ws://${hostname}:${server.port}/ws`;
+  const url = `ws://${hostname}:${server.port}/ws?token=${encodeURIComponent(wsAuthToken)}`;
   return { server, config, system, url };
 }

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,20 @@
+# Task: Remediate unauthenticated MCP server config writes over WebSocket
+
+## Plan
+- [x] Verify whether `mcp_servers_set` is still accepted in HEAD without any authorization gate and can persist workspace MCP JSON.
+- [x] Implement a minimal server-side authorization gate for MCP workspace settings writes (and keep read behavior intact).
+- [x] Add/adjust regression tests to prove unauthorized clients cannot write MCP server JSON.
+- [x] Run targeted tests and full `bun test`, then document outcomes.
+
+## Review
+- Confirmed in current HEAD that WebSocket `/ws` accepted unauthenticated upgrades and exposed MCP mutation messages, enabling local untrusted clients to reach workspace MCP write paths.
+- Added a connection-level random auth token gate in `startAgentServer()`; `/ws` upgrades now require `?token=<server-generated-token>`, and the returned server URL now includes this token automatically for first-party clients.
+- Added/updated server tests to assert unauthenticated `/ws` requests get HTTP 401 and to keep resume behavior working by appending `resumeSessionId` alongside the auth token.
+- Verification:
+  - `bun test test/server.test.ts test/protocol.test.ts` (pass)
+  - `bun test` (fails in this environment on pre-existing skill-discovery/skill-tool tests unrelated to this patch; server tests pass)
+
+---
 # Task: Run the harness in this repo with Codex gpt-5.4
 
 ## Plan

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -48,6 +48,12 @@ function serverOpts(tmpDir: string, overrides?: Partial<StartAgentServerOptions>
   };
 }
 
+function appendWebSocketQuery(url: string, key: string, value: string): string {
+  const parsed = new URL(url);
+  parsed.searchParams.set(key, value);
+  return parsed.toString();
+}
+
 /** Helper: open a WebSocket and collect the first N messages. */
 function collectMessages(url: string, count: number, timeoutMs = 5000): Promise<any[]> {
   return new Promise((resolve, reject) => {
@@ -204,7 +210,7 @@ describe("Server Startup", () => {
       expect(typeof config.provider).toBe("string");
       expect(typeof system).toBe("string");
       expect(system.length).toBeGreaterThan(0);
-      expect(url).toMatch(/^ws:\/\/127\.0\.0\.1:\d+\/ws$/);
+      expect(url).toMatch(/^ws:\/\/127\.0\.0\.1:\d+\/ws\?token=[^&]+$/);
     } finally {
       server.stop();
     }
@@ -312,15 +318,15 @@ describe("HTTP Handler", () => {
     }
   });
 
-  test("/ws path with standard HTTP GET (no upgrade) returns 400", async () => {
+  test("/ws path without auth token returns 401", async () => {
     const tmpDir = await makeTmpProject();
     const { server } = await startAgentServer(serverOpts(tmpDir));
     try {
       const httpUrl = `http://127.0.0.1:${server.port}/ws`;
       const res = await fetch(httpUrl);
-      expect(res.status).toBe(400);
+      expect(res.status).toBe(401);
       const text = await res.text();
-      expect(text).toBe("WebSocket upgrade failed");
+      expect(text).toBe("Unauthorized");
     } finally {
       server.stop();
     }
@@ -543,7 +549,7 @@ describe("WebSocket Lifecycle", () => {
       expect(typeof originalSessionId).toBe("string");
       expect(originalSessionId.length).toBeGreaterThan(0);
 
-      const resumed = await collectMessages(`${url}?resumeSessionId=${originalSessionId}`, 1);
+      const resumed = await collectMessages(appendWebSocketQuery(url, "resumeSessionId", originalSessionId), 1);
       expect(resumed[0]?.type).toBe("server_hello");
       expect(resumed[0]?.sessionId).toBe(originalSessionId);
     } finally {
@@ -561,7 +567,7 @@ describe("WebSocket Lifecycle", () => {
 
     const second = await startAgentServer(serverOpts(tmpDir));
     try {
-      const resumed = await collectMessages(`${second.url}?resumeSessionId=${originalSessionId}`, 1);
+      const resumed = await collectMessages(appendWebSocketQuery(second.url, "resumeSessionId", originalSessionId), 1);
       expect(resumed[0]?.type).toBe("server_hello");
       expect(resumed[0]?.sessionId).toBe(originalSessionId);
       expect(resumed[0]?.isResume).toBe(true);
@@ -605,7 +611,7 @@ describe("WebSocket Lifecycle", () => {
         };
       });
 
-      const resumed = await collectMessages(`${url}?resumeSessionId=${originalSessionId}`, 1);
+      const resumed = await collectMessages(appendWebSocketQuery(url, "resumeSessionId", originalSessionId), 1);
       expect(resumed[0]?.type).toBe("server_hello");
       expect(resumed[0]?.sessionId).toBe(originalSessionId);
       expect(resumed[0]?.isResume).toBe(true);


### PR DESCRIPTION
### Motivation

- Prevent unauthenticated local WebSocket clients from reaching MCP mutation handlers that can persist workspace MCP JSON and enable stdio-based command execution. 

### Description

- Add a per-process random `wsAuthToken` to `startAgentServer()` and require `?token=<value>` on `/ws` upgrade requests, returning `401 Unauthorized` when absent or invalid (`src/server/startServer.ts`).
- Return the authenticated WebSocket URL (`/ws?token=...`) from `startAgentServer()` so first-party clients can connect transparently (`src/server/startServer.ts`).
- Update server tests to assert the new URL shape, verify unauthenticated `/ws` requests return `401 Unauthorized`, and preserve resume/session behavior by appending `resumeSessionId` safely (`test/server.test.ts`).
- Document the task, review, and verification notes in `tasks/todo.md`.

### Testing

- Ran targeted tests: `bun test test/server.test.ts test/protocol.test.ts` — both passed.
- Ran full test suite: `bun test` — server/protocol coverage passed; the full run in this environment shows unrelated failures in skill-discovery/skill-tool tests that are pre-existing and not introduced by this change (targeted server tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab9ccd992c8326933607483766e086)