### PR TITLE
Cowork server binary release

### DIFF
--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -1,0 +1,144 @@
+name: Cowork Server Release
+
+on:
+  push:
+    tags:
+      - "server-v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: server-release-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Docs consistency check
+        run: bun run docs:check
+
+      - name: Unit tests
+        run: bun test
+
+      - name: Typecheck
+        run: bun run typecheck
+
+  package:
+    name: Package (${{ matrix.label }})
+    needs: validate
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest
+            label: macOS
+            artifact_name: cowork-server-release-macos
+          - os: windows-latest
+            label: Windows
+            artifact_name: cowork-server-release-windows
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build standalone cowork-server bundle
+        run: bun run build:server-binary -- --outdir release/cowork-server
+
+      - name: Read release metadata
+        id: release-metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          target_triple="$(bun -e 'const manifest = await Bun.file("release/cowork-server/cowork-server-manifest.json").json(); console.log(manifest.targetTriple)')"
+          if [ -z "$target_triple" ]; then
+            echo "Unable to determine target triple from release manifest." >&2
+            exit 1
+          fi
+
+          echo "target_triple=$target_triple" >> "$GITHUB_OUTPUT"
+          echo "archive_base=cowork-server-$target_triple" >> "$GITHUB_OUTPUT"
+
+      - name: Archive macOS bundle
+        if: ${{ runner.os == 'macOS' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd release
+          ditto -c -k --sequesterRsrc --keepParent "cowork-server" "${{ steps.release-metadata.outputs.archive_base }}.zip"
+
+      - name: Archive Windows bundle
+        if: ${{ runner.os == 'Windows' }}
+        shell: pwsh
+        run: |
+          Compress-Archive -Path "release/cowork-server" -DestinationPath "release/${{ steps.release-metadata.outputs.archive_base }}.zip" -Force
+
+      - name: Upload standalone cowork-server artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: release/${{ steps.release-metadata.outputs.archive_base }}.zip
+          if-no-files-found: error
+          retention-days: 14
+
+  publish:
+    name: Publish GitHub Release
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
+    needs: package
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download packaged artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: release-assets
+          pattern: cowork-server-release-*
+
+      - name: Collect release asset list
+        id: collect-release-assets
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s globstar nullglob
+
+          files=(release-assets/**/*.zip)
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "No standalone cowork-server release assets were downloaded." >&2
+            exit 1
+          fi
+
+          {
+            echo "files<<EOF"
+            printf '%s\n' "${files[@]}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Publish standalone cowork-server release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: cowork-server ${{ github.ref_name }}
+          files: ${{ steps.collect-release-assets.outputs.files }}
+          prerelease: true
+          generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -99,6 +99,26 @@ bun run serve -- --json
 
 TUI requires a real terminal. For headless or cloud workflows, prefer `bun run serve` and connect over WebSocket.
 
+### 4. Build the standalone websocket binary
+
+Compile just the core harness (no TUI/desktop UI) into a Bun binary bundle:
+
+```bash
+bun run build:server-binary
+./release/cowork-server-<target-triple>/cowork-server
+```
+
+The generated bundle contains:
+
+- `cowork-server` / `cowork-server.exe`
+- `dist/config`
+- `dist/prompts`
+- `dist/docs`
+
+When launched from that extracted bundle, the binary automatically finds its sibling `dist/` directory and starts the same WebSocket server used by the desktop app. Human mode logs the listening URL; `--json` prints a single machine-readable `server_listening` event for embedders.
+
+Prebuilt standalone bundles are published under `server-v*` prereleases. They stay separate from the desktop app’s main GitHub release stream, but remain available from the repository’s full releases list.
+
 ## Official clients
 
 ### TUI

--- a/apps/desktop/electron/services/sidecar.ts
+++ b/apps/desktop/electron/services/sidecar.ts
@@ -1,56 +1,39 @@
 import fs from "node:fs";
 import path from "node:path";
 
-export const SIDECAR_BASE_NAME = "cowork-server";
-export const SIDECAR_MANIFEST_NAME = "cowork-server-manifest.json";
+import {
+  buildServerBinaryManifest,
+  resolveServerBinaryFilename,
+  resolveServerTargetTriple,
+  SERVER_BINARY_BASE_NAME,
+  SERVER_BINARY_MANIFEST_NAME,
+  type ServerBinaryManifest,
+} from "../../../../src/server/binaryArtifact";
 
-export type SidecarManifest = {
-  filename: string;
-  targetTriple: string;
-  platform: NodeJS.Platform;
-  arch: string;
-};
+export const SIDECAR_BASE_NAME = SERVER_BINARY_BASE_NAME;
+export const SIDECAR_MANIFEST_NAME = SERVER_BINARY_MANIFEST_NAME;
+
+export type SidecarManifest = ServerBinaryManifest;
 
 export function resolveDesktopTargetTriple(
   platform: NodeJS.Platform = process.platform,
   arch: string = process.arch
 ): string {
-  if (platform === "win32") {
-    if (arch === "x64") return "x86_64-pc-windows-msvc";
-    if (arch === "arm64") return "aarch64-pc-windows-msvc";
-  }
-
-  if (platform === "darwin") {
-    if (arch === "x64") return "x86_64-apple-darwin";
-    if (arch === "arm64") return "aarch64-apple-darwin";
-  }
-
-  if (platform === "linux") {
-    if (arch === "x64") return "x86_64-unknown-linux-gnu";
-    if (arch === "arm64") return "aarch64-unknown-linux-gnu";
-  }
-
-  throw new Error(`Unsupported platform/arch for desktop sidecar: ${platform}/${arch}`);
+  return resolveServerTargetTriple(platform, arch);
 }
 
 export function resolvePackagedSidecarFilename(
   platform: NodeJS.Platform = process.platform,
   arch: string = process.arch
 ): string {
-  const ext = platform === "win32" ? ".exe" : "";
-  return `${SIDECAR_BASE_NAME}-${resolveDesktopTargetTriple(platform, arch)}${ext}`;
+  return resolveServerBinaryFilename({ platform, arch });
 }
 
 export function buildSidecarManifest(
   platform: NodeJS.Platform = process.platform,
   arch: string = process.arch
 ): SidecarManifest {
-  return {
-    filename: resolvePackagedSidecarFilename(platform, arch),
-    targetTriple: resolveDesktopTargetTriple(platform, arch),
-    platform,
-    arch,
-  };
+  return buildServerBinaryManifest({ platform, arch });
 }
 
 function isSidecarManifest(value: unknown): value is SidecarManifest {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "cli": "bun src/index.ts --cli",
     "dev": "bun --watch src/index.ts",
     "serve": "bun src/server/index.ts",
+    "build:server-binary": "bun scripts/build_server_binary.ts",
     "tui": "bun --preload @opentui/solid/preload src/tui/index.tsx",
     "desktop:dev": "cd apps/desktop && bun run dev",
     "desktop:build": "cd apps/desktop && bun run build",

--- a/scripts/build_desktop_resources.ts
+++ b/scripts/build_desktop_resources.ts
@@ -5,34 +5,11 @@ import {
   buildSidecarManifest,
   resolvePackagedSidecarFilename,
 } from "../apps/desktop/electron/services/sidecar";
-
-async function rmrf(p: string) {
-  await fs.rm(p, { recursive: true, force: true });
-}
-
-async function copyDir(src: string, dest: string) {
-  // Bun supports fs.cp (Node 16+). Use it when available for performance.
-  const anyFs = fs as any;
-  if (typeof anyFs.cp === "function") {
-    await anyFs.cp(src, dest, { recursive: true });
-    return;
-  }
-
-  await fs.mkdir(dest, { recursive: true });
-  const entries = await fs.readdir(src, { withFileTypes: true });
-  for (const e of entries) {
-    const from = path.join(src, e.name);
-    const to = path.join(dest, e.name);
-    if (e.isDirectory()) {
-      await copyDir(from, to);
-      continue;
-    }
-    if (e.isSymbolicLink()) continue;
-    if (e.isFile()) {
-      await fs.copyFile(from, to);
-    }
-  }
-}
+import {
+  rmrf,
+  runBunBuild,
+  stageBundledServerDist,
+} from "./lib/serverBuild";
 
 async function main() {
   const root = path.resolve(import.meta.dirname, "..");
@@ -43,31 +20,13 @@ async function main() {
   await rmrf(serverOutDir);
 
   const entry = path.join(root, "src", "server", "index.ts");
-  const proc = Bun.spawn(
-    [
-      "bun",
-      "build",
-      entry,
-      // Inline this env var into the bundle so provider modules can DCE
-      // desktop-only branches.
-      "--env",
-      "COWORK_DESKTOP_BUNDLE*",
-      "--outdir",
-      serverOutDir,
-      "--target",
-      "bun",
-      "--format",
-      "esm",
-    ],
-    {
-      cwd: root,
-      stdout: "inherit",
-      stderr: "inherit",
-      env: { ...process.env, COWORK_DESKTOP_BUNDLE: "1" },
-    }
-  );
-  const code = await proc.exited;
-  if (code !== 0) process.exit(code);
+  await runBunBuild({
+    root,
+    entry,
+    outdir: serverOutDir,
+    env: { ...process.env, COWORK_DESKTOP_BUNDLE: "1" },
+    inlineEnvPatterns: ["COWORK_DESKTOP_BUNDLE*"],
+  });
 
   // Build a standalone server sidecar so end users don't need Bun installed.
   // Electron packaging picks this up from apps/desktop/resources/binaries.
@@ -78,48 +37,26 @@ async function main() {
   const manifest = buildSidecarManifest();
   const sidecarOutfile = path.join(desktopBinariesDir, resolvePackagedSidecarFilename());
   await fs.rm(sidecarOutfile, { force: true }).catch(() => {});
-
-  const compileArgs = [
-    "bun",
-    "build",
+  await runBunBuild({
+    root,
     entry,
-    "--compile",
-    "--outfile",
-    sidecarOutfile,
-    "--env",
-    "COWORK_DESKTOP_BUNDLE*",
-    "--target",
-    "bun",
-  ];
-  if (process.platform === "win32") compileArgs.push("--windows-hide-console");
-
-  const sidecarProc = Bun.spawn(compileArgs, {
-    cwd: root,
-    stdout: "inherit",
-    stderr: "inherit",
+    compile: true,
+    outfile: sidecarOutfile,
     env: { ...process.env, COWORK_DESKTOP_BUNDLE: "1" },
+    inlineEnvPatterns: ["COWORK_DESKTOP_BUNDLE*"],
+    windowsHideConsole: process.platform === "win32",
   });
-  const sidecarCode = await sidecarProc.exited;
-  if (sidecarCode !== 0) process.exit(sidecarCode);
 
   await fs.writeFile(path.join(desktopBinariesDir, "cowork-server-manifest.json"), `${JSON.stringify(manifest, null, 2)}\n`);
 
   // The desktop sidecar still needs built-in prompts/config under dist/{prompts,config}.
   // Curated skills are bootstrapped into ~/.cowork/skills on first desktop startup instead
   // of being bundled into the app resources.
-  await rmrf(path.join(distDir, "skills"));
-  for (const dir of ["prompts", "config"] as const) {
-    const src = path.join(root, dir);
-    const dest = path.join(distDir, dir);
-    await rmrf(dest);
-    await copyDir(src, dest);
-  }
-
-  // Optional: include a copy of docs for UI builders.
-  const docsSrc = path.join(root, "docs");
-  const docsDest = path.join(distDir, "docs");
-  await rmrf(docsDest);
-  await copyDir(docsSrc, docsDest);
+  await stageBundledServerDist({
+    root,
+    distDir,
+    includeDocs: true,
+  });
 
   console.log(`[resources] built server bundle at ${path.relative(root, serverOutDir)}`);
   console.log(`[resources] built server sidecar at ${path.relative(root, sidecarOutfile)}`);

--- a/scripts/build_server_binary.ts
+++ b/scripts/build_server_binary.ts
@@ -1,0 +1,84 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import {
+  buildServerBinaryManifest,
+  resolveServerBinaryFilename,
+  resolveServerTargetTriple,
+  SERVER_BINARY_MANIFEST_NAME,
+} from "../src/server/binaryArtifact";
+import {
+  rmrf,
+  runBunBuild,
+  stageBundledServerDist,
+} from "./lib/serverBuild";
+
+function printUsage(): void {
+  console.log("Usage: bun scripts/build_server_binary.ts [--outdir <directory>]");
+}
+
+function parseArgs(argv: string[]): { outdir?: string } {
+  let outdir: string | undefined;
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--help" || arg === "-h") {
+      printUsage();
+      process.exit(0);
+    }
+    if (arg === "--outdir") {
+      const value = argv[i + 1];
+      if (!value) {
+        throw new Error("Missing value for --outdir");
+      }
+      outdir = value;
+      i += 1;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return { outdir };
+}
+
+async function main(): Promise<void> {
+  const { outdir } = parseArgs(process.argv.slice(2));
+  const root = path.resolve(import.meta.dirname, "..");
+  const targetTriple = resolveServerTargetTriple();
+  const releaseDir = path.resolve(root, outdir ?? path.join("release", `cowork-server-${targetTriple}`));
+  const binaryFilename = resolveServerBinaryFilename({ includeTargetTriple: false });
+  const binaryPath = path.join(releaseDir, binaryFilename);
+  const builtInDir = path.join(releaseDir, "dist");
+
+  await rmrf(releaseDir);
+  await fs.mkdir(releaseDir, { recursive: true });
+
+  await runBunBuild({
+    root,
+    entry: path.join(root, "src", "server", "index.ts"),
+    compile: true,
+    outfile: binaryPath,
+    env: process.env,
+  });
+
+  await stageBundledServerDist({
+    root,
+    distDir: builtInDir,
+    includeDocs: true,
+  });
+
+  const manifest = buildServerBinaryManifest({ includeTargetTriple: false });
+  await fs.writeFile(
+    path.join(releaseDir, SERVER_BINARY_MANIFEST_NAME),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+  );
+
+  console.log(`[server-binary] built ${targetTriple} bundle at ${path.relative(root, releaseDir)}`);
+  console.log(`[server-binary] binary: ${path.relative(root, binaryPath)}`);
+  console.log(`[server-binary] builtin dir: ${path.relative(root, builtInDir)}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/lib/serverBuild.ts
+++ b/scripts/lib/serverBuild.ts
@@ -1,0 +1,91 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+export async function rmrf(targetPath: string): Promise<void> {
+  await fs.rm(targetPath, { recursive: true, force: true });
+}
+
+export async function copyDir(src: string, dest: string): Promise<void> {
+  const anyFs = fs as typeof fs & {
+    cp?: (source: string, destination: string, options: { recursive: boolean }) => Promise<void>;
+  };
+  if (typeof anyFs.cp === "function") {
+    await anyFs.cp(src, dest, { recursive: true });
+    return;
+  }
+
+  await fs.mkdir(dest, { recursive: true });
+  const entries = await fs.readdir(src, { withFileTypes: true });
+  for (const entry of entries) {
+    const from = path.join(src, entry.name);
+    const to = path.join(dest, entry.name);
+    if (entry.isDirectory()) {
+      await copyDir(from, to);
+      continue;
+    }
+    if (entry.isSymbolicLink()) continue;
+    if (entry.isFile()) {
+      await fs.copyFile(from, to);
+    }
+  }
+}
+
+export async function runBunBuild(options: {
+  root: string;
+  entry: string;
+  outdir?: string;
+  outfile?: string;
+  compile?: boolean;
+  env?: Record<string, string | undefined>;
+  inlineEnvPatterns?: string[];
+  windowsHideConsole?: boolean;
+}): Promise<void> {
+  const args = ["bun", "build", options.entry];
+  if (options.compile) args.push("--compile");
+  if (options.outdir) args.push("--outdir", options.outdir);
+  if (options.outfile) args.push("--outfile", options.outfile);
+  for (const pattern of options.inlineEnvPatterns ?? []) {
+    args.push("--env", pattern);
+  }
+  args.push("--target", "bun");
+  if (!options.compile) {
+    args.push("--format", "esm");
+  }
+  if (options.windowsHideConsole) {
+    args.push("--windows-hide-console");
+  }
+
+  const proc = Bun.spawn(args, {
+    cwd: options.root,
+    stdout: "inherit",
+    stderr: "inherit",
+    env: options.env,
+  });
+  const code = await proc.exited;
+  if (code !== 0) {
+    process.exit(code);
+  }
+}
+
+export async function stageBundledServerDist(options: {
+  root: string;
+  distDir: string;
+  includeDocs?: boolean;
+}): Promise<void> {
+  await fs.mkdir(options.distDir, { recursive: true });
+  await rmrf(path.join(options.distDir, "skills"));
+
+  for (const dir of ["prompts", "config"] as const) {
+    const src = path.join(options.root, dir);
+    const dest = path.join(options.distDir, dir);
+    await rmrf(dest);
+    await copyDir(src, dest);
+  }
+
+  if (options.includeDocs) {
+    const docsSrc = path.join(options.root, "docs");
+    const docsDest = path.join(options.distDir, "docs");
+    await rmrf(docsDest);
+    await copyDir(docsSrc, docsDest);
+  }
+}

--- a/src/server/binaryArtifact.ts
+++ b/src/server/binaryArtifact.ts
@@ -1,0 +1,61 @@
+export const SERVER_BINARY_BASE_NAME = "cowork-server";
+export const SERVER_BINARY_MANIFEST_NAME = "cowork-server-manifest.json";
+
+export type ServerBinaryManifest = {
+  filename: string;
+  targetTriple: string;
+  platform: NodeJS.Platform;
+  arch: string;
+};
+
+export function resolveServerTargetTriple(
+  platform: NodeJS.Platform = process.platform,
+  arch: string = process.arch,
+): string {
+  if (platform === "win32") {
+    if (arch === "x64") return "x86_64-pc-windows-msvc";
+    if (arch === "arm64") return "aarch64-pc-windows-msvc";
+  }
+
+  if (platform === "darwin") {
+    if (arch === "x64") return "x86_64-apple-darwin";
+    if (arch === "arm64") return "aarch64-apple-darwin";
+  }
+
+  if (platform === "linux") {
+    if (arch === "x64") return "x86_64-unknown-linux-gnu";
+    if (arch === "arm64") return "aarch64-unknown-linux-gnu";
+  }
+
+  throw new Error(`Unsupported platform/arch for cowork-server binary: ${platform}/${arch}`);
+}
+
+export function resolveServerBinaryFilename(options: {
+  platform?: NodeJS.Platform;
+  arch?: string;
+  includeTargetTriple?: boolean;
+  basename?: string;
+} = {}): string {
+  const platform = options.platform ?? process.platform;
+  const arch = options.arch ?? process.arch;
+  const basename = options.basename ?? SERVER_BINARY_BASE_NAME;
+  const ext = platform === "win32" ? ".exe" : "";
+  const suffix = options.includeTargetTriple === false ? "" : `-${resolveServerTargetTriple(platform, arch)}`;
+  return `${basename}${suffix}${ext}`;
+}
+
+export function buildServerBinaryManifest(options: {
+  platform?: NodeJS.Platform;
+  arch?: string;
+  includeTargetTriple?: boolean;
+  basename?: string;
+} = {}): ServerBinaryManifest {
+  const platform = options.platform ?? process.platform;
+  const arch = options.arch ?? process.arch;
+  return {
+    filename: resolveServerBinaryFilename({ ...options, platform, arch }),
+    targetTriple: resolveServerTargetTriple(platform, arch),
+    platform,
+    arch,
+  };
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env bun
 
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 
@@ -11,7 +12,7 @@ const globalSettings = globalThis as typeof globalThis & { AI_SDK_LOG_WARNINGS?:
 globalSettings.AI_SDK_LOG_WARNINGS = false;
 
 function printUsage() {
-  console.log("Usage: bun src/server/index.ts [--dir <directory_path>] [--port <port>] [--yolo] [--json]");
+  console.log("Usage: cowork-server [--dir <directory_path>] [--port <port>] [--yolo] [--json]");
 }
 
 async function resolveAndValidateDir(dirArg: string): Promise<string> {
@@ -21,7 +22,7 @@ async function resolveAndValidateDir(dirArg: string): Promise<string> {
   return resolved;
 }
 
-function parseArgs(argv: string[]): { dir?: string; port: number; yolo: boolean; json: boolean } {
+export function parseArgs(argv: string[]): { dir?: string; port: number; yolo: boolean; json: boolean } {
   let dir: string | undefined;
   let port = 7337;
   let yolo = false;
@@ -64,17 +65,48 @@ function parseArgs(argv: string[]): { dir?: string; port: number; yolo: boolean;
   return { dir, port, yolo, json };
 }
 
+export function resolveBundledBuiltInDir(options: {
+  execPath?: string;
+  existsSync?: (candidate: string) => boolean;
+} = {}): string | undefined {
+  const execPath = options.execPath ?? process.execPath;
+  const existsSync = options.existsSync ?? fsSync.existsSync;
+  const execDir = path.dirname(path.resolve(execPath));
+  const candidates = [
+    path.join(execDir, "dist"),
+    path.join(execDir, "..", "dist"),
+  ];
+
+  for (const candidate of candidates) {
+    const hasConfig = existsSync(path.join(candidate, "config", "defaults.json"));
+    const hasPrompts = existsSync(path.join(candidate, "prompts", "system.md"));
+    if (hasConfig && hasPrompts) {
+      return candidate;
+    }
+  }
+
+  return undefined;
+}
+
 async function main() {
   const { dir, port, yolo, json } = parseArgs(process.argv.slice(2));
 
   const cwd = dir ? await resolveAndValidateDir(dir) : process.cwd();
   if (dir) process.chdir(cwd);
+  const bundledBuiltInDir =
+    typeof process.env.COWORK_BUILTIN_DIR === "string" && process.env.COWORK_BUILTIN_DIR.trim()
+      ? process.env.COWORK_BUILTIN_DIR
+      : resolveBundledBuiltInDir();
 
   const { server, config, url } = await startAgentServer({
     cwd,
     hostname: "127.0.0.1",
     port,
-    env: { ...process.env, AGENT_WORKING_DIR: cwd },
+    env: {
+      ...process.env,
+      AGENT_WORKING_DIR: cwd,
+      ...(bundledBuiltInDir ? { COWORK_BUILTIN_DIR: bundledBuiltInDir } : {}),
+    },
     providerOptions: DEFAULT_PROVIDER_OPTIONS,
     yolo,
   });
@@ -115,7 +147,7 @@ async function main() {
     return;
   }
 
-  console.log(`[server] ${url} (cwd=${config.workingDirectory})`);
+  console.log(`[cowork-server] listening on ${url} (cwd=${config.workingDirectory})`);
 }
 
 if (import.meta.main) {

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -2896,3 +2896,24 @@
 - `~/.bun/bin/bun run typecheck` -> pass
 - `~/.bun/bin/bun test` -> pass (`1998 pass, 2 skip, 0 fail`)
 - `git diff --check` -> pass
+
+# Task: Ship standalone cowork-server Bun binaries
+
+## Plan
+- [x] Inspect the existing server sidecar build, runtime resource loading, and release workflows to identify the minimum path for a standalone binary release.
+- [x] Extract or add a standalone server binary build path that compiles the websocket harness and stages the runtime resources it needs outside the desktop app.
+- [x] Update the standalone server runtime/docs/tests so an extracted release bundle can launch cleanly and the GitHub automation stays separate from desktop releases.
+- [x] Run focused verification, including a compiled-binary smoke test, then record the results below.
+
+## Review
+- Added shared server-artifact helpers in `src/server/binaryArtifact.ts` and `scripts/lib/serverBuild.ts`, then reused them from both `scripts/build_desktop_resources.ts` and the new `scripts/build_server_binary.ts`. Desktop sidecar naming stays consistent, while `bun run build:server-binary` now emits a standalone `release/cowork-server-<target-triple>/` bundle with `cowork-server`, `dist/config`, `dist/prompts`, `dist/docs`, and `cowork-server-manifest.json`.
+- Updated `src/server/index.ts` so compiled binaries auto-discover a sibling or parent `dist/` directory and continue to support the existing `--json` startup contract. In human mode the binary now logs a clearer `[cowork-server] listening on ...` line for terminal use.
+- Added `.github/workflows/server-release.yml` for `server-v*` tags. It validates the repo, builds standalone macOS/Windows bundles, uploads zipped artifacts, and publishes them as `cowork-server` prereleases so they stay separate from the desktop app’s main release stream.
+- Documented the standalone binary path in `README.md` and added focused tests in `test/server.args.test.ts` and `test/server-release.workflow.test.ts`.
+
+### Verification
+- `bun test test/server.args.test.ts test/server-release.workflow.test.ts test/desktop-release.workflow.test.ts apps/desktop/test/sidecar.test.ts test/docs.check.test.ts --bail` -> pass (`18 pass, 0 fail`)
+- `bun run typecheck` -> pass
+- `bun run build:desktop-resources` -> pass
+- `bun run build:server-binary` -> pass
+- Compiled binary smoke test -> pass; `release/cowork-server-x86_64-unknown-linux-gnu/cowork-server --dir /workspace --port 0 --json` emitted `server_listening`, and a separate websocket probe received `server_hello` from that URL.

--- a/test/server-release.workflow.test.ts
+++ b/test/server-release.workflow.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, test } from "bun:test";
+
+const workflowPath = new URL("../.github/workflows/server-release.yml", import.meta.url);
+const workflow = readFileSync(workflowPath, "utf8");
+
+describe("server release workflow", () => {
+  test("uses a dedicated server tag namespace and prerelease publish path", () => {
+    expect(workflow).toContain('      - "server-v*"');
+    expect(workflow).toContain("name: cowork-server ${{ github.ref_name }}");
+    expect(workflow).toContain("prerelease: true");
+    expect(workflow).not.toContain('      - "v*"');
+    expect(workflow).not.toContain('      - "desktop-v*"');
+  });
+
+  test("builds standalone bundles on macOS and Windows with the dedicated script", () => {
+    expect(workflow).toMatch(
+      /matrix:[\s\S]*?macos-latest[\s\S]*?cowork-server-release-macos[\s\S]*?windows-latest[\s\S]*?cowork-server-release-windows/,
+    );
+    expect(workflow).toContain("bun run build:server-binary -- --outdir release/cowork-server");
+    expect(workflow).toMatch(
+      /Read release metadata[\s\S]*?cowork-server-manifest\.json[\s\S]*?archive_base=cowork-server-\$target_triple/,
+    );
+    expect(workflow).toMatch(
+      /Archive macOS bundle[\s\S]*?ditto -c -k --sequesterRsrc --keepParent "cowork-server" "\$\{\{ steps\.release-metadata\.outputs\.archive_base \}\}\.zip"/,
+    );
+    expect(workflow).toMatch(
+      /Archive Windows bundle[\s\S]*?Compress-Archive -Path "release\/cowork-server" -DestinationPath "release\/\$\{\{ steps\.release-metadata\.outputs\.archive_base \}\}\.zip" -Force/,
+    );
+    expect(workflow).toMatch(
+      /Collect release asset list[\s\S]*?files=\(release-assets\/\*\*\/\*\.zip\)/,
+    );
+  });
+});

--- a/test/server.args.test.ts
+++ b/test/server.args.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import path from "node:path";
+
+import {
+  parseArgs,
+  resolveBundledBuiltInDir,
+} from "../src/server/index";
+
+describe("server CLI args", () => {
+  test("uses websocket-server defaults", () => {
+    expect(parseArgs([])).toEqual({
+      dir: undefined,
+      port: 7337,
+      yolo: false,
+      json: false,
+    });
+  });
+
+  test("accepts directory, port, yolo, and json flags", () => {
+    expect(parseArgs(["--dir", "/tmp/project", "--port", "0", "--yolo", "--json"])).toEqual({
+      dir: "/tmp/project",
+      port: 0,
+      yolo: true,
+      json: true,
+    });
+  });
+
+  test("rejects invalid ports", () => {
+    expect(() => parseArgs(["--port", "70000"])).toThrow("Invalid port: 70000");
+  });
+});
+
+describe("bundled server builtin-dir discovery", () => {
+  test("prefers a sibling dist directory next to the compiled binary", () => {
+    const execPath = path.join(path.sep, "bundle", "cowork-server");
+    const builtInDir = path.join(path.sep, "bundle", "dist");
+
+    expect(
+      resolveBundledBuiltInDir({
+        execPath,
+        existsSync: (candidate) =>
+          candidate === path.join(builtInDir, "config", "defaults.json") ||
+          candidate === path.join(builtInDir, "prompts", "system.md"),
+      }),
+    ).toBe(builtInDir);
+  });
+
+  test("falls back to a parent dist directory for embedded app layouts", () => {
+    const execPath = path.join(path.sep, "bundle", "bin", "cowork-server");
+    const builtInDir = path.join(path.sep, "bundle", "dist");
+
+    expect(
+      resolveBundledBuiltInDir({
+        execPath,
+        existsSync: (candidate) =>
+          candidate === path.join(builtInDir, "config", "defaults.json") ||
+          candidate === path.join(builtInDir, "prompts", "system.md"),
+      }),
+    ).toBe(builtInDir);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add a standalone Bun binary for the `cowork-server` websocket harness to enable independent deployment and a separate release channel from the desktop app.

The existing `cowork-server` was primarily built as a sidecar for the desktop Electron app. This PR promotes it to a first-class standalone binary, allowing it to be run independently or bundled with other applications, while maintaining a distinct release lifecycle (e.g., `server-v*` tags as prereleases) to avoid conflicts with the desktop app's "latest" release.

<div><a href="https://cursor.com/agents/bc-019f3bb9-0feb-492a-a2b9-b27ce09c4438"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3bb9-0feb-492a-a2b9-b27ce09c4438"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->