### PR TITLE
Add user profile prompt context with conditional injection (TUI, server, prompt templates)

### DIFF
--- a/apps/TUI/app.tsx
+++ b/apps/TUI/app.tsx
@@ -173,6 +173,13 @@ function GlobalHotkeys() {
       action: () => import("./component/dialog-mcp").then(({ openMcpDialog }) => openMcpDialog(dialog)),
     },
     {
+      id: "user-profile",
+      name: "User Profile",
+      description: "Manage user profile prompt context",
+      category: "system",
+      action: () => import("./component/dialog-user-profile").then(({ openUserProfileDialog }) => openUserProfileDialog(dialog)),
+    },
+    {
       id: "stash-prompt",
       name: "Stash Prompt",
       description: "Save current prompt text",

--- a/apps/TUI/component/dialog-command.tsx
+++ b/apps/TUI/component/dialog-command.tsx
@@ -143,6 +143,12 @@ function CommandPaletteDialog(props: { onDismiss: () => void }) {
         description: "View MCP server status",
         category: "System",
       },
+      {
+        label: "User Profile",
+        value: "user_profile",
+        description: "Manage prompt-injected user information",
+        category: "System",
+      },
 
       // Navigation / Help
       {
@@ -245,6 +251,9 @@ function CommandPaletteDialog(props: { onDismiss: () => void }) {
         break;
       case "mcp":
         import("./dialog-mcp").then(({ openMcpDialog }) => openMcpDialog(dialog));
+        break;
+      case "user_profile":
+        import("./dialog-user-profile").then(({ openUserProfileDialog }) => openUserProfileDialog(dialog));
         break;
       case "help":
         import("../ui/dialog-help").then(({ openHelpDialog }) => openHelpDialog(dialog));

--- a/apps/TUI/component/dialog-user-profile.tsx
+++ b/apps/TUI/component/dialog-user-profile.tsx
@@ -1,0 +1,126 @@
+import { createMemo } from "solid-js";
+import { DialogPrompt } from "../ui/dialog-prompt";
+import { DialogSelect, type SelectItem } from "../ui/dialog-select";
+import { useDialog } from "../context/dialog";
+import { useSyncActions, useSyncState } from "../context/sync";
+
+export function openUserProfileDialog(dialog: ReturnType<typeof useDialog>) {
+  dialog.push(
+    () => <UserProfileDialog onDismiss={() => dialog.pop()} />,
+    () => {}
+  );
+}
+
+function UserProfileDialog(props: { onDismiss: () => void }) {
+  const dialog = useDialog();
+  const syncState = useSyncState();
+
+  const items = createMemo((): SelectItem[] => {
+    const profile = syncState.userProfile;
+    return [
+      {
+        label: "Edit Name",
+        value: "name",
+        description: syncState.userName.trim() || "Not set",
+      },
+      {
+        label: "Edit Work/Job",
+        value: "work",
+        description: profile.work.trim() || "Not set",
+      },
+      {
+        label: "Edit Instructions",
+        value: "instructions",
+        description: profile.instructions.trim() || "Not set",
+      },
+      {
+        label: "Edit Details Agent Should Know",
+        value: "details",
+        description: profile.details.trim() || "Not set",
+      },
+    ];
+  });
+
+  const openEditor = (field: "name" | "work" | "instructions" | "details") => {
+    dialog.push(
+      () => <UserProfileFieldDialog field={field} onDismiss={() => dialog.pop()} />,
+      () => {}
+    );
+  };
+
+  return (
+    <DialogSelect
+      items={items()}
+      onDismiss={props.onDismiss}
+      title="User Profile"
+      placeholder="Choose a field to edit"
+      onSelect={(item) => {
+        if (item.value === "name" || item.value === "work" || item.value === "instructions" || item.value === "details") {
+          openEditor(item.value);
+        }
+      }}
+    />
+  );
+}
+
+function UserProfileFieldDialog(props: { field: "name" | "work" | "instructions" | "details"; onDismiss: () => void }) {
+  const syncState = useSyncState();
+  const syncActions = useSyncActions();
+
+  const title = createMemo(() => {
+    switch (props.field) {
+      case "name":
+        return "User Profile: Name";
+      case "work":
+        return "User Profile: Work/Job";
+      case "instructions":
+        return "User Profile: Instructions";
+      case "details":
+        return "User Profile: Details Agent Should Know";
+    }
+  });
+
+  const placeholder = createMemo(() => {
+    switch (props.field) {
+      case "name":
+        return "Name used in prompt context";
+      case "work":
+        return "Role, team, domain, or responsibilities";
+      case "instructions":
+        return "Behavior instructions the agent should follow";
+      case "details":
+        return "Personal/context details the agent should remember";
+    }
+  });
+
+  const handleSubmit = (value: string) => {
+    const trimmed = value.trim();
+    if (props.field === "name") {
+      syncActions.setConfig({ userName: trimmed });
+      props.onDismiss();
+      return;
+    }
+
+    syncActions.setConfig({
+      userProfile: {
+        [props.field]: trimmed,
+      },
+    });
+    props.onDismiss();
+  };
+
+  const currentValue = createMemo(() => {
+    if (props.field === "name") return syncState.userName;
+    return syncState.userProfile[props.field] ?? "";
+  });
+
+  return (
+    <DialogPrompt
+      title={title()}
+      placeholder={placeholder()}
+      value={currentValue()}
+      onDismiss={props.onDismiss}
+      onSubmit={handleSubmit}
+    />
+  );
+}

--- a/apps/TUI/context/sync.tsx
+++ b/apps/TUI/context/sync.tsx
@@ -67,6 +67,12 @@ export function SyncProvider(props: { serverUrl: string; children: JSX.Element }
     backup: null,
     contextUsage: null,
     sessionSummaries: [],
+    userName: "",
+    userProfile: {
+      instructions: "",
+      work: "",
+      details: "",
+    },
     busy: false,
     feed: [],
     todos: [],

--- a/apps/TUI/context/syncEventReducer.ts
+++ b/apps/TUI/context/syncEventReducer.ts
@@ -172,6 +172,8 @@ export function reduceNonProviderEvent(evt: ServerEvent, deps: SyncEventReducerD
 
     case "session_config":
       deps.setState("backupsEnabled", evt.config.backupsEnabled);
+      deps.setState("userName", evt.config.userName);
+      deps.setState("userProfile", evt.config.userProfile);
       return true;
 
     case "harness_context":

--- a/apps/TUI/context/syncTypes.ts
+++ b/apps/TUI/context/syncTypes.ts
@@ -82,6 +82,12 @@ export type SyncConfigPatch = {
   maxSteps?: number;
   toolOutputOverflowChars?: number | null;
   providerOptions?: Partial<Record<OpenAICompatibleProviderName, OpenAICompatibleProviderOptions>>;
+  userName?: string;
+  userProfile?: {
+    instructions?: string;
+    work?: string;
+    details?: string;
+  };
 };
 
 export type SyncState = {
@@ -110,6 +116,12 @@ export type SyncState = {
   backup: SessionBackupState;
   contextUsage: ContextUsageSnapshot | null;
   sessionSummaries: Extract<ServerEvent, { type: "sessions" }>["sessions"];
+  userName: string;
+  userProfile: {
+    instructions: string;
+    work: string;
+    details: string;
+  };
   busy: boolean;
   feed: FeedItem[];
   todos: TodoItem[];

--- a/apps/TUI/routes/session/index.tsx
+++ b/apps/TUI/routes/session/index.tsx
@@ -226,6 +226,11 @@ function FeedItemRenderer(props: { item: FeedItem; citationUrlsByIndex?: Readonl
       </Match>
 
       <Match when={props.item.type === "session_backup_state"}>
+        {(() => {
+          const backup = (props.item as any).backup;
+          const latestCheckpoint = backup.checkpoints[backup.checkpoints.length - 1];
+
+          return (
         <box
           border
           borderStyle="rounded"
@@ -242,21 +247,16 @@ function FeedItemRenderer(props: { item: FeedItem; citationUrlsByIndex?: Readonl
             reason: {(props.item as any).reason} · status: {(props.item as any).backup.status}
           </text>
           <text fg={theme.textMuted}>
-            checkpoints: {(props.item as any).backup.checkpoints.length}
+            checkpoints: {backup.checkpoints.length}
           </text>
-          <Show when={(props.item as any).backup.checkpoints.length > 0}>
-            {() => {
-              const latest = (props.item as any).backup.checkpoints[
-                (props.item as any).backup.checkpoints.length - 1
-              ];
-              return (
-                <text fg={theme.textMuted}>
-                  latest: {latest.id} ({latest.trigger}, {latest.changed ? "changed" : "unchanged"}, {formatBytes(latest.patchBytes)})
-                </text>
-              );
-            }}
+          <Show when={backup.checkpoints.length > 0}>
+            <text fg={theme.textMuted}>
+              latest: {latestCheckpoint.id} ({latestCheckpoint.trigger}, {latestCheckpoint.changed ? "changed" : "unchanged"}, {formatBytes(latestCheckpoint.patchBytes)})
+            </text>
           </Show>
         </box>
+          );
+        })()}
       </Match>
     </Switch>
   );

--- a/apps/TUI/routes/session/sidebar.tsx
+++ b/apps/TUI/routes/session/sidebar.tsx
@@ -1,5 +1,6 @@
 import { For, Show, createMemo } from "solid-js";
 import { useTheme } from "../../context/theme";
+import { useDialog } from "../../context/dialog";
 import { useSyncActions, useSyncState } from "../../context/sync";
 import { TodoItem } from "../../component/todo-item";
 
@@ -21,6 +22,7 @@ function formatBytes(value: number): string {
 
 export function SessionSidebar() {
   const theme = useTheme();
+  const dialog = useDialog();
   const syncState = useSyncState();
   const syncActions = useSyncActions();
 
@@ -156,6 +158,28 @@ export function SessionSidebar() {
           </box>
         )}
       </Show>
+
+      {/* Settings Section */}
+      <box flexDirection="column" marginBottom={1}>
+        <text fg={theme.text}>
+          <strong>Settings</strong>
+        </text>
+        <box paddingLeft={1} flexDirection="column" gap={1}>
+          <text fg={theme.textMuted}>User profile prompt context</text>
+          <box
+            border
+            borderStyle="single"
+            borderColor={theme.border}
+            paddingLeft={1}
+            paddingRight={1}
+            onMouseDown={() => {
+              import("../../component/dialog-user-profile").then(({ openUserProfileDialog }) => openUserProfileDialog(dialog));
+            }}
+          >
+            <text fg={theme.text}>Manage Profile</text>
+          </box>
+        </box>
+      </box>
 
       {/* Todos Section */}
       <Show when={syncState.todos.length > 0}>

--- a/apps/TUI/ui/dialog-prompt.tsx
+++ b/apps/TUI/ui/dialog-prompt.tsx
@@ -59,8 +59,8 @@ export function DialogPrompt(props: DialogPromptProps) {
             value={value()}
             onChange={(v: any) => setValue(typeof v === "string" ? v : v?.value ?? "")}
             onKeyDown={handleKeyDown}
-            onSubmit={(submittedValue: string) => {
-              submitValue(typeof submittedValue === "string" ? submittedValue : value());
+            onSubmit={() => {
+              submitValue(value());
             }}
             placeholder={props.placeholder ?? "Enter value..."}
             placeholderColor={theme.textMuted}

--- a/apps/TUI/ui/dialog-prompt.tsx
+++ b/apps/TUI/ui/dialog-prompt.tsx
@@ -6,6 +6,7 @@ import { keyNameFromEvent } from "../util/keyboard";
 type DialogPromptProps = {
   title: string;
   placeholder?: string;
+  value?: string;
   onSubmit: (value: string) => void;
   onDismiss: () => void;
 };
@@ -21,7 +22,7 @@ export function shouldDismissDialogPromptForKey(key: string): boolean {
 
 export function DialogPrompt(props: DialogPromptProps) {
   const theme = useTheme();
-  const [value, setValue] = createSignal("");
+  const [value, setValue] = createSignal(props.value ?? "");
 
   const submitValue = (raw: string) => {
     const text = resolveDialogPromptSubmitValue(raw);

--- a/apps/desktop/electron/services/persistence.ts
+++ b/apps/desktop/electron/services/persistence.ts
@@ -9,7 +9,9 @@ import type {
   ThreadRecord,
   TranscriptEvent,
   WorkspaceRecord,
+  WorkspaceUserProfile,
 } from "../../src/app/types";
+import { normalizeWorkspaceUserProfile } from "../../src/app/types";
 import { normalizeWorkspaceProviderOptions } from "../../src/app/openaiCompatibleProviderOptions";
 import { normalizePersistedProviderState } from "../../src/app/persistedProviderState";
 import type { TranscriptBatchInput } from "../../src/lib/desktopApi";
@@ -59,6 +61,10 @@ function asNonEmptyString(value: unknown): string | null {
   }
   const trimmed = value.trim();
   return trimmed ? trimmed : null;
+}
+
+function asDefinedString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
 }
 
 function asSafeId(value: unknown): string | null {
@@ -172,6 +178,10 @@ async function sanitizeWorkspaces(value: unknown): Promise<WorkspaceRecord[]> {
       defaultSubAgentModel: asOptionalString(item.defaultSubAgentModel),
       defaultToolOutputOverflowChars: asOptionalNullableNonNegativeInteger(item.defaultToolOutputOverflowChars),
       providerOptions: normalizeWorkspaceProviderOptions(item.providerOptions),
+      userName: asDefinedString(item.userName),
+      userProfile: isRecord(item.userProfile)
+        ? normalizeWorkspaceUserProfile(item.userProfile as Partial<WorkspaceUserProfile>)
+        : undefined,
       defaultEnableMcp: typeof item.defaultEnableMcp === "boolean" ? item.defaultEnableMcp : true,
       defaultBackupsEnabled: typeof item.defaultBackupsEnabled === "boolean" ? item.defaultBackupsEnabled : true,
       yolo: typeof item.yolo === "boolean" ? item.yolo : false,

--- a/apps/desktop/src/app/store.actions/bootstrap.ts
+++ b/apps/desktop/src/app/store.actions/bootstrap.ts
@@ -50,10 +50,19 @@ import {
 } from "../store.helpers";
 import { deriveConnectedProviders, normalizePersistedProviderState } from "../persistedProviderState";
 import { normalizeWorkspaceProviderOptions } from "../openaiCompatibleProviderOptions";
-import type { PersistedProviderState, ThreadRecord, WorkspaceRecord } from "../types";
+import {
+  normalizeWorkspaceUserProfile,
+  type PersistedProviderState,
+  type ThreadRecord,
+  type WorkspaceRecord,
+} from "../types";
 
 const optionalStringWithContentSchema = z.preprocess(
   (value) => (typeof value === "string" && value.trim() ? value : undefined),
+  z.string().optional()
+);
+const optionalStringSchema = z.preprocess(
+  (value) => (typeof value === "string" ? value : undefined),
   z.string().optional()
 );
 
@@ -95,6 +104,12 @@ const persistedWorkspaceSchema = z.object({
     return undefined;
   }, z.number().int().nonnegative().nullable().optional()),
   providerOptions: z.unknown().optional(),
+  userName: optionalStringSchema,
+  userProfile: z.object({
+    instructions: optionalStringSchema,
+    work: optionalStringSchema,
+    details: optionalStringSchema,
+  }).passthrough().optional(),
   defaultEnableMcp: z.preprocess((value) => (typeof value === "boolean" ? value : true), z.boolean()),
   defaultBackupsEnabled: z.preprocess((value) => (typeof value === "boolean" ? value : true), z.boolean()),
   yolo: z.preprocess((value) => (typeof value === "boolean" ? value : false), z.boolean()),
@@ -111,6 +126,8 @@ const persistedWorkspaceSchema = z.object({
     defaultSubAgentModel: workspace.defaultSubAgentModel ?? model,
     defaultToolOutputOverflowChars: workspace.defaultToolOutputOverflowChars,
     providerOptions: normalizeWorkspaceProviderOptions(workspace.providerOptions),
+    userName: workspace.userName,
+    userProfile: workspace.userProfile ? normalizeWorkspaceUserProfile(workspace.userProfile) : undefined,
     defaultEnableMcp: workspace.defaultEnableMcp,
     defaultBackupsEnabled: workspace.defaultBackupsEnabled,
     yolo: workspace.yolo,

--- a/apps/desktop/src/app/store.actions/workspaceDefaults.ts
+++ b/apps/desktop/src/app/store.actions/workspaceDefaults.ts
@@ -47,6 +47,7 @@ import {
   truncateTitle,
 } from "../store.helpers";
 import { mergeWorkspaceProviderOptions } from "../openaiCompatibleProviderOptions";
+import { normalizeWorkspaceUserProfile } from "../types";
 import type { ThreadRecord, WorkspaceDefaultsPatch, WorkspaceRecord } from "../types";
 
 export function createWorkspaceDefaultsActions(set: StoreSet, get: StoreGet): Pick<AppStoreActions, "applyWorkspaceDefaultsToThread" | "updateWorkspaceDefaults"> {
@@ -114,6 +115,9 @@ export function createWorkspaceDefaultsActions(set: StoreSet, get: StoreGet): Pi
       const subAgentModel =
         (ws.defaultSubAgentModel?.trim() || ws.defaultModel?.trim() || rt.sessionConfig?.subAgentModel?.trim() || "") || undefined;
       const providerOptions = ws.providerOptions;
+      const userName = ws.userName;
+      const userProfile = ws.userProfile ? normalizeWorkspaceUserProfile(ws.userProfile) : undefined;
+      const hasProfileDefaults = userName !== undefined || userProfile !== undefined;
 
       if (provider && model) {
         const ok = sendThread(get, threadId, (sessionId) => ({
@@ -125,13 +129,15 @@ export function createWorkspaceDefaultsActions(set: StoreSet, get: StoreGet): Pi
         if (ok) appendThreadTranscript(threadId, "client", { type: "set_model", sessionId: rt.sessionId, provider, model });
       }
 
-      if (subAgentModel || providerOptions) {
+      if (subAgentModel || providerOptions || hasProfileDefaults) {
         const okConfig = sendThread(get, threadId, (sessionId) => ({
           type: "set_config",
           sessionId,
           config: {
             ...(subAgentModel ? { subAgentModel } : {}),
             ...(providerOptions ? { providerOptions: providerOptions as OpenAiCompatibleProviderOptionsByProvider } : {}),
+            ...(userName !== undefined ? { userName } : {}),
+            ...(userProfile !== undefined ? { userProfile } : {}),
           },
         }));
         if (okConfig) {
@@ -141,6 +147,8 @@ export function createWorkspaceDefaultsActions(set: StoreSet, get: StoreGet): Pi
             config: {
               ...(subAgentModel ? { subAgentModel } : {}),
               ...(providerOptions ? { providerOptions } : {}),
+              ...(userName !== undefined ? { userName } : {}),
+              ...(userProfile !== undefined ? { userProfile } : {}),
             },
           });
         }
@@ -158,7 +166,7 @@ export function createWorkspaceDefaultsActions(set: StoreSet, get: StoreGet): Pi
   
 
     updateWorkspaceDefaults: async (workspaceId, patch: WorkspaceDefaultsPatch) => {
-      const { clearDefaultToolOutputOverflowChars, ...workspacePatch } = patch;
+      const { clearDefaultToolOutputOverflowChars, userProfile: userProfilePatch, ...workspacePatch } = patch;
       set((s) => ({
         workspaces: s.workspaces.map((w) => {
           if (w.id !== workspaceId) return w;
@@ -169,6 +177,14 @@ export function createWorkspaceDefaultsActions(set: StoreSet, get: StoreGet): Pi
             ...(workspacePatch.providerOptions !== undefined
               ? {
                   providerOptions: mergeWorkspaceProviderOptions(w.providerOptions, workspacePatch.providerOptions),
+                }
+              : {}),
+            ...(userProfilePatch !== undefined
+              ? {
+                  userProfile: {
+                    ...normalizeWorkspaceUserProfile(w.userProfile),
+                    ...userProfilePatch,
+                  },
                 }
               : {}),
           };
@@ -184,7 +200,9 @@ export function createWorkspaceDefaultsActions(set: StoreSet, get: StoreGet): Pi
         clearDefaultToolOutputOverflowChars === true ||
         workspacePatch.defaultEnableMcp !== undefined ||
         workspacePatch.defaultBackupsEnabled !== undefined ||
-        workspacePatch.providerOptions !== undefined;
+        workspacePatch.providerOptions !== undefined ||
+        workspacePatch.userName !== undefined ||
+        userProfilePatch !== undefined;
       if (!shouldSyncCoreSettings) {
         return;
       }
@@ -204,6 +222,8 @@ export function createWorkspaceDefaultsActions(set: StoreSet, get: StoreGet): Pi
       const subAgentModel = workspace.defaultSubAgentModel?.trim() || model;
       const toolOutputOverflowChars = workspace.defaultToolOutputOverflowChars;
       const providerOptions = workspace.providerOptions;
+      const userName = workspace.userName;
+      const userProfile = workspace.userProfile ? normalizeWorkspaceUserProfile(workspace.userProfile) : undefined;
       const clearToolOutputOverflowChars = clearDefaultToolOutputOverflowChars === true;
 
       const modelPersisted = sendControl(get, workspaceId, (sessionId) => ({
@@ -224,6 +244,8 @@ export function createWorkspaceDefaultsActions(set: StoreSet, get: StoreGet): Pi
               ? { clearToolOutputOverflowChars: true }
               : {}),
           ...(providerOptions ? { providerOptions: providerOptions as OpenAiCompatibleProviderOptionsByProvider } : {}),
+          ...(userName !== undefined ? { userName } : {}),
+          ...(userProfile !== undefined ? { userProfile } : {}),
         },
       }));
       const mcpPersisted = sendControl(get, workspaceId, (sessionId) => ({

--- a/apps/desktop/src/app/store.helpers/controlSocket.ts
+++ b/apps/desktop/src/app/store.helpers/controlSocket.ts
@@ -2,6 +2,7 @@ import { AgentSocket } from "../../lib/agentSocket";
 import type { ClientMessage, ProviderName, ServerEvent } from "../../lib/wsProtocol";
 import type { StoreGet, StoreSet } from "../store.helpers";
 import { normalizeWorkspaceProviderOptions } from "../openaiCompatibleProviderOptions";
+import { normalizeWorkspaceUserProfile } from "../types";
 import type { Notification } from "../types";
 import { RUNTIME } from "./runtimeState";
 
@@ -102,6 +103,7 @@ export function createControlSocketHelpers(deps: ControlSocketDeps) {
 
         if (evt.type === "session_config") {
           const providerOptions = normalizeWorkspaceProviderOptions((evt.config as any).providerOptions);
+          const userProfile = evt.config.userProfile ? normalizeWorkspaceUserProfile(evt.config.userProfile) : undefined;
           set((s) => ({
             workspaces: s.workspaces.map((workspace) =>
               workspace.id === workspaceId
@@ -111,6 +113,8 @@ export function createControlSocketHelpers(deps: ControlSocketDeps) {
                     defaultSubAgentModel: evt.config.subAgentModel,
                     defaultToolOutputOverflowChars: evt.config.defaultToolOutputOverflowChars,
                     providerOptions,
+                    ...(typeof evt.config.userName === "string" ? { userName: evt.config.userName } : {}),
+                    ...(userProfile ? { userProfile } : {}),
                   }
                 : workspace,
             ),

--- a/apps/desktop/src/app/types.ts
+++ b/apps/desktop/src/app/types.ts
@@ -10,6 +10,22 @@ import type {
 } from "../lib/wsProtocol";
 import type { WorkspaceProviderOptions } from "./openaiCompatibleProviderOptions";
 
+export type WorkspaceUserProfile = {
+  instructions: string;
+  work: string;
+  details: string;
+};
+
+export function normalizeWorkspaceUserProfile(
+  value?: Partial<WorkspaceUserProfile> | null,
+): WorkspaceUserProfile {
+  return {
+    instructions: typeof value?.instructions === "string" ? value.instructions : "",
+    work: typeof value?.work === "string" ? value.work : "",
+    details: typeof value?.details === "string" ? value.details : "",
+  };
+}
+
 export type ExplorerEntry = {
   name: string;
   path: string;
@@ -40,13 +56,16 @@ export type WorkspaceRecord = {
   defaultSubAgentModel?: string;
   defaultToolOutputOverflowChars?: number | null;
   providerOptions?: WorkspaceProviderOptions;
+  userName?: string;
+  userProfile?: WorkspaceUserProfile;
   defaultEnableMcp: boolean;
   defaultBackupsEnabled: boolean;
   yolo: boolean;
 };
 
-export type WorkspaceDefaultsPatch = Partial<WorkspaceRecord> & {
+export type WorkspaceDefaultsPatch = Partial<Omit<WorkspaceRecord, "userProfile">> & {
   clearDefaultToolOutputOverflowChars?: boolean;
+  userProfile?: Partial<WorkspaceUserProfile>;
 };
 
 export type ThreadStatus = "active" | "disconnected";

--- a/apps/desktop/src/lib/desktopSchemas.ts
+++ b/apps/desktop/src/lib/desktopSchemas.ts
@@ -34,6 +34,10 @@ const invalidPathSegmentPattern = /[/\\\0]/;
 
 const nonEmptyStringSchema = z.string().trim().min(1);
 const optionalNonEmptyStringSchema = nonEmptyStringSchema.optional();
+const optionalStringSchema = z.preprocess(
+  (value) => (typeof value === "string" ? value : undefined),
+  z.string().optional(),
+);
 const safeIdSchema = nonEmptyStringSchema.regex(SAFE_ID, "contains invalid characters");
 const directionSchema = z.enum(["server", "client"]);
 
@@ -121,6 +125,12 @@ const persistedWorkspaceSchema = z.object({
     return undefined;
   }, z.number().int().nonnegative().nullable().optional()),
   providerOptions: workspaceProviderOptionsSchema.optional(),
+  userName: optionalStringSchema,
+  userProfile: z.object({
+    instructions: optionalStringSchema,
+    work: optionalStringSchema,
+    details: optionalStringSchema,
+  }).passthrough().optional(),
   defaultEnableMcp: z.preprocess((value) => (typeof value === "boolean" ? value : true), z.boolean()),
   defaultBackupsEnabled: z.preprocess((value) => (typeof value === "boolean" ? value : true), z.boolean()),
   yolo: z.preprocess((value) => (typeof value === "boolean" ? value : false), z.boolean()),

--- a/apps/desktop/src/ui/ChatView.tsx
+++ b/apps/desktop/src/ui/ChatView.tsx
@@ -480,7 +480,7 @@ export function ChatView() {
 
     const entries = [...citationOverflowFilePathsByMessageId.entries()];
     if (entries.length === 0) {
-      setOverflowCitationUrlsByMessageId(new Map());
+      setOverflowCitationUrlsByMessageId((current) => (current.size === 0 ? current : new Map()));
       return;
     }
 

--- a/apps/desktop/src/ui/settings/pages/WorkspacesPage.tsx
+++ b/apps/desktop/src/ui/settings/pages/WorkspacesPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { defaultModelForProvider } from "@cowork/providers/catalog";
 
@@ -15,12 +15,17 @@ import {
   type ReasoningSummaryValue,
   type TextVerbosityValue,
 } from "../../../app/openaiCompatibleProviderOptions";
-import type { WorkspaceRecord } from "../../../app/types";
+import {
+  normalizeWorkspaceUserProfile,
+  type WorkspaceRecord,
+  type WorkspaceUserProfile,
+} from "../../../app/types";
 import { useAppStore } from "../../../app/store";
 import { Badge } from "../../../components/ui/badge";
 import { Button } from "../../../components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../../../components/ui/card";
 import { Checkbox } from "../../../components/ui/checkbox";
+import { Input } from "../../../components/ui/input";
 import {
   Select,
   SelectContent,
@@ -28,6 +33,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "../../../components/ui/select";
+import { Textarea } from "../../../components/ui/textarea";
 import { confirmAction } from "../../../lib/desktopCommands";
 import { MODEL_CHOICES, modelOptionsForProvider, UI_DISABLED_PROVIDERS } from "../../../lib/modelChoices";
 import type { ProviderName } from "../../../lib/wsProtocol";
@@ -191,6 +197,135 @@ export function OpenAiCompatibleModelSettingsCard({
             </div>
           </div>
         ))}
+      </CardContent>
+    </Card>
+  );
+}
+
+type WorkspaceUserProfileCardProps = {
+  workspace: Pick<WorkspaceRecord, "id" | "userName" | "userProfile">;
+  updateWorkspaceDefaults: (
+    workspaceId: string,
+    patch: { userName?: string; userProfile?: Partial<WorkspaceUserProfile> },
+  ) => Promise<unknown> | void;
+};
+
+function buildUserProfileDraft(workspace: WorkspaceUserProfileCardProps["workspace"]) {
+  const profile = normalizeWorkspaceUserProfile(workspace.userProfile);
+  return {
+    userName: workspace.userName ?? "",
+    instructions: profile.instructions,
+    work: profile.work,
+    details: profile.details,
+  };
+}
+
+export function WorkspaceUserProfileCard({
+  workspace,
+  updateWorkspaceDefaults,
+}: WorkspaceUserProfileCardProps) {
+  const [draft, setDraft] = useState(() => buildUserProfileDraft(workspace));
+
+  useEffect(() => {
+    setDraft(buildUserProfileDraft(workspace));
+  }, [
+    workspace.id,
+    workspace.userName,
+    workspace.userProfile?.instructions,
+    workspace.userProfile?.work,
+    workspace.userProfile?.details,
+  ]);
+
+  const currentProfile = normalizeWorkspaceUserProfile(workspace.userProfile);
+
+  const commitUserName = (value: string) => {
+    const trimmed = value.trim();
+    if (trimmed === (workspace.userName ?? "")) return;
+    void updateWorkspaceDefaults(workspace.id, { userName: trimmed });
+  };
+
+  const commitProfileField = (field: keyof WorkspaceUserProfile, value: string) => {
+    const trimmed = value.trim();
+    if (trimmed === currentProfile[field]) return;
+    void updateWorkspaceDefaults(workspace.id, { userProfile: { [field]: trimmed } });
+  };
+
+  return (
+    <Card className="border-border/80 bg-card/85">
+      <CardHeader>
+        <CardTitle>User Profile Context</CardTitle>
+        <CardDescription>
+          Workspace-specific identity and prompt context. Changes save when the field loses focus.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <div className="text-sm font-medium text-foreground">Name</div>
+          <Input
+            aria-label="Workspace user name"
+            autoComplete="off"
+            placeholder="Name used in prompt context"
+            value={draft.userName}
+            onChange={(event) =>
+              setDraft((current) => ({
+                ...current,
+                userName: event.currentTarget.value,
+              }))
+            }
+            onBlur={(event) => commitUserName(event.currentTarget.value)}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <div className="text-sm font-medium text-foreground">Work / Job</div>
+          <Textarea
+            aria-label="Workspace work context"
+            className="min-h-24"
+            placeholder="Role, team, domain, or responsibilities"
+            value={draft.work}
+            onChange={(event) =>
+              setDraft((current) => ({
+                ...current,
+                work: event.currentTarget.value,
+              }))
+            }
+            onBlur={(event) => commitProfileField("work", event.currentTarget.value)}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <div className="text-sm font-medium text-foreground">Instructions</div>
+          <Textarea
+            aria-label="Workspace profile instructions"
+            className="min-h-24"
+            placeholder="Behavior instructions the agent should follow"
+            value={draft.instructions}
+            onChange={(event) =>
+              setDraft((current) => ({
+                ...current,
+                instructions: event.currentTarget.value,
+              }))
+            }
+            onBlur={(event) => commitProfileField("instructions", event.currentTarget.value)}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <div className="text-sm font-medium text-foreground">Details Agent Should Know</div>
+          <Textarea
+            aria-label="Workspace profile details"
+            className="min-h-24"
+            placeholder="Personal or project details the agent should remember"
+            value={draft.details}
+            onChange={(event) =>
+              setDraft((current) => ({
+                ...current,
+                details: event.currentTarget.value,
+              }))
+            }
+            onBlur={(event) => commitProfileField("details", event.currentTarget.value)}
+          />
+        </div>
       </CardContent>
     </Card>
   );
@@ -418,6 +553,11 @@ export function WorkspacesPage() {
               </div>
             </CardContent>
           </Card>
+
+          <WorkspaceUserProfileCard
+            workspace={ws}
+            updateWorkspaceDefaults={updateWorkspaceDefaults}
+          />
 
           <OpenAiCompatibleModelSettingsCard
             workspace={ws}

--- a/apps/desktop/test/chat-view.stability.test.tsx
+++ b/apps/desktop/test/chat-view.stability.test.tsx
@@ -1,0 +1,214 @@
+import { describe, expect, mock, test } from "bun:test";
+import { JSDOM } from "jsdom";
+import { createElement, StrictMode } from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+
+const MOCK_SYSTEM_APPEARANCE = {
+  platform: "linux",
+  themeSource: "system",
+  shouldUseDarkColors: false,
+  shouldUseHighContrastColors: false,
+  shouldUseInvertedColorScheme: false,
+  prefersReducedTransparency: false,
+  inForcedColorsMode: false,
+};
+const MOCK_UPDATE_STATE = {
+  phase: "idle",
+  currentVersion: "0.1.0",
+  packaged: false,
+  lastCheckedAt: null,
+  release: null,
+  progress: null,
+  error: null,
+};
+
+mock.module("../src/lib/desktopCommands", () => ({
+  appendTranscriptBatch: async () => {},
+  appendTranscriptEvent: async () => {},
+  deleteTranscript: async () => {},
+  listDirectory: async () => [],
+  loadState: async () => ({ version: 1, workspaces: [], threads: [] }),
+  pickWorkspaceDirectory: async () => null,
+  readTranscript: async () => [],
+  saveState: async () => {},
+  startWorkspaceServer: async () => ({ url: "ws://mock" }),
+  stopWorkspaceServer: async () => {},
+  showContextMenu: async () => null,
+  windowMinimize: async () => {},
+  windowMaximize: async () => {},
+  windowClose: async () => {},
+  getPlatform: async () => "linux",
+  readFile: async () => "",
+  previewOSFile: async () => {},
+  openPath: async () => {},
+  revealPath: async () => {},
+  copyPath: async () => {},
+  createDirectory: async () => {},
+  renamePath: async () => {},
+  trashPath: async () => {},
+  confirmAction: async () => true,
+  showNotification: async () => true,
+  getSystemAppearance: async () => MOCK_SYSTEM_APPEARANCE,
+  setWindowAppearance: async () => MOCK_SYSTEM_APPEARANCE,
+  getUpdateState: async () => MOCK_UPDATE_STATE,
+  checkForUpdates: async () => {},
+  quitAndInstallUpdate: async () => {},
+  onSystemAppearanceChanged: () => () => {},
+  onMenuCommand: () => () => {},
+  onUpdateStateChanged: () => () => {},
+}));
+
+mock.module("../src/lib/agentSocket", () => ({
+  AgentSocket: class {
+    connect() {}
+    send() {
+      return true;
+    }
+    close() {}
+  },
+}));
+
+type JsdomHarness = {
+  dom: JSDOM;
+  restore: () => void;
+};
+
+function setupJsdom(): JsdomHarness {
+  const dom = new JSDOM("<!doctype html><html><body><div id='root'></div></body></html>", {
+    url: "http://localhost",
+  });
+  const saved = {
+    window: globalThis.window,
+    document: globalThis.document,
+    navigator: globalThis.navigator,
+    HTMLElement: globalThis.HTMLElement,
+    Node: globalThis.Node,
+    getComputedStyle: globalThis.getComputedStyle,
+    requestAnimationFrame: globalThis.requestAnimationFrame,
+    cancelAnimationFrame: globalThis.cancelAnimationFrame,
+    actEnv: (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT,
+  };
+
+  Object.assign(globalThis, {
+    window: dom.window,
+    document: dom.window.document,
+    navigator: dom.window.navigator,
+    HTMLElement: dom.window.HTMLElement,
+    Node: dom.window.Node,
+    getComputedStyle: dom.window.getComputedStyle.bind(dom.window),
+    requestAnimationFrame: (callback: FrameRequestCallback) => setTimeout(() => callback(Date.now()), 0) as unknown as number,
+    cancelAnimationFrame: (id: number) => clearTimeout(id),
+  });
+  dom.window.requestAnimationFrame = globalThis.requestAnimationFrame;
+  dom.window.cancelAnimationFrame = globalThis.cancelAnimationFrame;
+  (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+  return {
+    dom,
+    restore: () => {
+      globalThis.window = saved.window;
+      globalThis.document = saved.document;
+      globalThis.navigator = saved.navigator;
+      globalThis.HTMLElement = saved.HTMLElement;
+      globalThis.Node = saved.Node;
+      globalThis.getComputedStyle = saved.getComputedStyle;
+      globalThis.requestAnimationFrame = saved.requestAnimationFrame;
+      globalThis.cancelAnimationFrame = saved.cancelAnimationFrame;
+      (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = saved.actEnv;
+      dom.window.close();
+    },
+  };
+}
+
+const { useAppStore } = await import("../src/app/store");
+const { ChatView } = await import("../src/ui/ChatView");
+
+describe("desktop chat view stability", () => {
+  test("does not loop when citation overflow state is empty", async () => {
+    useAppStore.setState({
+      ready: true,
+      startupError: null,
+      view: "chat",
+      selectedWorkspaceId: "ws-1",
+      selectedThreadId: "thread-1",
+      workspaces: [
+        {
+          id: "ws-1",
+          name: "Workspace 1",
+          path: "/tmp/workspace-1",
+          createdAt: "2026-03-12T00:00:00.000Z",
+          lastOpenedAt: "2026-03-12T00:00:00.000Z",
+          defaultEnableMcp: true,
+          defaultBackupsEnabled: true,
+          yolo: false,
+        },
+      ],
+      threads: [
+        {
+          id: "thread-1",
+          workspaceId: "ws-1",
+          title: "Thread 1",
+          createdAt: "2026-03-12T00:00:00.000Z",
+          lastMessageAt: "2026-03-12T00:00:00.000Z",
+          status: "active",
+          sessionId: "session-1",
+          lastEventSeq: 0,
+        },
+      ],
+      threadRuntimeById: {
+        "thread-1": {
+          wsUrl: null,
+          connected: true,
+          sessionId: "session-1",
+          config: {
+            provider: "openai",
+            model: "gpt-5.4",
+          },
+          sessionConfig: null,
+          sessionUsage: null,
+          lastTurnUsage: null,
+          enableMcp: true,
+          busy: false,
+          busySince: null,
+          feed: [],
+          transcriptOnly: false,
+        },
+      },
+      composerText: "",
+    });
+
+    const harness = setupJsdom();
+    const realError = console.error;
+    const consoleErrors: string[] = [];
+    console.error = (...args: unknown[]) => {
+      consoleErrors.push(args.map((arg) => String(arg)).join(" "));
+    };
+
+    try {
+      const container = harness.dom.window.document.getElementById("root");
+      if (!container) throw new Error("missing root");
+      const root = createRoot(container);
+
+      await act(async () => {
+        root.render(
+          createElement(
+            StrictMode,
+            null,
+            createElement(ChatView),
+          ),
+        );
+      });
+
+      expect(container.textContent).toContain("Thread 1");
+      expect(consoleErrors.some((entry) => entry.includes("Maximum update depth exceeded"))).toBe(false);
+
+      await act(async () => {
+        root.unmount();
+      });
+    } finally {
+      console.error = realError;
+      harness.restore();
+    }
+  });
+});

--- a/apps/desktop/test/desktop-schemas.test.ts
+++ b/apps/desktop/test/desktop-schemas.test.ts
@@ -41,6 +41,12 @@ describe("desktop persisted-state schema defaults", () => {
           defaultEnableMcp: false,
           defaultBackupsEnabled: false,
           defaultToolOutputOverflowChars: null,
+          userName: "Alex",
+          userProfile: {
+            instructions: "Keep answers terse.",
+            work: "Platform engineer",
+            details: "Prefers Bun",
+          },
           yolo: true,
         },
       ],
@@ -52,6 +58,12 @@ describe("desktop persisted-state schema defaults", () => {
     expect(parsed.workspaces[0]?.defaultEnableMcp).toBe(false);
     expect(parsed.workspaces[0]?.defaultBackupsEnabled).toBe(false);
     expect(parsed.workspaces[0]?.defaultToolOutputOverflowChars).toBeNull();
+    expect(parsed.workspaces[0]?.userName).toBe("Alex");
+    expect(parsed.workspaces[0]?.userProfile).toEqual({
+      instructions: "Keep answers terse.",
+      work: "Platform engineer",
+      details: "Prefers Bun",
+    });
     expect(parsed.workspaces[0]?.yolo).toBe(true);
     expect(parsed.developerMode).toBe(true);
     expect(parsed.showHiddenFiles).toBe(true);

--- a/apps/desktop/test/persistence-state-sanitization.test.ts
+++ b/apps/desktop/test/persistence-state-sanitization.test.ts
@@ -198,6 +198,45 @@ describe("desktop persistence state validation", () => {
     expect(loaded.workspaces.find((workspace) => workspace.id === "ws_overflow_inherited")?.defaultToolOutputOverflowChars).toBeUndefined();
   });
 
+  test("saveState preserves workspace user profile defaults", async () => {
+    const persistence = new PersistenceService();
+    const profileWorkspace = path.join(userDataDir, "workspace-profile");
+    await fs.mkdir(profileWorkspace, { recursive: true });
+
+    await persistence.saveState({
+      version: 2,
+      workspaces: [
+        {
+          id: "ws_profile",
+          name: "Profile workspace",
+          path: profileWorkspace,
+          createdAt: TS,
+          lastOpenedAt: TS,
+          userName: "Alex",
+          userProfile: {
+            instructions: "Keep answers terse.",
+            work: "Platform engineer",
+            details: "Prefers Bun",
+          },
+          defaultEnableMcp: true,
+          defaultBackupsEnabled: true,
+          yolo: false,
+        },
+      ],
+      threads: [],
+      developerMode: false,
+      showHiddenFiles: false,
+    });
+
+    const loaded = await persistence.loadState();
+    expect(loaded.workspaces[0]?.userName).toBe("Alex");
+    expect(loaded.workspaces[0]?.userProfile).toEqual({
+      instructions: "Keep answers terse.",
+      work: "Platform engineer",
+      details: "Prefers Bun",
+    });
+  });
+
   test("saveState drops recoverable expired codex status snapshots that would look disconnected on restart", async () => {
     const persistence = new PersistenceService();
     const validWorkspace = path.join(userDataDir, "workspace-provider-recoverable");

--- a/apps/desktop/test/workspace-settings-sync.test.ts
+++ b/apps/desktop/test/workspace-settings-sync.test.ts
@@ -216,6 +216,45 @@ describe("workspace settings sync", () => {
     expect(loaded?.defaultSubAgentModel).toBe("gpt-5.2");
   });
 
+  test("init preserves workspace user profile defaults during rehydration", async () => {
+    mockedLoadedState = {
+      version: 2,
+      workspaces: [
+        {
+          id: "ws-profile",
+          name: "Loaded profile",
+          path: "/tmp/workspace-profile",
+          createdAt: "2026-02-19T00:00:00.000Z",
+          lastOpenedAt: "2026-02-19T00:00:00.000Z",
+          defaultProvider: "openai",
+          defaultModel: "gpt-5.2",
+          userName: "Alex",
+          userProfile: {
+            instructions: "Keep answers terse.",
+            work: "Platform engineer",
+            details: "Prefers Bun",
+          },
+          defaultEnableMcp: true,
+          defaultBackupsEnabled: true,
+          yolo: false,
+        },
+      ],
+      threads: [],
+      developerMode: false,
+      showHiddenFiles: false,
+    };
+
+    await useAppStore.getState().init();
+
+    const loaded = useAppStore.getState().workspaces[0];
+    expect(loaded?.userName).toBe("Alex");
+    expect(loaded?.userProfile).toEqual({
+      instructions: "Keep answers terse.",
+      work: "Platform engineer",
+      details: "Prefers Bun",
+    });
+  });
+
   test("init preserves persisted workspace overflow defaults during rehydration", async () => {
     mockedLoadedState = {
       version: 2,
@@ -449,10 +488,14 @@ describe("workspace settings sync", () => {
     expect(workspace?.defaultSubAgentModel).toBe("gpt-5-mini");
     expect(workspace?.defaultBackupsEnabled).toBe(false);
     expect(workspace?.defaultToolOutputOverflowChars).toBe(12000);
+    expect(workspace?.userName).toBe("Alex");
+    expect(workspace?.userProfile).toEqual({ instructions: "", work: "", details: "" });
     expect(runtime?.controlSessionConfig?.subAgentModel).toBe("gpt-5-mini");
     expect(runtime?.controlSessionConfig?.backupsEnabled).toBe(false);
     expect(runtime?.controlSessionConfig?.defaultBackupsEnabled).toBe(false);
     expect(runtime?.controlSessionConfig?.toolOutputOverflowChars).toBe(12000);
+    expect((runtime?.controlSessionConfig as any)?.userName).toBe("Alex");
+    expect((runtime?.controlSessionConfig as any)?.userProfile).toEqual({ instructions: "", work: "", details: "" });
   });
 
   test("control session_config keeps session backup overrides separate from the workspace default", async () => {
@@ -492,6 +535,12 @@ describe("workspace settings sync", () => {
         workspace.id === workspaceId
           ? {
               ...workspace,
+              userName: "Alex",
+              userProfile: {
+                instructions: "Keep answers terse.",
+                work: "Platform engineer",
+                details: "Prefers Bun",
+              },
               providerOptions: {
                 openai: {
                   reasoningEffort: "high",
@@ -565,6 +614,12 @@ describe("workspace settings sync", () => {
         workspace.id === workspaceId
           ? {
               ...workspace,
+              userName: "Alex",
+              userProfile: {
+                instructions: "Keep answers terse.",
+                work: "Platform engineer",
+                details: "Prefers Bun",
+              },
               providerOptions: {
                 openai: {
                   reasoningEffort: "high",
@@ -610,6 +665,12 @@ describe("workspace settings sync", () => {
         workspace.id === workspaceId
           ? {
               ...workspace,
+              userName: "Alex",
+              userProfile: {
+                instructions: "Keep answers terse.",
+                work: "Platform engineer",
+                details: "Prefers Bun",
+              },
               providerOptions: {
                 openai: {
                   reasoningEffort: "high",
@@ -652,6 +713,12 @@ describe("workspace settings sync", () => {
       type: "set_config",
       config: {
         subAgentModel: "gpt-5.2",
+        userName: "Alex",
+        userProfile: {
+          instructions: "Keep answers terse.",
+          work: "Platform engineer",
+          details: "Prefers Bun",
+        },
         providerOptions: {
           openai: {
             reasoningEffort: "high",
@@ -744,6 +811,82 @@ describe("workspace settings sync", () => {
       config: {
         backupsEnabled: false,
         toolOutputOverflowChars: 12000,
+      },
+    });
+  });
+
+  test("updateWorkspaceDefaults merges user profile fields and syncs control plus live threads", async () => {
+    useAppStore.setState((state) => ({
+      ...state,
+      workspaces: state.workspaces.map((workspace) =>
+        workspace.id === workspaceId
+          ? {
+              ...workspace,
+              userName: "Alex",
+              userProfile: {
+                instructions: "Keep answers terse.",
+                work: "Platform engineer",
+                details: "Prefers Bun",
+              },
+            }
+          : workspace,
+      ),
+    }));
+
+    await useAppStore.getState().newThread({ workspaceId });
+    const controlSocket = socketByClient("desktop-control");
+    emitServerHello(controlSocket, "control-session");
+    const threadSocket = socketByClient("desktop");
+    emitServerHello(threadSocket, "thread-session");
+
+    controlSocket.sent = [];
+    threadSocket.sent = [];
+
+    await useAppStore.getState().updateWorkspaceDefaults(workspaceId, {
+      userName: "Taylor",
+      userProfile: {
+        details: "Prefers Bun and TypeScript",
+      },
+    });
+
+    const workspace = useAppStore.getState().workspaces.find((entry) => entry.id === workspaceId);
+    expect(workspace?.userName).toBe("Taylor");
+    expect(workspace?.userProfile).toEqual({
+      instructions: "Keep answers terse.",
+      work: "Platform engineer",
+      details: "Prefers Bun and TypeScript",
+    });
+
+    expect(controlSocket.sent.find((message) => message?.type === "set_config")).toMatchObject({
+      type: "set_config",
+      config: {
+        backupsEnabled: true,
+        subAgentModel: "gpt-5.2",
+        userName: "Taylor",
+        userProfile: {
+          instructions: "Keep answers terse.",
+          work: "Platform engineer",
+          details: "Prefers Bun and TypeScript",
+        },
+      },
+    });
+
+    expect(threadSocket.sent.map((message) => message?.type)).toEqual([
+      "set_config",
+      "set_model",
+      "set_config",
+      "set_enable_mcp",
+    ]);
+    expect(threadSocket.sent[2]).toMatchObject({
+      type: "set_config",
+      config: {
+        subAgentModel: "gpt-5.2",
+        userName: "Taylor",
+        userProfile: {
+          instructions: "Keep answers terse.",
+          work: "Platform engineer",
+          details: "Prefers Bun and TypeScript",
+        },
       },
     });
   });

--- a/apps/desktop/test/workspace-settings-sync.test.ts
+++ b/apps/desktop/test/workspace-settings-sync.test.ts
@@ -439,6 +439,8 @@ describe("workspace settings sync", () => {
         defaultToolOutputOverflowChars: 12000,
         subAgentModel: "gpt-5-mini",
         maxSteps: 75,
+        userName: "Alex",
+        userProfile: { instructions: "", work: "", details: "" },
       },
     });
 
@@ -469,6 +471,8 @@ describe("workspace settings sync", () => {
         toolOutputOverflowChars: 25000,
         subAgentModel: "gpt-5-mini",
         maxSteps: 75,
+        userName: "Alex",
+        userProfile: { instructions: "", work: "", details: "" },
       },
     });
 
@@ -588,6 +592,8 @@ describe("workspace settings sync", () => {
         toolOutputOverflowChars: 25000,
         subAgentModel: "gpt-5-mini",
         maxSteps: 75,
+        userName: "Alex",
+        userProfile: { instructions: "", work: "", details: "" },
       },
     });
 
@@ -690,6 +696,8 @@ describe("workspace settings sync", () => {
         toolOutputOverflowChars: 25000,
         subAgentModel: "gpt-5.2",
         maxSteps: 75,
+        userName: "Alex",
+        userProfile: { instructions: "", work: "", details: "" },
       },
     });
 
@@ -722,6 +730,8 @@ describe("workspace settings sync", () => {
         defaultToolOutputOverflowChars: 12000,
         subAgentModel: "gpt-5.2",
         maxSteps: 75,
+        userName: "Alex",
+        userProfile: { instructions: "", work: "", details: "" },
       },
     });
 
@@ -766,6 +776,8 @@ describe("workspace settings sync", () => {
         defaultToolOutputOverflowChars: 12000,
         subAgentModel: "gpt-5.2",
         maxSteps: 75,
+        userName: "Alex",
+        userProfile: { instructions: "", work: "", details: "" },
       },
     });
 
@@ -783,6 +795,8 @@ describe("workspace settings sync", () => {
         defaultToolOutputOverflowChars: 12000,
         subAgentModel: "gpt-5.2",
         maxSteps: 75,
+        userName: "Alex",
+        userProfile: { instructions: "", work: "", details: "" },
       },
     });
 

--- a/apps/desktop/test/workspaces-page.test.ts
+++ b/apps/desktop/test/workspaces-page.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, mock, test } from "bun:test";
-import { createElement } from "react";
+import { JSDOM } from "jsdom";
+import { createElement, StrictMode } from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
 
 const MOCK_SYSTEM_APPEARANCE = {
@@ -67,10 +70,56 @@ mock.module("../src/lib/agentSocket", () => ({
   },
 }));
 
+type JsdomHarness = {
+  dom: JSDOM;
+  restore: () => void;
+};
+
+function setupJsdom(): JsdomHarness {
+  const dom = new JSDOM("<!doctype html><html><body><div id='root'></div></body></html>", {
+    url: "http://localhost",
+  });
+  const saved = {
+    window: globalThis.window,
+    document: globalThis.document,
+    navigator: globalThis.navigator,
+    HTMLElement: globalThis.HTMLElement,
+    Node: globalThis.Node,
+    getComputedStyle: globalThis.getComputedStyle,
+    actEnv: (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT,
+  };
+
+  Object.assign(globalThis, {
+    window: dom.window,
+    document: dom.window.document,
+    navigator: dom.window.navigator,
+    HTMLElement: dom.window.HTMLElement,
+    Node: dom.window.Node,
+    getComputedStyle: dom.window.getComputedStyle.bind(dom.window),
+  });
+  (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+  return {
+    dom,
+    restore: () => {
+      globalThis.window = saved.window;
+      globalThis.document = saved.document;
+      globalThis.navigator = saved.navigator;
+      globalThis.HTMLElement = saved.HTMLElement;
+      globalThis.Node = saved.Node;
+      globalThis.getComputedStyle = saved.getComputedStyle;
+      (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = saved.actEnv;
+      dom.window.close();
+    },
+  };
+}
+
 const {
   OpenAiCompatibleModelSettingsCard,
   WorkspaceUserProfileCard,
 } = await import("../src/ui/settings/pages/WorkspacesPage");
+const App = (await import("../src/App")).default;
+const { useAppStore } = await import("../src/app/store");
 
 describe("desktop workspaces page", () => {
   test("renders workspace controls for openai-compatible verbosity, reasoning effort, and reasoning summary", () => {
@@ -124,5 +173,145 @@ describe("desktop workspaces page", () => {
     expect(html).toContain("Work / Job");
     expect(html).toContain("Instructions");
     expect(html).toContain("Details Agent Should Know");
+  });
+
+  test("typing into workspace profile fields does not trigger a render loop", async () => {
+    const harness = setupJsdom();
+    const realError = console.error;
+    const consoleErrors: string[] = [];
+    console.error = (...args: unknown[]) => {
+      consoleErrors.push(args.map((arg) => String(arg)).join(" "));
+    };
+
+    try {
+      const container = harness.dom.window.document.getElementById("root");
+      if (!container) throw new Error("missing root");
+      const root = createRoot(container);
+
+      await act(async () => {
+        root.render(
+          createElement(
+            StrictMode,
+            null,
+            createElement(WorkspaceUserProfileCard, {
+              workspace: {
+                id: "ws-1",
+                userName: "Alex",
+                userProfile: {
+                  instructions: "",
+                  work: "",
+                  details: "",
+                },
+              },
+              updateWorkspaceDefaults: async () => {},
+            }),
+          ),
+        );
+      });
+
+      const textarea = container.querySelector('[aria-label="Workspace work context"]');
+      if (!(textarea instanceof harness.dom.window.HTMLTextAreaElement)) {
+        throw new Error("missing workspace work context textarea");
+      }
+
+      await act(async () => {
+        textarea.value = "Platform engineer";
+        textarea.dispatchEvent(new harness.dom.window.Event("input", { bubbles: true }));
+        textarea.dispatchEvent(new harness.dom.window.Event("change", { bubbles: true }));
+      });
+
+      expect(container.textContent).toContain("User Profile Context");
+      expect(textarea.value).toBe("Platform engineer");
+      expect(consoleErrors.some((entry) => entry.includes("Maximum update depth exceeded"))).toBe(false);
+
+      await act(async () => {
+        root.unmount();
+      });
+    } finally {
+      console.error = realError;
+      harness.restore();
+    }
+  });
+
+  test("typing into workspace profile fields does not blank the full settings app", async () => {
+    const harness = setupJsdom();
+    const realError = console.error;
+    const consoleErrors: string[] = [];
+    console.error = (...args: unknown[]) => {
+      consoleErrors.push(args.map((arg) => String(arg)).join(" "));
+    };
+
+    useAppStore.setState({
+      ready: true,
+      startupError: null,
+      view: "settings",
+      settingsPage: "workspaces",
+      lastNonSettingsView: "chat",
+      workspaces: [
+        {
+          id: "ws-1",
+          name: "Workspace 1",
+          path: "/tmp/workspace-1",
+          createdAt: "2026-03-12T00:00:00.000Z",
+          lastOpenedAt: "2026-03-12T00:00:00.000Z",
+          defaultProvider: "openai",
+          defaultModel: "gpt-5.4",
+          defaultSubAgentModel: "gpt-5.4",
+          defaultEnableMcp: true,
+          defaultBackupsEnabled: true,
+          yolo: false,
+          userName: "",
+          userProfile: {
+            instructions: "",
+            work: "",
+            details: "",
+          },
+        },
+      ],
+      selectedWorkspaceId: "ws-1",
+      selectedThreadId: null,
+      threads: [],
+      threadRuntimeById: {},
+      workspaceRuntimeById: {},
+    });
+
+    try {
+      const container = harness.dom.window.document.getElementById("root");
+      if (!container) throw new Error("missing root");
+      const root = createRoot(container);
+
+      await act(async () => {
+        root.render(
+          createElement(
+            StrictMode,
+            null,
+            createElement(App),
+          ),
+        );
+      });
+
+      const textarea = container.querySelector('[aria-label="Workspace work context"]');
+      if (!(textarea instanceof harness.dom.window.HTMLTextAreaElement)) {
+        throw new Error("missing workspace work context textarea");
+      }
+
+      await act(async () => {
+        textarea.value = "Platform engineer";
+        textarea.dispatchEvent(new harness.dom.window.Event("input", { bubbles: true }));
+        textarea.dispatchEvent(new harness.dom.window.Event("change", { bubbles: true }));
+        textarea.dispatchEvent(new harness.dom.window.FocusEvent("blur", { bubbles: true }));
+      });
+
+      expect(container.textContent).toContain("User Profile Context");
+      expect(container.textContent).toContain("Workspace 1");
+      expect(consoleErrors.some((entry) => entry.includes("Maximum update depth exceeded"))).toBe(false);
+
+      await act(async () => {
+        root.unmount();
+      });
+    } finally {
+      console.error = realError;
+      harness.restore();
+    }
   });
 });

--- a/apps/desktop/test/workspaces-page.test.ts
+++ b/apps/desktop/test/workspaces-page.test.ts
@@ -67,7 +67,10 @@ mock.module("../src/lib/agentSocket", () => ({
   },
 }));
 
-const { OpenAiCompatibleModelSettingsCard } = await import("../src/ui/settings/pages/WorkspacesPage");
+const {
+  OpenAiCompatibleModelSettingsCard,
+  WorkspaceUserProfileCard,
+} = await import("../src/ui/settings/pages/WorkspacesPage");
 
 describe("desktop workspaces page", () => {
   test("renders workspace controls for openai-compatible verbosity, reasoning effort, and reasoning summary", () => {
@@ -98,5 +101,28 @@ describe("desktop workspaces page", () => {
     expect(html).toContain("Verbosity");
     expect(html).toContain("Reasoning effort");
     expect(html).toContain("Reasoning summary");
+  });
+
+  test("renders workspace controls for user profile context", () => {
+    const html = renderToStaticMarkup(
+      createElement(WorkspaceUserProfileCard, {
+        workspace: {
+          id: "ws-1",
+          userName: "Alex",
+          userProfile: {
+            instructions: "Keep answers terse.",
+            work: "Platform engineer",
+            details: "Prefers Bun and TypeScript",
+          },
+        },
+        updateWorkspaceDefaults: async () => {},
+      }),
+    );
+
+    expect(html).toContain("User Profile Context");
+    expect(html).toContain("Name");
+    expect(html).toContain("Work / Job");
+    expect(html).toContain("Instructions");
+    expect(html).toContain("Details Agent Should Know");
   });
 });

--- a/docs/websocket-protocol.md
+++ b/docs/websocket-protocol.md
@@ -177,7 +177,7 @@ When a WebSocket connection opens, the server sends these events in order:
 
 1. `server_hello` — session ID, config, protocol version, capabilities
 2. `session_settings` — current runtime settings (e.g. MCP toggle)
-3. `session_config` — current runtime config (`yolo`, `observabilityEnabled`, `backupsEnabled`, `defaultBackupsEnabled`, `toolOutputOverflowChars`, `defaultToolOutputOverflowChars`, `subAgentModel`, `maxSteps`, `providerOptions`)
+3. `session_config` — current runtime config (`yolo`, `observabilityEnabled`, `backupsEnabled`, `defaultBackupsEnabled`, `toolOutputOverflowChars`, `defaultToolOutputOverflowChars`, `subAgentModel`, `maxSteps`, `providerOptions`, `userName`, `userProfile`)
 4. `session_info` — session metadata including title
 5. `observability_status` — Langfuse observability state
 6. `provider_catalog` — available providers and models (async)
@@ -1790,6 +1790,11 @@ Update runtime configuration values.
 | `config.providerOptions.codex-cli.reasoningEffort` | `"none" \| "low" \| "medium" \| "high" \| "xhigh"` | No | Codex CLI reasoning effort |
 | `config.providerOptions.codex-cli.reasoningSummary` | `"auto" \| "concise" \| "detailed"` | No | Codex CLI reasoning summary |
 | `config.providerOptions.codex-cli.textVerbosity` | `"low" \| "medium" \| "high"` | No | Codex CLI verbosity |
+| `config.userProfile` | `object` | No | User profile patch merged into persisted workspace config |
+| `config.userName` | `string` | No | User name used for prompt injection |
+| `config.userProfile.instructions` | `string` | No | Custom behavioral instructions the agent should follow |
+| `config.userProfile.work` | `string` | No | Work/job context for prompt injection |
+| `config.userProfile.details` | `string` | No | Extra user details the agent should know |
 
 **Response:** `session_config`
 
@@ -3147,6 +3152,11 @@ Current runtime config. Sent on connection and after `set_config`.
 | `config.subAgentModel` | `string` | Sub-agent model identifier |
 | `config.maxSteps` | `number` | Maximum steps per turn |
 | `config.providerOptions` | `object?` | Editable OpenAI-compatible provider options when configured |
+| `config.userName` | `string` | Effective user name |
+| `config.userProfile` | `object` | Effective user profile metadata used for prompt injection |
+| `config.userProfile.instructions` | `string` | Effective profile instructions |
+| `config.userProfile.work` | `string` | Effective profile work/job context |
+| `config.userProfile.details` | `string` | Effective profile details |
 | `config.providerOptions.openai.reasoningEffort` | `"none" \| "low" \| "medium" \| "high" \| "xhigh"` | Current editable OpenAI reasoning effort |
 | `config.providerOptions.openai.reasoningSummary` | `"auto" \| "concise" \| "detailed"` | Current editable OpenAI reasoning summary |
 | `config.providerOptions.openai.textVerbosity` | `"low" \| "medium" \| "high"` | Current editable OpenAI verbosity |

--- a/docs/websocket-protocol.md
+++ b/docs/websocket-protocol.md
@@ -1790,11 +1790,11 @@ Update runtime configuration values.
 | `config.providerOptions.codex-cli.reasoningEffort` | `"none" \| "low" \| "medium" \| "high" \| "xhigh"` | No | Codex CLI reasoning effort |
 | `config.providerOptions.codex-cli.reasoningSummary` | `"auto" \| "concise" \| "detailed"` | No | Codex CLI reasoning summary |
 | `config.providerOptions.codex-cli.textVerbosity` | `"low" \| "medium" \| "high"` | No | Codex CLI verbosity |
-| `config.userProfile` | `object` | No | User profile patch merged into persisted workspace config |
-| `config.userName` | `string` | No | User name used for prompt injection |
-| `config.userProfile.instructions` | `string` | No | Custom behavioral instructions the agent should follow |
-| `config.userProfile.work` | `string` | No | Work/job context for prompt injection |
-| `config.userProfile.details` | `string` | No | Extra user details the agent should know |
+| `config.userProfile` | `object` | No | User profile patch merged into persisted workspace config. Empty-string fields clear the corresponding prompt context |
+| `config.userName` | `string` | No | User name used for prompt injection. An empty string clears it |
+| `config.userProfile.instructions` | `string` | No | Custom behavioral instructions the agent should follow. An empty string clears it |
+| `config.userProfile.work` | `string` | No | Work/job context for prompt injection. An empty string clears it |
+| `config.userProfile.details` | `string` | No | Extra user details the agent should know. An empty string clears it |
 
 **Response:** `session_config`
 

--- a/prompts/system-models/claude-haiku-4-5.md
+++ b/prompts/system-models/claude-haiku-4-5.md
@@ -7,7 +7,10 @@ You are a fast, efficient local AI agent specializing in software engineering, f
 - Current date: {{currentDate}}
 - Current year: {{currentYear}}
 - Model: {{modelName}}
-- User name: {{userName}} (if provided)
+- User name: {{userName}}
+- User profile work/job: {{userProfileWork}}
+- User profile instructions: {{userProfileInstructions}}
+- User profile details the agent should know: {{userProfileDetails}}
 - Knowledge cutoff: {{knowledgeCutoff}} (search the web for anything that may have changed after this date)
 
 <directory_structure>

--- a/prompts/system-models/claude-opus-4-6.md
+++ b/prompts/system-models/claude-opus-4-6.md
@@ -7,7 +7,10 @@ You are a highly capable local AI agent specializing in software engineering, fi
 - Current date: {{currentDate}}
 - Current year: {{currentYear}}
 - Model: {{modelName}}
-- User name: {{userName}} (if provided)
+- User name: {{userName}}
+- User profile work/job: {{userProfileWork}}
+- User profile instructions: {{userProfileInstructions}}
+- User profile details the agent should know: {{userProfileDetails}}
 - Knowledge cutoff: {{knowledgeCutoff}} (search the web for anything that may have changed after this date)
 
 <directory_structure>

--- a/prompts/system-models/claude-sonnet-4-6.md
+++ b/prompts/system-models/claude-sonnet-4-6.md
@@ -7,7 +7,10 @@ You are a highly capable local AI agent specializing in software engineering, fi
 - Current date: {{currentDate}}
 - Current year: {{currentYear}}
 - Model: {{modelName}}
-- User name: {{userName}} (if provided)
+- User name: {{userName}}
+- User profile work/job: {{userProfileWork}}
+- User profile instructions: {{userProfileInstructions}}
+- User profile details the agent should know: {{userProfileDetails}}
 - Knowledge cutoff: {{knowledgeCutoff}} (search the web for anything that may have changed after this date)
 
 <directory_structure>

--- a/prompts/system-models/gemini-3-flash-preview.md
+++ b/prompts/system-models/gemini-3-flash-preview.md
@@ -6,7 +6,10 @@ You are a direct, action-oriented AI assistant running locally on the user's com
 - Current date: {{currentDate}}
 - Current year: {{currentYear}}
 - Model: {{modelName}}
-- User name: {{userName}} (if provided)
+- User name: {{userName}}
+- User profile work/job: {{userProfileWork}}
+- User profile instructions: {{userProfileInstructions}}
+- User profile details the agent should know: {{userProfileDetails}}
 - Knowledge cutoff: {{knowledgeCutoff}} (search the web for anything that may have changed after this date)
 
 ## Directory Structure

--- a/prompts/system-models/gemini-3-pro-preview.md
+++ b/prompts/system-models/gemini-3-pro-preview.md
@@ -11,7 +11,10 @@ This model's reasoning is optimized for temperature 1.0. Do not adjust temperatu
 - Current date: {{currentDate}}
 - Current year: {{currentYear}}
 - Model: {{modelName}}
-- User name: {{userName}} (if provided)
+- User name: {{userName}}
+- User profile work/job: {{userProfileWork}}
+- User profile instructions: {{userProfileInstructions}}
+- User profile details the agent should know: {{userProfileDetails}}
 - Knowledge cutoff: {{knowledgeCutoff}} (search the web for anything that may have changed after this date)
 
 <directory_structure>

--- a/prompts/system-models/gpt-5.2.md
+++ b/prompts/system-models/gpt-5.2.md
@@ -15,7 +15,10 @@ You follow instructions more literally than previous GPT models. This is a stren
 - Current date: {{currentDate}}
 - Current year: {{currentYear}}
 - Model: {{modelName}}
-- User name: {{userName}} (if provided)
+- User name: {{userName}}
+- User profile work/job: {{userProfileWork}}
+- User profile instructions: {{userProfileInstructions}}
+- User profile details the agent should know: {{userProfileDetails}}
 - Knowledge cutoff: {{knowledgeCutoff}} (search the web for anything that may have changed after this date)
 - Role context: This prompt is delivered via the developer role (not the legacy system role).
 

--- a/prompts/system-models/gpt-5.4.md
+++ b/prompts/system-models/gpt-5.4.md
@@ -15,7 +15,10 @@ You follow instructions more literally than previous GPT models. This is a stren
 - Current date: {{currentDate}}
 - Current year: {{currentYear}}
 - Model: {{modelName}}
-- User name: {{userName}} (if provided)
+- User name: {{userName}}
+- User profile work/job: {{userProfileWork}}
+- User profile instructions: {{userProfileInstructions}}
+- User profile details the agent should know: {{userProfileDetails}}
 - Knowledge cutoff: {{knowledgeCutoff}} (search the web for anything that may have changed after this date)
 - Role context: This prompt is delivered via the developer role (not the legacy system role).
 

--- a/prompts/system.md
+++ b/prompts/system.md
@@ -6,7 +6,10 @@ You are an AI assistant running locally on the user's computer. You have direct 
 - Current date: {{currentDate}}
 - Current year: {{currentYear}}
 - Model: {{modelName}}
-- User name: {{userName}} (if provided)
+- User name: {{userName}}
+- User profile work/job: {{userProfileWork}}
+- User profile instructions: {{userProfileInstructions}}
+- User profile details the agent should know: {{userProfileDetails}}
 - Knowledge cutoff: {{knowledgeCutoff}} (search the web for anything that may have changed after this date)
 
 ## Directory Structure

--- a/src/config.ts
+++ b/src/config.ts
@@ -172,6 +172,11 @@ const harnessLayerSchema = z.object({
 const modelSettingsLayerSchema = z.object({
   maxRetries: nonNegativeIntegerLikeSchema.optional(),
 }).passthrough();
+const userProfileLayerSchema = z.object({
+  instructions: z.string().optional(),
+  work: z.string().optional(),
+  details: z.string().optional(),
+}).passthrough();
 
 function parseCommandConfig(raw: unknown): AgentConfig["command"] | undefined {
   if (raw === undefined) return undefined;
@@ -365,6 +370,16 @@ export async function loadConfig(options: LoadConfigOptions = {}): Promise<Agent
     asNonEmptyString(userConfig.userName) ||
     asString(builtInDefaults.userName) ||
     "";
+  const mergedUserProfile = parseLayer(
+    userProfileLayerSchema,
+    (merged as Record<string, unknown>).userProfile,
+    {},
+  );
+  const userProfile = {
+    instructions: asString(mergedUserProfile.instructions) ?? "",
+    work: asString(mergedUserProfile.work) ?? "",
+    details: asString(mergedUserProfile.details) ?? "",
+  };
   const knowledgeCutoff = supportedModel.knowledgeCutoff;
 
   const enableMcp =
@@ -459,6 +474,7 @@ export async function loadConfig(options: LoadConfigOptions = {}): Promise<Agent
     outputDirectory,
     uploadsDirectory,
     userName,
+    userProfile,
     knowledgeCutoff,
 
     projectAgentDir,

--- a/src/config.ts
+++ b/src/config.ts
@@ -226,6 +226,11 @@ function asString(v: unknown): string | undefined {
   return parsed.success ? parsed.data : undefined;
 }
 
+function asTrimmedString(v: unknown): string | undefined {
+  const parsed = stringSchema.safeParse(v);
+  return parsed.success ? parsed.data.trim() : undefined;
+}
+
 function asBoolean(v: unknown): boolean | null {
   const parsed = booleanLikeSchema.safeParse(v);
   return parsed.success ? parsed.data : null;
@@ -364,12 +369,7 @@ export async function loadConfig(options: LoadConfigOptions = {}): Promise<Agent
     undefined;
   const uploadsDirectory = uploadsDirRaw ? resolveDir(uploadsDirRaw, cwd) : undefined;
 
-  const userName =
-    asNonEmptyString(env.AGENT_USER_NAME) ||
-    asNonEmptyString(projectConfig.userName) ||
-    asNonEmptyString(userConfig.userName) ||
-    asString(builtInDefaults.userName) ||
-    "";
+  const userName = asTrimmedString(env.AGENT_USER_NAME) ?? asTrimmedString((merged as Record<string, unknown>).userName) ?? "";
   const mergedUserProfile = parseLayer(
     userProfileLayerSchema,
     (merged as Record<string, unknown>).userProfile,

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -23,6 +23,16 @@ function stripPromptLine(prompt: string, matcher: RegExp): string {
     .join("\n");
 }
 
+function injectTemplateVariable(prompt: string, key: string, value: string): string {
+  if (value.trim().length > 0) {
+    const tokenRegex = new RegExp(`\{\{${key}\}\}`, "g");
+    return prompt.replace(tokenRegex, value);
+  }
+
+  const lineRegex = new RegExp(`^.*\{\{${key}\}\}.*(?:\r?\n|$)`, "gm");
+  return prompt.replace(lineRegex, "");
+}
+
 function renderCapabilitySpecificPrompt(prompt: string, supportedModel: SupportedModel): string {
   if (supportedModel.supportsImageInput) return prompt;
 
@@ -145,6 +155,9 @@ export async function loadSystemPromptWithSkills(config: AgentConfig): Promise<S
     currentYear: new Date().getFullYear().toString(),
     modelName: supportedModel.displayName,
     userName: config.userName || "",
+    userProfileInstructions: config.userProfile?.instructions || "",
+    userProfileWork: config.userProfile?.work || "",
+    userProfileDetails: config.userProfile?.details || "",
     knowledgeCutoff: supportedModel.knowledgeCutoff,
     skillNames: skillNames || '"pdf", "doc", "slides", "spreadsheet"',
     skillExamples:
@@ -157,9 +170,9 @@ export async function loadSystemPromptWithSkills(config: AgentConfig): Promise<S
       ].join("\n"),
   };
 
-  prompt = prompt.replace(/{{(\w+)}}/g, (match, key) => {
-    return Object.prototype.hasOwnProperty.call(vars, key) ? vars[key] : match;
-  });
+  for (const [key, value] of Object.entries(vars)) {
+    prompt = injectTemplateVariable(prompt, key, value);
+  }
   prompt = renderCapabilitySpecificPrompt(prompt, supportedModel);
 
   prompt += `\n\n${buildSkillPolicySection(vars.skillNames, vars.skillExamples, config)}`;

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -23,14 +23,20 @@ function stripPromptLine(prompt: string, matcher: RegExp): string {
     .join("\n");
 }
 
-function injectTemplateVariable(prompt: string, key: string, value: string): string {
-  if (value.trim().length > 0) {
-    const tokenRegex = new RegExp(`\{\{${key}\}\}`, "g");
-    return prompt.replace(tokenRegex, value);
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function renderTemplateVariables(prompt: string, vars: Record<string, string>): string {
+  let out = prompt;
+
+  for (const [key, value] of Object.entries(vars)) {
+    if (value.trim().length > 0) continue;
+    const lineRegex = new RegExp(`^.*\\{\\{${escapeRegExp(key)}\\}\\}.*(?:\\r?\\n|$)`, "gm");
+    out = out.replace(lineRegex, "");
   }
 
-  const lineRegex = new RegExp(`^.*\{\{${key}\}\}.*(?:\r?\n|$)`, "gm");
-  return prompt.replace(lineRegex, "");
+  return out.replace(/\{\{([A-Za-z0-9_]+)\}\}/g, (match, key: string) => vars[key] ?? match);
 }
 
 function renderCapabilitySpecificPrompt(prompt: string, supportedModel: SupportedModel): string {
@@ -170,9 +176,7 @@ export async function loadSystemPromptWithSkills(config: AgentConfig): Promise<S
       ].join("\n"),
   };
 
-  for (const [key, value] of Object.entries(vars)) {
-    prompt = injectTemplateVariable(prompt, key, value);
-  }
+  prompt = renderTemplateVariables(prompt, vars);
   prompt = renderCapabilitySpecificPrompt(prompt, supportedModel);
 
   prompt += `\n\n${buildSkillPolicySection(vars.skillNames, vars.skillExamples, config)}`;

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -37,6 +37,12 @@ export type SessionConfigPatch = {
   toolOutputOverflowChars?: number | null;
   clearToolOutputOverflowChars?: boolean;
   providerOptions?: OpenAiCompatibleProviderOptionsByProvider;
+  userName?: string;
+  userProfile?: {
+    instructions?: string;
+    work?: string;
+    details?: string;
+  };
 };
 
 export type SessionConfigState = {
@@ -49,6 +55,12 @@ export type SessionConfigState = {
   toolOutputOverflowChars: number | null;
   defaultToolOutputOverflowChars?: number | null;
   providerOptions?: OpenAiCompatibleProviderOptionsByProvider;
+  userName: string;
+  userProfile: {
+    instructions: string;
+    work: string;
+    details: string;
+  };
 };
 
 export type ClientMessage =

--- a/src/server/protocolEventParser.ts
+++ b/src/server/protocolEventParser.ts
@@ -385,6 +385,12 @@ const serverEventSchema = z.discriminatedUnion("type", [
       toolOutputOverflowChars: z.number().int().nonnegative().nullable(),
       defaultToolOutputOverflowChars: z.number().int().nonnegative().nullable().optional(),
       providerOptions: editableOpenAiProviderOptionsByProviderSchema.optional(),
+      userName: z.string(),
+      userProfile: z.object({
+        instructions: z.string(),
+        work: z.string(),
+        details: z.string(),
+      }).passthrough(),
     }).passthrough(),
   }).passthrough(),
   z.object({

--- a/src/server/protocolParser.ts
+++ b/src/server/protocolParser.ts
@@ -31,7 +31,7 @@ const setConfigFieldErrorMessages: Record<string, string> = {
   toolOutputOverflowChars: "set_config config.toolOutputOverflowChars must be null or non-negative integer",
   clearToolOutputOverflowChars: "set_config config.clearToolOutputOverflowChars must be boolean",
   providerOptions: "set_config config.providerOptions must be an object",
-  userName: "set_config config.userName must be non-empty string",
+  userName: "set_config config.userName must be string",
   userProfile: "set_config config.userProfile must be an object",
 };
 
@@ -96,7 +96,7 @@ const setConfigPayloadSchema = z.object({
   toolOutputOverflowChars: z.number().int().nonnegative().nullable().optional(),
   clearToolOutputOverflowChars: z.boolean().optional(),
   providerOptions: editableOpenAiProviderOptionsByProviderSchema.optional(),
-  userName: z.string().trim().min(1).optional(),
+  userName: z.string().optional(),
   userProfile: z.object({
     instructions: z.string().optional(),
     work: z.string().optional(),

--- a/src/server/protocolParser.ts
+++ b/src/server/protocolParser.ts
@@ -31,6 +31,8 @@ const setConfigFieldErrorMessages: Record<string, string> = {
   toolOutputOverflowChars: "set_config config.toolOutputOverflowChars must be null or non-negative integer",
   clearToolOutputOverflowChars: "set_config config.clearToolOutputOverflowChars must be boolean",
   providerOptions: "set_config config.providerOptions must be an object",
+  userName: "set_config config.userName must be non-empty string",
+  userProfile: "set_config config.userProfile must be an object",
 };
 
 function requiredString(message: string): z.ZodType<string> {
@@ -94,6 +96,12 @@ const setConfigPayloadSchema = z.object({
   toolOutputOverflowChars: z.number().int().nonnegative().nullable().optional(),
   clearToolOutputOverflowChars: z.boolean().optional(),
   providerOptions: editableOpenAiProviderOptionsByProviderSchema.optional(),
+  userName: z.string().trim().min(1).optional(),
+  userProfile: z.object({
+    instructions: z.string().optional(),
+    work: z.string().optional(),
+    details: z.string().optional(),
+  }).passthrough().optional(),
 }).passthrough();
 
 const MAX_MCP_API_KEY_SIZE = 100_000;

--- a/src/server/session/AgentSession.ts
+++ b/src/server/session/AgentSession.ts
@@ -128,6 +128,7 @@ export class AgentSession {
   private readonly metadataManager: SessionMetadataManager;
   private readonly adminManager: SessionAdminManager;
   private readonly backupController: SessionBackupController;
+  private pendingConfigMutation: Promise<void> = Promise.resolve();
   private bufferDisconnectedEvents = false;
   private disconnectedReplayEvents: ServerEvent[] = [];
 
@@ -808,7 +809,9 @@ export class AgentSession {
   }
 
   async setConfig(patch: SessionConfigPatch) {
-    await this.metadataManager.setConfig(patch);
+    await this.enqueueConfigMutation(async () => {
+      await this.metadataManager.setConfig(patch);
+    });
   }
 
   async setBackupsEnabledOverride(backupsEnabledOverride: boolean | null) {
@@ -840,6 +843,7 @@ export class AgentSession {
   }
 
   async sendUserMessage(text: string, clientMessageId?: string, displayText?: string) {
+    await this.pendingConfigMutation.catch(() => {});
     await this.turnExecutionManager.sendUserMessage(text, clientMessageId, displayText);
   }
 
@@ -897,6 +901,12 @@ export class AgentSession {
 
   private queuePersistSessionSnapshot(reason: string) {
     this.persistenceManager.queuePersistSessionSnapshot(reason);
+  }
+
+  private enqueueConfigMutation(task: () => Promise<void>): Promise<void> {
+    const mutation = this.pendingConfigMutation.catch(() => {}).then(task);
+    this.pendingConfigMutation = mutation;
+    return mutation;
   }
 
   private getCoworkPaths() {

--- a/src/server/session/AgentSession.ts
+++ b/src/server/session/AgentSession.ts
@@ -1,4 +1,5 @@
 import { connectProvider as connectModelProvider, getAiCoworkerPaths, type ConnectProviderResult } from "../../connect";
+import { loadSystemPromptWithSkills } from "../../prompt";
 import { runTurn } from "../../agent";
 import { HarnessContextStore } from "../../harness/contextStore";
 import { SessionCostTracker } from "../../session/costTracker";
@@ -139,6 +140,7 @@ export class AgentSession {
     emit: (evt: ServerEvent) => void;
     connectProviderImpl?: typeof connectModelProvider;
     getAiCoworkerPathsImpl?: typeof getAiCoworkerPaths;
+    loadSystemPromptWithSkillsImpl?: typeof loadSystemPromptWithSkills;
     getProviderCatalogImpl?: typeof getProviderCatalog;
     getProviderStatusesImpl?: typeof getProviderStatuses;
     sessionBackupFactory?: SessionBackupFactory;
@@ -217,6 +219,7 @@ export class AgentSession {
     this.deps = {
       connectProviderImpl: opts.connectProviderImpl ?? connectModelProvider,
       getAiCoworkerPathsImpl: opts.getAiCoworkerPathsImpl ?? getAiCoworkerPaths,
+      loadSystemPromptWithSkillsImpl: opts.loadSystemPromptWithSkillsImpl ?? loadSystemPromptWithSkills,
       getProviderCatalogImpl: opts.getProviderCatalogImpl ?? getProviderCatalog,
       getProviderStatusesImpl: opts.getProviderStatusesImpl ?? getProviderStatuses,
       sessionBackupFactory:

--- a/src/server/session/SessionContext.ts
+++ b/src/server/session/SessionContext.ts
@@ -39,9 +39,10 @@ export type PersistedModelSelection = {
 export type PersistedProjectConfigPatch = Partial<
   Pick<
     AgentConfig,
-    "provider" | "model" | "subAgentModel" | "enableMcp" | "observabilityEnabled" | "backupsEnabled" | "toolOutputOverflowChars"
+    "provider" | "model" | "subAgentModel" | "enableMcp" | "observabilityEnabled" | "backupsEnabled" | "toolOutputOverflowChars" | "userName"
   >
 > & {
+  userProfile?: Partial<NonNullable<AgentConfig["userProfile"]>>;
   clearToolOutputOverflowChars?: boolean;
   providerOptions?: OpenAiCompatibleProviderOptionsByProvider;
 };

--- a/src/server/session/SessionContext.ts
+++ b/src/server/session/SessionContext.ts
@@ -1,4 +1,5 @@
 import type { connectProvider as connectModelProvider, ConnectProviderResult, getAiCoworkerPaths } from "../../connect";
+import type { loadSystemPromptWithSkills } from "../../prompt";
 import type { SessionCostTracker, SessionUsageSnapshot } from "../../session/costTracker";
 import type { runTurn } from "../../agent";
 import type { HarnessContextStore } from "../../harness/contextStore";
@@ -92,6 +93,7 @@ export type SessionRuntimeState = {
 export type SessionDependencies = {
   connectProviderImpl: typeof connectModelProvider;
   getAiCoworkerPathsImpl: typeof getAiCoworkerPaths;
+  loadSystemPromptWithSkillsImpl: typeof loadSystemPromptWithSkills;
   getProviderCatalogImpl: typeof getProviderCatalog;
   getProviderStatusesImpl: typeof getProviderStatuses;
   sessionBackupFactory: SessionBackupFactory;

--- a/src/server/session/SessionMetadataManager.ts
+++ b/src/server/session/SessionMetadataManager.ts
@@ -22,6 +22,21 @@ export class SessionMetadataManager {
     };
   }
 
+  private promptRefreshConfig(patch: SessionConfigPatch): AgentConfig {
+    return {
+      ...this.context.state.config,
+      ...(patch.userName !== undefined ? { userName: patch.userName } : {}),
+      ...(patch.userProfile !== undefined
+        ? {
+            userProfile: {
+              ...this.effectiveUserProfile(),
+              ...patch.userProfile,
+            },
+          }
+        : {}),
+    };
+  }
+
   getPublicConfig() {
     return {
       provider: this.context.state.config.provider,
@@ -201,6 +216,20 @@ export class SessionMetadataManager {
       }
     }
 
+    let refreshedSystemPrompt: Awaited<ReturnType<SessionContext["deps"]["loadSystemPromptWithSkillsImpl"]>> | null = null;
+    if (patch.userName !== undefined || patch.userProfile !== undefined) {
+      try {
+        refreshedSystemPrompt = await this.context.deps.loadSystemPromptWithSkillsImpl(this.promptRefreshConfig(patch));
+      } catch (err) {
+        this.context.emitError(
+          "internal_error",
+          "session",
+          `Failed to refresh system prompt: ${String(err)}`
+        );
+        return;
+      }
+    }
+
     const persistPatch: import("./SessionContext").PersistedProjectConfigPatch = {};
     if (normalizedSubAgentModel !== undefined) {
       persistPatch.subAgentModel = normalizedSubAgentModel;
@@ -297,6 +326,10 @@ export class SessionMetadataManager {
       };
     }
     if (patch.maxSteps !== undefined) this.context.state.maxSteps = patch.maxSteps;
+    if (refreshedSystemPrompt) {
+      this.context.state.system = refreshedSystemPrompt.prompt;
+      this.context.state.discoveredSkills = refreshedSystemPrompt.discoveredSkills;
+    }
 
     this.context.emit(this.getSessionConfigEvent());
     if (patch.backupsEnabled !== undefined) {

--- a/src/server/session/SessionMetadataManager.ts
+++ b/src/server/session/SessionMetadataManager.ts
@@ -13,6 +13,15 @@ import type { SessionContext } from "./SessionContext";
 export class SessionMetadataManager {
   constructor(private readonly context: SessionContext) {}
 
+  private effectiveUserProfile() {
+    const profile = this.context.state.config.userProfile;
+    return {
+      instructions: profile?.instructions ?? "",
+      work: profile?.work ?? "",
+      details: profile?.details ?? "",
+    };
+  }
+
   getPublicConfig() {
     return {
       provider: this.context.state.config.provider,
@@ -49,6 +58,8 @@ export class SessionMetadataManager {
         toolOutputOverflowChars,
         ...(defaultToolOutputOverflowChars !== undefined ? { defaultToolOutputOverflowChars } : {}),
         ...(providerOptions ? { providerOptions } : {}),
+        userName: this.context.state.config.userName,
+        userProfile: this.effectiveUserProfile(),
       },
     };
   }
@@ -209,6 +220,12 @@ export class SessionMetadataManager {
     if (patch.providerOptions !== undefined) {
       persistPatch.providerOptions = patch.providerOptions;
     }
+    if (patch.userName !== undefined) {
+      persistPatch.userName = patch.userName;
+    }
+    if (patch.userProfile !== undefined) {
+      persistPatch.userProfile = patch.userProfile;
+    }
     if (Object.keys(persistPatch).length > 0 && this.context.deps.persistProjectConfigPatchImpl) {
       try {
         await this.context.deps.persistProjectConfigPatchImpl(persistPatch);
@@ -262,6 +279,21 @@ export class SessionMetadataManager {
           this.context.state.config.providerOptions,
           patch.providerOptions,
         ),
+      };
+    }
+    if (patch.userName !== undefined) {
+      this.context.state.config = {
+        ...this.context.state.config,
+        userName: patch.userName,
+      };
+    }
+    if (patch.userProfile !== undefined) {
+      this.context.state.config = {
+        ...this.context.state.config,
+        userProfile: {
+          ...this.effectiveUserProfile(),
+          ...patch.userProfile,
+        },
       };
     }
     if (patch.maxSteps !== undefined) this.context.state.maxSteps = patch.maxSteps;

--- a/src/server/startServer.ts
+++ b/src/server/startServer.ts
@@ -78,9 +78,10 @@ async function persistProjectConfigPatch(
   patch: Partial<
     Pick<
       AgentConfig,
-      "provider" | "model" | "subAgentModel" | "enableMcp" | "observabilityEnabled" | "backupsEnabled" | "toolOutputOverflowChars"
+      "provider" | "model" | "subAgentModel" | "enableMcp" | "observabilityEnabled" | "backupsEnabled" | "toolOutputOverflowChars" | "userName"
     >
   > & {
+    userProfile?: Partial<NonNullable<AgentConfig["userProfile"]>>;
     clearToolOutputOverflowChars?: boolean;
     providerOptions?: OpenAiCompatibleProviderOptionsByProvider;
   },
@@ -122,6 +123,14 @@ async function persistProjectConfigPatch(
       next[key] = Object.keys(currentProviderOptions).length > 0 ? currentProviderOptions : undefined;
       continue;
     }
+    if (key === "userProfile" && isPlainObject(value)) {
+      const currentUserProfile = isPlainObject(current.userProfile) ? current.userProfile : {};
+      next[key] = {
+        ...currentUserProfile,
+        ...value,
+      };
+      continue;
+    }
     next[key] = value;
   }
   if (shouldClearToolOutputOverflowChars) {
@@ -137,9 +146,10 @@ function mergeConfigPatch(
   patch: Partial<
     Pick<
       AgentConfig,
-      "provider" | "model" | "subAgentModel" | "enableMcp" | "observabilityEnabled" | "backupsEnabled" | "toolOutputOverflowChars"
+      "provider" | "model" | "subAgentModel" | "enableMcp" | "observabilityEnabled" | "backupsEnabled" | "toolOutputOverflowChars" | "userName"
     >
   > & {
+    userProfile?: Partial<NonNullable<AgentConfig["userProfile"]>>;
     clearToolOutputOverflowChars?: boolean;
     providerOptions?: OpenAiCompatibleProviderOptionsByProvider;
   }
@@ -159,6 +169,12 @@ function mergeConfigPatch(
   }
   if (patch.providerOptions !== undefined) {
     next.providerOptions = mergeEditableOpenAiCompatibleProviderOptions(config.providerOptions, patch.providerOptions);
+  }
+  if (patch.userProfile !== undefined) {
+    next.userProfile = {
+      ...config.userProfile,
+      ...patch.userProfile,
+    };
   }
   return next;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,6 +58,12 @@ export interface ModelRuntimeSettings {
   maxRetries?: number;
 }
 
+export interface UserProfile {
+  instructions?: string;
+  work?: string;
+  details?: string;
+}
+
 export interface AgentConfig {
   provider: ProviderName;
   runtime?: RuntimeName;
@@ -82,6 +88,7 @@ export interface AgentConfig {
   uploadsDirectory?: string;
 
   userName: string;
+  userProfile?: UserProfile;
   knowledgeCutoff: string;
 
   projectAgentDir: string;

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -92,3 +92,5 @@
 - When a review surfaces a missing provider capability, verify the repo’s intended product contract before turning it into a bug; `opencode-go` intentionally has no local pricing or pricing overrides here.
 - When a tool has both saved credentials and environment fallback, match the repo’s standard precedence: user-saved auth should win over ambient shell env unless the product explicitly says otherwise.
 - When the user supplies an authoritative model-cutoff table mid-implementation, stop and update the registry assumptions immediately instead of continuing to churn around older local defaults or partial web results.
+- When adding profile metadata, do not introduce a second name field; keep identity sourced from existing `userName` unless the user explicitly asks for a separate profile-name concept.
+- For optional prompt metadata fields, do not leave placeholder labels like "(if provided)" in templates; injection should conditionally remove whole lines when values are empty.

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,6 +1,7 @@
 # Lessons
 
 - When the user explicitly changes a CI request from “narrow the trigger” to “delete the workflow,” stop refining the trigger and remove the job/workflow exactly as requested.
+- When the user expands a bugfix to include verification failures found during the lane, treat every concrete error you surfaced as in-scope work instead of stopping after the original fix.
 - For expensive environment-backed CI in this repo, never leave the heavy job gated only on `event_name != 'pull_request'`; explicitly scope it to the intended branch or manual dispatch so ordinary `main` pushes do not burn the testing environment.
 - For automated PR review bots in this repo, optimize for unresolved findings only: cancel in-flight review runs when a PR closes, skip drafts, disable public session-share noise, and never post long “everything looks good now” summaries.
 - When finishing PR review work in this repo, do not stop at local code/test changes; reply on each completed GitHub review thread and resolve it in the PR in the same pass.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -218,18 +218,28 @@
 - [x] Add regression coverage and run the required verification commands, then record the results here.
 
 ## Review
-- Added `src/shared/displayCitationMarkers.ts` to normalize stored raw citation markers into display-safe output for both desktop and TUI rendering. Resolvable citations are rendered as superscript links; unresolvable citations are removed entirely so the message text does not keep stray numbers or spacing artifacts.
-- Desktop message rendering now hydrates citation URLs from both inline `webSearch` results and overflow spill files, which fixes missing later-source links in long search outputs. The same shared citation normalization is also wired into the TUI markdown path so both clients present the same user-facing contract.
-- Added regressions in `test/displayCitationMarkers.test.ts` and `apps/desktop/test/message-links.test.ts` covering linked superscripts, missing-link elision, repeated citation handling, and overflow-backed URL recovery.
-- Verification:
-  - `~/.bun/bin/bun test test/displayCitationMarkers.test.ts apps/desktop/test/message-links.test.ts --bail` -> pass (`17 pass, 0 fail`)
-  - `~/.bun/bin/bun test` -> fails only in the external remote MCP coverage: `runTurn + remote MCP (mcp.grep.app) > loads the remote MCP tools and can execute them via the tools passed to streamText` returned `Streamable HTTP error ... 500: Internal Server Error`
-- `~/.bun/bin/bunx tsc --noEmit -p apps/desktop/tsconfig.json` -> pass
+
+# Task: Address unresolved PR #37 review comments
+
+## Plan
+- [x] Identify the open GitHub PR for the current branch and fetch all unresolved review threads/comments that need attention.
+- [x] Summarize each thread into a numbered fix candidate with the concrete code/doc/test surface it would require.
+- [x] Fix the remaining config-layering and `set_config` ordering issues, then rerun the required verification/build lane and update the PR threads.
+
+## Review
+- `src/config.ts` now resolves `userName` from the merged config layers with trimming that preserves explicit empty strings, so a persisted project-level clear (`""`) survives restart instead of falling back to inherited user or built-in defaults.
+- `src/server/session/AgentSession.ts` now serializes pending config mutations before `sendUserMessage()`, which removes the race where a back-to-back `set_config` and `user_message` could run one turn with the stale cached prompt.
+- Added focused regressions in `test/config.test.ts`, `test/session.test.ts`, and `test/server.test.ts` covering explicit-empty `userName` layering, in-flight `setConfig()` prompt refresh ordering, and restart persistence for cleared profile fields.
+
+### Verification
+- `git diff --check` -> pass
+- `HOME=$(mktemp -d) ~/.bun/bin/bun test test/config.test.ts test/session.test.ts test/server.test.ts --bail` -> pass (`344 pass, 0 fail`)
+- `HOME=$(mktemp -d) ~/.bun/bin/bun test` -> pass (`2228 pass, 2 skip, 0 fail`)
 - `~/.bun/bin/bun run typecheck` -> pass
-- `./node_modules/.bin/tsc --noEmit -p apps/TUI/tsconfig.json` -> fails in unchanged TUI code at `apps/TUI/routes/session/index.tsx:248` (`TS2769`) and `apps/TUI/ui/dialog-prompt.tsx:61` (`TS2322`)
+- `./node_modules/.bin/tsc --noEmit -p apps/TUI/tsconfig.json` -> fails in unchanged TUI code at `apps/TUI/routes/session/index.tsx:248` (`TS2769`) and `apps/TUI/ui/dialog-prompt.tsx:62` (`TS2322`)
 - `~/.bun/bin/bun run build:server-binary` -> pass
 - `~/.bun/bin/bun run build:desktop-resources` -> pass
-- `~/.bun/bin/bun run desktop:build` -> pass
+- `~/.bun/bin/bun run desktop:build` -> pass; macOS notarization skipped because Apple notarization credentials are not configured in this environment
 
 # Task: Ship v0.1.21
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,26 @@
+# Task: Address PR #37 review comments
+
+## Plan
+- [x] Inspect the unresolved PR #37 review threads and separate the real runtime regression from any already-satisfied parser contract.
+- [x] Refresh the cached session system prompt when `set_config` changes `userName` or `userProfile`, without changing unrelated runtime behavior.
+- [x] Add regression coverage for live prompt refresh and for clearing persisted profile fields with empty strings.
+- [x] Run focused tests, the full test suite, typechecks, required builds, and record the outcome here.
+
+## Review
+- Addressed the real `P1` regression in [SessionMetadataManager.ts](/Users/mweinbach/Projects/agent-coworker/src/server/session/SessionMetadataManager.ts): `setConfig()` now refreshes the cached `state.system` and `discoveredSkills` via the same system-prompt loader whenever `userName` or `userProfile` changes, so the next turn in the current session uses the updated prompt context immediately.
+- Kept the refresh path testable by adding an injected `loadSystemPromptWithSkillsImpl` dependency in [SessionContext.ts](/Users/mweinbach/Projects/agent-coworker/src/server/session/SessionContext.ts) and [AgentSession.ts](/Users/mweinbach/Projects/agent-coworker/src/server/session/AgentSession.ts), matching the repo’s existing dependency-injection pattern.
+- The `P2` parser concern was already satisfied in the current branch: `set_config` already accepted `userName: ""` and empty `userProfile` strings. Instead of churning that parser path again, I added an end-to-end server regression in [server.test.ts](/Users/mweinbach/Projects/agent-coworker/test/server.test.ts) and clarified the contract in [websocket-protocol.md](/Users/mweinbach/Projects/agent-coworker/docs/websocket-protocol.md) so empty strings are explicitly documented as clearing prompt context.
+- Added targeted regression coverage in [session.test.ts](/Users/mweinbach/Projects/agent-coworker/test/session.test.ts) to prove a live `setConfig()` profile edit changes the system prompt actually passed into the next `runTurn()` call.
+- Verification:
+  - `git diff --check` -> pass
+  - `HOME=$(mktemp -d) ~/.bun/bin/bun test test/protocol.test.ts test/session.test.ts test/server.test.ts --bail` -> pass (`447 pass, 0 fail`)
+  - `HOME=$(mktemp -d) ~/.bun/bin/bun test` -> pass (`2222 pass, 2 skip, 0 fail`)
+  - `~/.bun/bin/bun run typecheck` -> pass
+  - `./node_modules/.bin/tsc --noEmit -p apps/TUI/tsconfig.json` -> fails in unchanged TUI files at `apps/TUI/routes/session/index.tsx:248` (`TS2769`) and `apps/TUI/ui/dialog-prompt.tsx:62` (`TS2322`)
+  - `~/.bun/bin/bun run build:server-binary` -> pass
+  - `~/.bun/bin/bun run build:desktop-resources` -> pass
+  - `~/.bun/bin/bun run desktop:build` -> pass; macOS notarization skipped because Apple notarization credentials are not fully configured in this environment
+
 # Task: Stop Harness Full from running on every main push
 
 ## Plan

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,25 @@
+# Task: Review PR #37 desktop management coverage for user profile context
+
+## Plan
+- [x] Inspect the PR #37 diff with emphasis on websocket protocol, session/config persistence, and any desktop-facing surfaces that need to manage the new profile fields.
+- [x] Verify whether the desktop app already receives and can update the new user profile state through the server/workspace settings flow; patch any missing protocol or desktop wiring if needed.
+- [x] Run focused regression tests first, then the repo-required test/build verification lane, and record the result plus any residual risks here.
+
+## Review
+- The review found a real desktop gap: the PR extended websocket `session_config` with `userName` and `userProfile`, but the desktop layer only updated sync fixtures. It was not persisting those workspace defaults, hydrating them from the control session, replaying them to live thread sessions, or exposing them in the workspace settings UI.
+- Patched the desktop workspace model and sanitizers so `userName` and `userProfile` now survive renderer bootstrap, IPC validation, and Electron persistence in [types.ts](/Users/mweinbach/Projects/agent-coworker/apps/desktop/src/app/types.ts), [bootstrap.ts](/Users/mweinbach/Projects/agent-coworker/apps/desktop/src/app/store.actions/bootstrap.ts), [desktopSchemas.ts](/Users/mweinbach/Projects/agent-coworker/apps/desktop/src/lib/desktopSchemas.ts), and [persistence.ts](/Users/mweinbach/Projects/agent-coworker/apps/desktop/electron/services/persistence.ts).
+- Patched desktop control/thread sync so harness `session_config` snapshots hydrate the new fields and workspace default updates replay them through `set_config` to both the control session and live thread sessions in [controlSocket.ts](/Users/mweinbach/Projects/agent-coworker/apps/desktop/src/app/store.helpers/controlSocket.ts) and [workspaceDefaults.ts](/Users/mweinbach/Projects/agent-coworker/apps/desktop/src/app/store.actions/workspaceDefaults.ts).
+- Added a new workspace settings card so the desktop app can actually manage the profile fields, not just store them, in [WorkspacesPage.tsx](/Users/mweinbach/Projects/agent-coworker/apps/desktop/src/ui/settings/pages/WorkspacesPage.tsx).
+- Added regression coverage for renderer bootstrap, persistence, workspace sync, and settings rendering in [workspace-settings-sync.test.ts](/Users/mweinbach/Projects/agent-coworker/apps/desktop/test/workspace-settings-sync.test.ts), [persistence-state-sanitization.test.ts](/Users/mweinbach/Projects/agent-coworker/apps/desktop/test/persistence-state-sanitization.test.ts), [desktop-schemas.test.ts](/Users/mweinbach/Projects/agent-coworker/apps/desktop/test/desktop-schemas.test.ts), and [workspaces-page.test.ts](/Users/mweinbach/Projects/agent-coworker/apps/desktop/test/workspaces-page.test.ts).
+- Verification:
+  - `HOME=$(mktemp -d) ~/.bun/bin/bun test apps/desktop/test/workspace-settings-sync.test.ts apps/desktop/test/workspaces-page.test.ts apps/desktop/test/desktop-schemas.test.ts apps/desktop/test/persistence-state-sanitization.test.ts --bail` -> pass (`32 pass, 0 fail`)
+  - `HOME=$(mktemp -d) ~/.bun/bin/bun test` -> pass (`2226 pass, 2 skip, 0 fail`)
+  - `~/.bun/bin/bun run typecheck` -> pass
+  - `./node_modules/.bin/tsc --noEmit -p apps/TUI/tsconfig.json` -> fails in unchanged TUI files at `apps/TUI/routes/session/index.tsx:248` (`TS2769`) and `apps/TUI/ui/dialog-prompt.tsx:62` (`TS2322`)
+  - `~/.bun/bin/bun run build:server-binary` -> pass
+  - `~/.bun/bin/bun run build:desktop-resources` -> pass
+  - `~/.bun/bin/bun run desktop:build` -> pass; macOS notarization skipped because Apple notarization credentials are not configured in this environment
+
 # Task: Address PR #37 review comments
 
 ## Plan

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -3791,3 +3791,27 @@
   - `~/.bun/bin/bun run build:server-binary` -> pass
   - `~/.bun/bin/bun run build:desktop-resources` -> pass
   - `~/.bun/bin/bun run desktop:build` -> pass
+
+# Task: Align profile name handling to `userName`
+
+## Plan
+- [x] Refactor profile config/protocol shapes so name is set through `userName` and `userProfile` only carries instructions/work/details.
+- [x] Update prompt variables/templates so name comes from `{{userName}}` only, removing `{{userProfileName}}`.
+- [x] Update TUI profile dialog/state wiring so “Edit Name” updates `userName`, then rerun required verification/build commands.
+
+## Review
+- Reworked config + websocket patch/state types so `set_config` now accepts top-level `userName` for name updates while `userProfile` is now limited to `instructions`, `work`, and `details`.
+- Updated prompt rendering and all shipped system prompt templates to remove `userProfileName` and rely on existing `userName` for user identity injection.
+- Updated the TUI User Profile flow so the name editor writes `userName`, while other fields keep writing `userProfile`.
+
+# Task: Make user profile/name prompt injection conditional via regex line injection
+
+## Plan
+- [x] Update prompt template wording to remove literal "(if provided)" suffixes for user name/profile lines.
+- [x] Refactor prompt variable injection to use regex-based line replacement that removes entire placeholder lines when values are empty.
+- [x] Run targeted prompt tests plus required typecheck/build/test commands and record results.
+
+## Review
+- Implemented regex-based injection behavior so blank `userName`/`userProfile*` values remove their full prompt lines instead of leaving empty labels.
+- Removed `(if provided)` phrasing in shipped prompt templates because conditional visibility is now handled by injection logic.
+- Verified with prompt-focused tests and required build/typecheck commands.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,24 @@
+# Task: Fix remaining PR #37 prompt templating review comments
+
+## Plan
+- [x] Inspect the unresolved `src/prompt.ts` review threads and confirm whether they can be addressed with one templating change.
+- [x] Make user-provided prompt variables literal-safe and non-recursive without changing the rest of the prompt contract.
+- [x] Add focused regressions, run the required verification lane, and resolve the completed PR threads.
+
+## Review
+- Addressed the two remaining PR #37 prompt-template review threads in [prompt.ts](/Users/mweinbach/Projects/agent-coworker/src/prompt.ts) by replacing the iterative `injectTemplateVariable` flow with a single callback-based `renderTemplateVariables()` pass. Empty-value template lines are stripped before substitution, then all remaining `{{...}}` tokens are resolved against the original prompt in one pass so user-provided text is always treated literally.
+- This fixes both reported regressions without changing the broader prompt contract: `$...` sequences in `userName` or `userProfile` no longer trigger replacement-pattern behavior, and `{{...}}` sequences inside user-supplied profile content no longer recurse into later template substitutions.
+- Added focused regressions in [prompt.test.ts](/Users/mweinbach/Projects/agent-coworker/test/prompt.test.ts) that prove literal `$&` and `$1` content survives unchanged and that profile text containing `{{workingDirectory}}` remains verbatim while the real prompt token still resolves elsewhere in the prompt.
+- Verification:
+  - `git diff --check` -> pass
+  - `HOME=$(mktemp -d) ~/.bun/bin/bun test test/prompt.test.ts --bail` -> pass (`51 pass, 0 fail`)
+  - `HOME=$(mktemp -d) ~/.bun/bin/bun test` -> pass (`2233 pass, 2 skip, 0 fail`)
+  - `~/.bun/bin/bun run typecheck` -> pass
+  - `./node_modules/.bin/tsc --noEmit -p apps/TUI/tsconfig.json` -> pass
+  - `~/.bun/bin/bun run build:server-binary` -> pass
+  - `~/.bun/bin/bun run build:desktop-resources` -> pass
+  - `~/.bun/bin/bun run desktop:build` -> pass; notarization explicitly skipped because notarization credentials are not fully configured in this environment
+
 # Task: Review PR #37 desktop management coverage for user profile context
 
 ## Plan
@@ -3895,3 +3916,27 @@
 - Implemented regex-based injection behavior so blank `userName`/`userProfile*` values remove their full prompt lines instead of leaving empty labels.
 - Removed `(if provided)` phrasing in shipped prompt templates because conditional visibility is now handled by injection logic.
 - Verified with prompt-focused tests and required build/typecheck commands.
+
+# Task: Set up Linear for agent-coworker
+
+## Plan
+- [x] Validate the current Linear connection plus existing `AgentCoworker` team/project state so setup work is based on live workspace data.
+- [x] Create the minimal Linear project-side bootstrap for this repo without inventing a larger workflow structure than the workspace currently has.
+- [x] Verify the created Linear resources and document the outcome plus any remaining gaps here.
+
+## Review
+- Linear MCP was already configured and authenticated for this Codex environment, so setup work started from the live workspace instead of redoing connection setup.
+- Verified the only available team is `AgentCoworker` (`AGE`) and that there was no existing `agent-coworker` project before bootstrap. The workspace already had the default `Bug`, `Feature`, and `Improvement` issue labels plus Linear’s onboarding issues `AGE-1` through `AGE-4`.
+- Created the Linear project `agent-coworker` with Max as lead, attached it to the `AgentCoworker` team, and seeded it with a repo-specific summary/description focused on the WebSocket-first harness architecture and the repo’s default verification lane.
+- Created the project document `agent-coworker project brief` and attached it to the project as the initial source-of-truth note for scope, architecture, main code surfaces, verification commands, and triage guidance.
+- Remaining gap: the project now has a home, but it does not yet have milestones or backlog issues beyond Linear’s default onboarding tickets. That is intentional to avoid inventing roadmap structure the workspace does not already define.
+- Verification:
+  - Linear readback: project `agent-coworker` exists at `https://linear.app/agentcoworker/project/agent-coworker-9dd25d9290a3`
+  - Linear readback: document `agent-coworker project brief` exists at `https://linear.app/agentcoworker/document/agent-coworker-project-brief-76150c26ca36`
+  - `HOME=/tmp/agent-coworker-test-home-$(date +%s) ~/.bun/bin/bun test` -> pass (`2231 pass, 2 skip, 0 fail`)
+  - `~/.bun/bin/bun run typecheck` -> pass
+  - `./node_modules/.bin/tsc --noEmit -p apps/TUI/tsconfig.json` -> pass
+  - `~/.bun/bin/bun run build:server-binary` -> pass
+  - `~/.bun/bin/bun run build:desktop-resources` -> pass
+  - `~/.bun/bin/bun run desktop:build` -> pass; notarization skipped because Apple notarization credentials are not configured in this environment
+  - `git diff --check` -> pass

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -219,6 +219,31 @@
 
 ## Review
 
+# Task: Fix desktop user profile context blank screen on input
+
+## Plan
+- [x] Reproduce the desktop renderer failure in the actual Electron workspaces settings flow and isolate the real render loop source.
+- [x] Patch the render loop, then add regressions for both the chat-view loop and the workspaces typing path that triggered it.
+- [x] Fix the standalone TUI typecheck failures surfaced during verification, rerun the repo-required test/build lane, and record the outcome here.
+
+## Review
+- Reproduced the blank-screen bug in the real Electron app by launching desktop dev mode with remote debugging and typing into the `Workspace work context` field in Settings -> Workspaces. The renderer hit React's `Maximum update depth exceeded` warning and the page blanked.
+- Root cause was not the workspace profile form. The loop came from [ChatView.tsx](/Users/mweinbach/Projects/agent-coworker/apps/desktop/src/ui/ChatView.tsx): the citation-overflow effect reset `overflowCitationUrlsByMessageId` to a fresh empty `Map()` every render when the derived `citationOverflowFilePathsByMessageId` was empty. Because that derived map is rebuilt during render, the effect kept scheduling a new state update and the renderer never settled.
+- Fixed [ChatView.tsx](/Users/mweinbach/Projects/agent-coworker/apps/desktop/src/ui/ChatView.tsx) so the empty-path case preserves the existing empty map instead of creating a new one. That breaks the passive-effect update loop while keeping the citation reset behavior when there is real state to clear.
+- Added a dedicated desktop regression in [chat-view.stability.test.tsx](/Users/mweinbach/Projects/agent-coworker/apps/desktop/test/chat-view.stability.test.tsx) that mounts `ChatView` under `StrictMode` with an empty feed and asserts no max-depth warning is emitted. Extended [workspaces-page.test.ts](/Users/mweinbach/Projects/agent-coworker/apps/desktop/test/workspaces-page.test.ts) to prove typing in the profile fields no longer triggers a render loop or blanks the settings shell.
+- The repo-required verification lane still surfaced the previously known standalone TUI type errors, and the user explicitly expanded scope to include them. Fixed [index.tsx](/Users/mweinbach/Projects/agent-coworker/apps/TUI/routes/session/index.tsx) by replacing the function-child `Show` branch with a direct rendered node, and fixed [dialog-prompt.tsx](/Users/mweinbach/Projects/agent-coworker/apps/TUI/ui/dialog-prompt.tsx) by aligning `onSubmit` with the OpenTUI input callback shape.
+- Manual Electron verification after the fix showed the Settings -> Workspaces page remained interactive after typing into `Workspace work context`, and the max-depth warning no longer appeared in the renderer console.
+
+### Verification
+- `HOME=$(mktemp -d) ~/.bun/bin/bun test apps/desktop/test/chat-view.stability.test.tsx apps/desktop/test/workspaces-page.test.ts --bail` -> pass (`5 pass, 0 fail`)
+- `HOME=$(mktemp -d) ~/.bun/bin/bun test` -> pass (`2231 pass, 2 skip, 0 fail`)
+- `~/.bun/bin/bun run typecheck` -> pass
+- `./node_modules/.bin/tsc --noEmit -p apps/TUI/tsconfig.json` -> pass
+- `~/.bun/bin/bun run build:server-binary` -> pass
+- `~/.bun/bin/bun run build:desktop-resources` -> pass
+- `~/.bun/bin/bun run desktop:build` -> pass; macOS notarization skipped because Apple notarization credentials are not configured in this environment
+- `git diff --check` -> pass
+
 # Task: Address unresolved PR #37 review comments
 
 ## Plan

--- a/test/agentSocket.parse.test.ts
+++ b/test/agentSocket.parse.test.ts
@@ -90,6 +90,12 @@ describe("agent socket parser", () => {
           defaultToolOutputOverflowChars: 25000,
           subAgentModel: "gpt-5.2",
           maxSteps: 100,
+          userName: "Alex",
+          userProfile: {
+            instructions: "Keep responses concise.",
+            work: "Product manager",
+            details: "Prefers concrete examples",
+          },
           providerOptions: {
             openai: {
               reasoningEffort: "high",

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1093,6 +1093,27 @@ describe("deepMerge (tested indirectly through recognized fields)", () => {
     expect(cfg.knowledgeCutoff).toBe("January 2025");
   });
 
+  test("project config can explicitly clear an inherited userName", async () => {
+    const { cwd, home } = await makeTmpDirs();
+
+    await writeJson(path.join(home, ".agent", "config.json"), {
+      userName: "UserLevel",
+    });
+
+    await writeJson(path.join(cwd, ".agent", "config.json"), {
+      userName: "",
+    });
+
+    const cfg = await loadConfig({
+      cwd,
+      homedir: home,
+      builtInDir: repoRoot(),
+      env: {},
+    });
+
+    expect(cfg.userName).toBe("");
+  });
+
   test("does not mutate original objects (verified by loading twice)", async () => {
     const { cwd, home } = await makeTmpDirs();
 

--- a/test/prompt.test.ts
+++ b/test/prompt.test.ts
@@ -202,6 +202,34 @@ describe("loadSystemPrompt", () => {
     expect(prompt).toContain("- User profile details the agent should know: Prefers bullet points");
   });
 
+  test("treats dollar sequences in user profile fields as literal text", async () => {
+    const config = makeConfig({
+      userName: "$&",
+      userProfile: {
+        work: "Shell user with $1 placeholders",
+      },
+    });
+    const prompt = await loadSystemPrompt(config);
+
+    expect(prompt).toContain("- User name: $&");
+    expect(prompt).toContain("- User profile work/job: Shell user with $1 placeholders");
+    expect(prompt).not.toContain("- User name: {{userName}}");
+  });
+
+  test("does not expand template-looking text inside user profile fields", async () => {
+    const config = makeConfig({
+      userProfile: {
+        details: "Literal token {{workingDirectory}} should stay as written.",
+      },
+    });
+    const prompt = await loadSystemPrompt(config);
+
+    expect(prompt).toContain(
+      "- User profile details the agent should know: Literal token {{workingDirectory}} should stay as written."
+    );
+    expect(prompt).toContain("/test/working");
+  });
+
   test("replaces {{currentDate}} template variable", async () => {
     const config = makeConfig();
     const prompt = await loadSystemPrompt(config);

--- a/test/prompt.test.ts
+++ b/test/prompt.test.ts
@@ -170,6 +170,38 @@ describe("loadSystemPrompt", () => {
     expect(prompt).not.toContain("{{userName}}");
   });
 
+  test("omits user identity/profile lines when userName and profile fields are empty", async () => {
+    const config = makeConfig({
+      userName: "",
+      userProfile: {
+        instructions: "",
+        work: "",
+        details: "",
+      },
+    });
+    const prompt = await loadSystemPrompt(config);
+    expect(prompt).not.toContain("User name:");
+    expect(prompt).not.toContain("User profile work/job:");
+    expect(prompt).not.toContain("User profile instructions:");
+    expect(prompt).not.toContain("User profile details the agent should know:");
+  });
+
+  test("keeps user identity/profile lines when values are provided", async () => {
+    const config = makeConfig({
+      userName: "Casey",
+      userProfile: {
+        instructions: "Keep answers concise.",
+        work: "Engineering manager",
+        details: "Prefers bullet points",
+      },
+    });
+    const prompt = await loadSystemPrompt(config);
+    expect(prompt).toContain("- User name: Casey");
+    expect(prompt).toContain("- User profile work/job: Engineering manager");
+    expect(prompt).toContain("- User profile instructions: Keep answers concise.");
+    expect(prompt).toContain("- User profile details the agent should know: Prefers bullet points");
+  });
+
   test("replaces {{currentDate}} template variable", async () => {
     const config = makeConfig();
     const prompt = await loadSystemPrompt(config);

--- a/test/protocol.test.ts
+++ b/test/protocol.test.ts
@@ -1169,6 +1169,88 @@ describe("safeParseClientMessage", () => {
         ),
       ).toBe("set_config config.providerOptions.codex-cli.textVerbosity must be one of low, medium, high");
     });
+
+    test("set_config accepts userName with non-empty string", () => {
+      const msg = expectOk(
+        JSON.stringify({
+          type: "set_config",
+          sessionId: "s1",
+          config: { userName: "Alice" },
+        }),
+      );
+      expect(msg.type).toBe("set_config");
+      if (msg.type === "set_config") {
+        expect(msg.config.userName).toBe("Alice");
+      }
+    });
+
+    test("set_config accepts empty userName to clear the field", () => {
+      const msg = expectOk(
+        JSON.stringify({
+          type: "set_config",
+          sessionId: "s1",
+          config: { userName: "" },
+        }),
+      );
+      expect(msg.type).toBe("set_config");
+      if (msg.type === "set_config") {
+        expect(msg.config.userName).toBe("");
+      }
+    });
+
+    test("set_config accepts userProfile object", () => {
+      const msg = expectOk(
+        JSON.stringify({
+          type: "set_config",
+          sessionId: "s1",
+          config: {
+            userProfile: {
+              instructions: "Be concise",
+              work: "Software engineer",
+              details: "Uses TypeScript",
+            },
+          },
+        }),
+      );
+      expect(msg.type).toBe("set_config");
+      if (msg.type === "set_config") {
+        expect(msg.config.userProfile?.instructions).toBe("Be concise");
+        expect(msg.config.userProfile?.work).toBe("Software engineer");
+        expect(msg.config.userProfile?.details).toBe("Uses TypeScript");
+      }
+    });
+
+    test("set_config accepts partial userProfile fields", () => {
+      const msg = expectOk(
+        JSON.stringify({
+          type: "set_config",
+          sessionId: "s1",
+          config: { userProfile: { work: "Dev" } },
+        }),
+      );
+      expect(msg.type).toBe("set_config");
+      if (msg.type === "set_config") {
+        expect(msg.config.userProfile?.work).toBe("Dev");
+        expect(msg.config.userProfile?.instructions).toBeUndefined();
+        expect(msg.config.userProfile?.details).toBeUndefined();
+      }
+    });
+
+    test("set_config accepts empty userProfile field strings to clear them", () => {
+      const msg = expectOk(
+        JSON.stringify({
+          type: "set_config",
+          sessionId: "s1",
+          config: { userProfile: { instructions: "", work: "", details: "" } },
+        }),
+      );
+      expect(msg.type).toBe("set_config");
+      if (msg.type === "set_config") {
+        expect(msg.config.userProfile?.instructions).toBe("");
+        expect(msg.config.userProfile?.work).toBe("");
+        expect(msg.config.userProfile?.details).toBe("");
+      }
+    });
   });
 
   describe("upload_file", () => {

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -2632,6 +2632,66 @@ describe("Protocol Doc Parity", () => {
     }
   });
 
+  test("set_config accepts empty user profile values to clear persisted prompt context", async () => {
+    const tmpDir = await makeTmpProject();
+    await fs.writeFile(
+      path.join(tmpDir, ".agent", "config.json"),
+      `${JSON.stringify({
+        userName: "Alice",
+        userProfile: {
+          instructions: "Be concise",
+          work: "Engineer",
+          details: "Uses TypeScript",
+        },
+      }, null, 2)}\n`,
+      "utf-8",
+    );
+
+    const { server, url } = await startAgentServer(serverOpts(tmpDir));
+    try {
+      const event = await sendAndWaitForEvent(
+        url,
+        (sessionId) => ({
+          type: "set_config",
+          sessionId,
+          config: {
+            userName: "",
+            userProfile: {
+              instructions: "",
+              work: "",
+              details: "",
+            },
+          },
+        }),
+        (message) =>
+          message.type === "session_config" &&
+          message.config?.userName === "" &&
+          message.config?.userProfile?.instructions === "" &&
+          message.config?.userProfile?.work === "" &&
+          message.config?.userProfile?.details === "",
+      );
+
+      expect(event.config.userName).toBe("");
+      expect(event.config.userProfile).toEqual({
+        instructions: "",
+        work: "",
+        details: "",
+      });
+
+      const persistedConfig = JSON.parse(
+        await fs.readFile(path.join(tmpDir, ".agent", "config.json"), "utf-8"),
+      ) as any;
+      expect(persistedConfig.userName).toBe("");
+      expect(persistedConfig.userProfile).toEqual({
+        instructions: "",
+        work: "",
+        details: "",
+      });
+    } finally {
+      server.stop();
+    }
+  });
+
   test("set_config rejects unsupported subAgentModel values before persisting them", async () => {
     const tmpDir = await makeTmpProject();
     await fs.writeFile(

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -2690,6 +2690,20 @@ describe("Protocol Doc Parity", () => {
     } finally {
       server.stop();
     }
+
+    const restarted = await startAgentServer(serverOpts(tmpDir));
+    try {
+      const initialMessages = await collectMessages(restarted.url, 5);
+      const sessionConfig = initialMessages.find((message) => message.type === "session_config");
+      expect(sessionConfig?.config?.userName).toBe("");
+      expect(sessionConfig?.config?.userProfile).toEqual({
+        instructions: "",
+        work: "",
+        details: "",
+      });
+    } finally {
+      restarted.server.stop();
+    }
   });
 
   test("set_config rejects unsupported subAgentModel values before persisting them", async () => {

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -798,6 +798,40 @@ describe("AgentSession", () => {
       expect(configEvent.config.userProfile.work).toBe("Engineer");
     });
 
+    test("sendUserMessage waits for an in-flight setConfig prompt refresh", async () => {
+      const refreshGate = Promise.withResolvers<void>();
+      const loadSystemPromptWithSkillsImpl = mock(async (config: AgentConfig) => {
+        await refreshGate.promise;
+        return {
+          prompt: `prompt:${config.userName ?? ""}:${config.userProfile?.work ?? ""}`,
+          discoveredSkills: [{ name: "refreshed-skill", description: "Refreshed skill" }],
+        };
+      });
+      const { session } = makeSession({
+        loadSystemPromptWithSkillsImpl,
+        system: "prompt:stale:",
+      });
+
+      const pendingConfig = session.setConfig({
+        userName: "Casey",
+        userProfile: { work: "Engineer" },
+      });
+      const pendingTurn = session.sendUserMessage("hello");
+
+      await flushAsyncWork();
+      expect(mockRunTurn).not.toHaveBeenCalled();
+
+      refreshGate.resolve();
+      await pendingConfig;
+      await pendingTurn;
+
+      const runTurnArgs = mockRunTurn.mock.calls.at(-1)?.[0] as any;
+      expect(runTurnArgs.system).toBe("prompt:Casey:Engineer");
+      expect(runTurnArgs.discoveredSkills).toEqual([
+        { name: "refreshed-skill", description: "Refreshed skill" },
+      ]);
+    });
+
     test("setConfig rejects unsupported subAgentModel values before persistence", async () => {
       const persistProjectConfigPatchImpl = mock(async () => {});
       const { session, events } = makeSession({

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -184,12 +184,17 @@ function makeSession(
       patch: Partial<
         Pick<
           AgentConfig,
-          "provider" | "model" | "subAgentModel" | "enableMcp" | "observabilityEnabled" | "backupsEnabled" | "toolOutputOverflowChars"
+          "provider" | "model" | "subAgentModel" | "enableMcp" | "observabilityEnabled" | "backupsEnabled" | "toolOutputOverflowChars" | "userName"
         >
       > & {
+        userProfile?: Partial<NonNullable<AgentConfig["userProfile"]>>;
         clearToolOutputOverflowChars?: boolean;
       }
     ) => Promise<void> | void;
+    loadSystemPromptWithSkillsImpl: (config: AgentConfig) => Promise<{
+      prompt: string;
+      discoveredSkills: Array<{ name: string; description: string }>;
+    }>;
     generateSessionTitleImpl: (opts: { config: AgentConfig; query: string }) => Promise<{
       title: string;
       source: "default" | "model" | "heuristic";
@@ -215,6 +220,7 @@ function makeSession(
     emit: overrides?.emit ?? emit,
     connectProviderImpl: overrides?.connectProviderImpl,
     getAiCoworkerPathsImpl: overrides?.getAiCoworkerPathsImpl,
+    loadSystemPromptWithSkillsImpl: overrides?.loadSystemPromptWithSkillsImpl,
     getProviderCatalogImpl: overrides?.getProviderCatalogImpl as any,
     getProviderStatusesImpl,
     sessionBackupFactory,
@@ -756,6 +762,40 @@ describe("AgentSession", () => {
         backupsEnabled: false,
         toolOutputOverflowChars: null,
       });
+    });
+
+    test("setConfig refreshes the cached system prompt when user profile fields change", async () => {
+      const persistProjectConfigPatchImpl = mock(async () => {});
+      const loadSystemPromptWithSkillsImpl = mock(async (config: AgentConfig) => ({
+        prompt: `prompt:${config.userName ?? ""}:${config.userProfile?.work ?? ""}`,
+        discoveredSkills: [{ name: "refreshed-skill", description: "Refreshed skill" }],
+      }));
+      const { session } = makeSession({
+        persistProjectConfigPatchImpl,
+        loadSystemPromptWithSkillsImpl,
+      });
+
+      await session.setConfig({
+        userName: "Casey",
+        userProfile: { work: "Engineer" },
+      });
+      await session.sendUserMessage("hello");
+
+      expect(loadSystemPromptWithSkillsImpl).toHaveBeenCalledTimes(1);
+      expect(persistProjectConfigPatchImpl).toHaveBeenCalledWith({
+        userName: "Casey",
+        userProfile: { work: "Engineer" },
+      });
+
+      const runTurnArgs = mockRunTurn.mock.calls.at(-1)?.[0] as any;
+      expect(runTurnArgs.system).toBe("prompt:Casey:Engineer");
+      expect(runTurnArgs.discoveredSkills).toEqual([
+        { name: "refreshed-skill", description: "Refreshed skill" },
+      ]);
+
+      const configEvent = session.getSessionConfigEvent();
+      expect(configEvent.config.userName).toBe("Casey");
+      expect(configEvent.config.userProfile.work).toBe("Engineer");
     });
 
     test("setConfig rejects unsupported subAgentModel values before persistence", async () => {


### PR DESCRIPTION
### Motivation

- Introduce structured user profile metadata to be injected into system prompts for better personalized prompt context.  
- Align name handling so the identity remains sourced from the existing `userName` field while `userProfile` carries only instructions/work/details.  
- Make prompt template injection conditional so empty profile fields remove whole prompt lines instead of leaving placeholder labels.  
- Provide a TUI surface to view and edit profile fields for live sessions.

### Description

- Added `userName` and `userProfile` shapes to client/server protocol, runtime types (`SessionConfigPatch`, `SessionConfigState`, `SyncConfigPatch`, `AgentConfig`, etc.), and zod validation to accept and validate profile patches.  
- Persisted and merged profile data through server/session layers, including `persistProjectConfigPatch`, `mergeConfigPatch`, `SessionMetadataManager` emit logic, and session config events include `userName`/`userProfile`.  
- Updated config loading (`loadConfig`) to parse a `userProfile` layer and surface `userProfile` on the returned `AgentConfig`, and adjusted prompt rendering (`loadSystemPromptWithSkills`) to support `userProfile*` variables.  
- Implemented conditional template injection via `injectTemplateVariable` which removes template lines when values are empty, and updated shipped prompt templates to include the new profile variables and drop the “(if provided)” phrasing.  
- Added TUI UI for editing profile data: new `dialog-user-profile.tsx`, command palette and global hotkey entries, and a sidebar “Manage Profile” button wired into the sync/dialog contexts.  
- Updated numerous tests and docs to reflect the new `userName`/`userProfile` fields and prompt behavior.

### Testing

- Ran unit tests with `bun test`, including updated `test/prompt.test.ts` and `test/agentSocket.parse.test.ts`, and the suite passed.  
- Performed type checks with `bun run typecheck` and built server and desktop artifacts with `bun run build:server-binary` and `bun run desktop:build`, all of which completed successfully.  
- Verified prompt rendering behavior via targeted prompt tests that assert lines are omitted when profile fields are empty and present when populated, and those tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b398c4cf3c8326b138882d5f944662)