### PR TITLE
[codex] Move Codex auth and runtime onto OpenAI Responses

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ Before finishing your work, make sure you have run the tests and build the proje
 
 ## Commit & Pull Request Guidelines
 
-- Recent history favors short, imperative commit subjects (“Add …”, “Handle …”, “Refactor …”); use `chore:` for dependency bumps when applicable.
+- Commit messages must use [Conventional Commits](https://www.conventionalcommits.org/) format (e.g. `fix: …`, `feat: …`, `refactor: …`, `chore: …`, `test: …`, `docs: …`). Keep subjects short and imperative.
 - PRs should include: what/why, how to test (`bun test`), and screenshots or a short recording for TUI changes. Keep changes focused and add tests for fixes/features.
 
 ## WebSocket-First Development

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ Tests live in `test/` and use Bun's built-in test runner (`bun:test`). Test file
 
 **Commits & PRs**
 
-- Commit messages: Follow the [Conventional Commits](https://www.conventionalcommits.org/) format. Liberally make commits as you go. 
+- Commit messages: Follow the [Conventional Commits](https://www.conventionalcommits.org/) format (e.g. `fix:`, `feat:`, `refactor:`, `chore:`, `test:`, `docs:`). Liberally make commits as you go.
 - Pull Requests: Ensure all tests pass and provide a clear description of the changes.
 
 ## Workflow Orchestration

--- a/apps/TUI/component/dialog-provider.test.ts
+++ b/apps/TUI/component/dialog-provider.test.ts
@@ -50,17 +50,34 @@ describe("provider dialog auth flow helpers", () => {
       selectedMethod: autoOauthMethod,
       currentChallenge: null,
       initialChallenge: null,
+      handledChallenge: null,
     })).toBe(false);
     expect(shouldStartAutoOauthCallback({
       selectedMethod: autoOauthMethod,
       currentChallenge: initialChallenge,
       initialChallenge,
+      handledChallenge: null,
     })).toBe(false);
     expect(shouldStartAutoOauthCallback({
       selectedMethod: autoOauthMethod,
       currentChallenge: nextChallenge,
       initialChallenge,
+      handledChallenge: null,
     })).toBe(true);
+  });
+
+  test("does not restart auto OAuth for a challenge that was already handled", () => {
+    const handledChallenge = {
+      method: "auto" as const,
+      instructions: "Continue in browser",
+    };
+
+    expect(shouldStartAutoOauthCallback({
+      selectedMethod: autoOauthMethod,
+      currentChallenge: handledChallenge,
+      initialChallenge: null,
+      handledChallenge,
+    })).toBe(false);
   });
 
   test("never auto-starts callback for API key or manual-code methods", () => {
@@ -73,11 +90,13 @@ describe("provider dialog auth flow helpers", () => {
       selectedMethod: apiMethod,
       currentChallenge: challenge,
       initialChallenge: null,
+      handledChallenge: null,
     })).toBe(false);
     expect(shouldStartAutoOauthCallback({
       selectedMethod: codeOauthMethod,
       currentChallenge: challenge,
       initialChallenge: null,
+      handledChallenge: null,
     })).toBe(false);
   });
 });

--- a/apps/TUI/component/dialog-provider.test.ts
+++ b/apps/TUI/component/dialog-provider.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  stageAfterAuthMethodSelection,
+  shouldStartAutoOauthCallback,
+  type AuthMethod,
+} from "./dialog-provider";
+
+const apiMethod: AuthMethod = {
+  id: "api_key",
+  type: "api",
+  label: "API key",
+};
+
+const autoOauthMethod: AuthMethod = {
+  id: "oauth_cli",
+  type: "oauth",
+  label: "ChatGPT (browser)",
+  oauthMode: "auto",
+};
+
+const codeOauthMethod: AuthMethod = {
+  id: "oauth_code",
+  type: "oauth",
+  label: "Paste code",
+  oauthMode: "code",
+};
+
+describe("provider dialog auth flow helpers", () => {
+  test("keeps auto OAuth on the method stage until authorization succeeds", () => {
+    expect(stageAfterAuthMethodSelection(autoOauthMethod)).toBe("method");
+  });
+
+  test("routes API key and code OAuth methods to their dedicated stages", () => {
+    expect(stageAfterAuthMethodSelection(apiMethod)).toBe("api_key");
+    expect(stageAfterAuthMethodSelection(codeOauthMethod)).toBe("oauth_code");
+  });
+
+  test("starts auto OAuth callback only for a fresh challenge", () => {
+    const initialChallenge = {
+      method: "auto" as const,
+      instructions: "Continue in browser",
+    };
+    const nextChallenge = {
+      method: "auto" as const,
+      instructions: "Continue in browser",
+    };
+
+    expect(shouldStartAutoOauthCallback({
+      selectedMethod: autoOauthMethod,
+      currentChallenge: null,
+      initialChallenge: null,
+    })).toBe(false);
+    expect(shouldStartAutoOauthCallback({
+      selectedMethod: autoOauthMethod,
+      currentChallenge: initialChallenge,
+      initialChallenge,
+    })).toBe(false);
+    expect(shouldStartAutoOauthCallback({
+      selectedMethod: autoOauthMethod,
+      currentChallenge: nextChallenge,
+      initialChallenge,
+    })).toBe(true);
+  });
+
+  test("never auto-starts callback for API key or manual-code methods", () => {
+    const challenge = {
+      method: "auto" as const,
+      instructions: "Continue in browser",
+    };
+
+    expect(shouldStartAutoOauthCallback({
+      selectedMethod: apiMethod,
+      currentChallenge: challenge,
+      initialChallenge: null,
+    })).toBe(false);
+    expect(shouldStartAutoOauthCallback({
+      selectedMethod: codeOauthMethod,
+      currentChallenge: challenge,
+      initialChallenge: null,
+    })).toBe(false);
+  });
+});

--- a/apps/TUI/component/dialog-provider.test.ts
+++ b/apps/TUI/component/dialog-provider.test.ts
@@ -80,6 +80,35 @@ describe("provider dialog auth flow helpers", () => {
     })).toBe(false);
   });
 
+  test("blocks duplicate auto OAuth callback while awaiting result", () => {
+    const initialChallenge = {
+      method: "auto" as const,
+      instructions: "Continue in browser",
+    };
+    const nextChallenge = {
+      method: "auto" as const,
+      instructions: "Continue in browser",
+    };
+
+    // Without awaitingResult, a fresh challenge triggers the callback
+    expect(shouldStartAutoOauthCallback({
+      selectedMethod: autoOauthMethod,
+      currentChallenge: nextChallenge,
+      initialChallenge,
+      handledChallenge: null,
+      awaitingResult: false,
+    })).toBe(true);
+
+    // With awaitingResult set, the same fresh challenge is blocked
+    expect(shouldStartAutoOauthCallback({
+      selectedMethod: autoOauthMethod,
+      currentChallenge: nextChallenge,
+      initialChallenge,
+      handledChallenge: null,
+      awaitingResult: true,
+    })).toBe(false);
+  });
+
   test("never auto-starts callback for API key or manual-code methods", () => {
     const challenge = {
       method: "auto" as const,

--- a/apps/TUI/component/dialog-provider.tsx
+++ b/apps/TUI/component/dialog-provider.tsx
@@ -29,11 +29,13 @@ export function shouldStartAutoOauthCallback(opts: {
   selectedMethod: AuthMethod | null;
   currentChallenge: ProviderAuthChallengePayload | null;
   initialChallenge: ProviderAuthChallengePayload | null;
+  handledChallenge: ProviderAuthChallengePayload | null;
 }): boolean {
   if (!opts.selectedMethod || opts.selectedMethod.type !== "oauth" || opts.selectedMethod.oauthMode === "code") {
     return false;
   }
   if (!opts.currentChallenge) return false;
+  if (opts.currentChallenge === opts.handledChallenge) return false;
   return opts.currentChallenge !== opts.initialChallenge;
 }
 
@@ -63,6 +65,7 @@ function ProviderDialog(props: { onDismiss: () => void; initialProvider?: string
   const [stage, setStage] = createSignal<ProviderDialogStage>(props.initialProvider ? "method" : "provider");
   const [awaitingResult, setAwaitingResult] = createSignal(false);
   const [pendingAutoOauthChallenge, setPendingAutoOauthChallenge] = createSignal<ProviderAuthChallengePayload | null>(null);
+  const [handledAutoOauthChallenge, setHandledAutoOauthChallenge] = createSignal<ProviderAuthChallengePayload | null>(null);
   const [didAutoAdvanceInitial, setDidAutoAdvanceInitial] = createSignal(false);
 
   const providerItems = createMemo((): SelectItem[] => {
@@ -157,8 +160,10 @@ function ProviderDialog(props: { onDismiss: () => void; initialProvider?: string
       selectedMethod,
       currentChallenge: challenge,
       initialChallenge: pendingAutoOauthChallenge(),
+      handledChallenge: handledAutoOauthChallenge(),
     })) return;
 
+    setHandledAutoOauthChallenge(challenge);
     setPendingAutoOauthChallenge(null);
     setAwaitingResult(true);
     setStage("waiting");
@@ -183,6 +188,7 @@ function ProviderDialog(props: { onDismiss: () => void; initialProvider?: string
     setMethod(selectedMethod);
     setAwaitingResult(false);
     setPendingAutoOauthChallenge(null);
+    setHandledAutoOauthChallenge(null);
     const nextStage = stageAfterAuthMethodSelection(selectedMethod);
     setStage(nextStage);
     if (nextStage === "api_key") {
@@ -202,6 +208,7 @@ function ProviderDialog(props: { onDismiss: () => void; initialProvider?: string
     setProvider(nextProvider);
     setAwaitingResult(false);
     setPendingAutoOauthChallenge(null);
+    setHandledAutoOauthChallenge(null);
 
     if (nextMethods.length === 1) {
       beginMethodFlow(nextProvider, nextMethods[0]!);

--- a/apps/TUI/component/dialog-provider.tsx
+++ b/apps/TUI/component/dialog-provider.tsx
@@ -5,14 +5,37 @@ import { DialogSelect, type SelectItem } from "../ui/dialog-select";
 import { useDialog } from "../context/dialog";
 import { useLocal } from "../context/local";
 import { useSyncActions, useSyncState } from "../context/sync";
+import type { ProviderAuthChallengeState } from "../context/syncTypes";
 import { useTheme } from "../context/theme";
 
-type AuthMethod = {
+type ProviderAuthChallengePayload = NonNullable<ProviderAuthChallengeState>["challenge"];
+
+export type AuthMethod = {
   id: string;
   type: "api" | "oauth";
   label: string;
   oauthMode?: "auto" | "code";
 };
+
+export type ProviderDialogStage = "provider" | "method" | "api_key" | "oauth_code" | "waiting";
+
+export function stageAfterAuthMethodSelection(selectedMethod: AuthMethod): ProviderDialogStage {
+  if (selectedMethod.type === "api") return "api_key";
+  if (selectedMethod.oauthMode === "code") return "oauth_code";
+  return "method";
+}
+
+export function shouldStartAutoOauthCallback(opts: {
+  selectedMethod: AuthMethod | null;
+  currentChallenge: ProviderAuthChallengePayload | null;
+  initialChallenge: ProviderAuthChallengePayload | null;
+}): boolean {
+  if (!opts.selectedMethod || opts.selectedMethod.type !== "oauth" || opts.selectedMethod.oauthMode === "code") {
+    return false;
+  }
+  if (!opts.currentChallenge) return false;
+  return opts.currentChallenge !== opts.initialChallenge;
+}
 
 export function openProviderDialog(dialog: ReturnType<typeof useDialog>) {
   dialog.push(
@@ -37,8 +60,9 @@ function ProviderDialog(props: { onDismiss: () => void; initialProvider?: string
   const syncActions = useSyncActions();
   const [provider, setProvider] = createSignal(props.initialProvider ?? "");
   const [method, setMethod] = createSignal<AuthMethod | null>(null);
-  const [stage, setStage] = createSignal<"provider" | "method" | "api_key" | "oauth_code" | "waiting">(props.initialProvider ? "method" : "provider");
+  const [stage, setStage] = createSignal<ProviderDialogStage>(props.initialProvider ? "method" : "provider");
   const [awaitingResult, setAwaitingResult] = createSignal(false);
+  const [pendingAutoOauthChallenge, setPendingAutoOauthChallenge] = createSignal<ProviderAuthChallengePayload | null>(null);
   const [didAutoAdvanceInitial, setDidAutoAdvanceInitial] = createSignal(false);
 
   const providerItems = createMemo((): SelectItem[] => {
@@ -68,7 +92,6 @@ function ProviderDialog(props: { onDismiss: () => void; initialProvider?: string
     }
     if (selected === "codex-cli") {
       base.unshift(
-        { id: "oauth_device", type: "oauth", label: "ChatGPT (device code)", oauthMode: "auto" },
         { id: "oauth_cli", type: "oauth", label: "ChatGPT (browser)", oauthMode: "auto" }
       );
     }
@@ -78,6 +101,14 @@ function ProviderDialog(props: { onDismiss: () => void; initialProvider?: string
   const methodsForProvider = createMemo((): AuthMethod[] => {
     const selected = provider();
     return getMethodsForProvider(selected);
+  });
+
+  const matchingChallenge = createMemo(() => {
+    const challenge = syncState.providerAuthChallenge;
+    if (!challenge) return null;
+    if (challenge.provider !== provider()) return null;
+    if (challenge.methodId !== method()?.id) return null;
+    return challenge.challenge;
   });
 
   const matchingResult = createMemo(() => {
@@ -119,6 +150,21 @@ function ProviderDialog(props: { onDismiss: () => void; initialProvider?: string
     });
   });
 
+  createEffect(() => {
+    const selectedMethod = method();
+    const challenge = matchingChallenge();
+    if (!shouldStartAutoOauthCallback({
+      selectedMethod,
+      currentChallenge: challenge,
+      initialChallenge: pendingAutoOauthChallenge(),
+    })) return;
+
+    setPendingAutoOauthChallenge(null);
+    setAwaitingResult(true);
+    setStage("waiting");
+    syncActions.callbackProviderAuth(provider(), selectedMethod.id);
+  });
+
   const methodItems = createMemo((): SelectItem[] => {
     return methodsForProvider().map((item) => ({
       label: item.label,
@@ -136,18 +182,18 @@ function ProviderDialog(props: { onDismiss: () => void; initialProvider?: string
   const beginMethodFlow = (selectedProvider: string, selectedMethod: AuthMethod) => {
     setMethod(selectedMethod);
     setAwaitingResult(false);
-    if (selectedMethod.type === "api") {
-      setStage("api_key");
+    setPendingAutoOauthChallenge(null);
+    const nextStage = stageAfterAuthMethodSelection(selectedMethod);
+    setStage(nextStage);
+    if (nextStage === "api_key") {
       return;
     }
     syncActions.authorizeProviderAuth(selectedProvider, selectedMethod.id);
-    if (selectedMethod.oauthMode === "code") {
-      setStage("oauth_code");
+    if (nextStage === "oauth_code") {
       return;
     }
-    setAwaitingResult(true);
-    setStage("waiting");
-    syncActions.callbackProviderAuth(selectedProvider, selectedMethod.id);
+    // Only advance auto OAuth once a fresh challenge confirms authorization succeeded.
+    setPendingAutoOauthChallenge(matchingChallenge());
   };
 
   const handleProviderSelect = (item: SelectItem) => {
@@ -155,6 +201,7 @@ function ProviderDialog(props: { onDismiss: () => void; initialProvider?: string
     const nextMethods = getMethodsForProvider(nextProvider);
     setProvider(nextProvider);
     setAwaitingResult(false);
+    setPendingAutoOauthChallenge(null);
 
     if (nextMethods.length === 1) {
       beginMethodFlow(nextProvider, nextMethods[0]!);

--- a/apps/TUI/component/dialog-provider.tsx
+++ b/apps/TUI/component/dialog-provider.tsx
@@ -37,7 +37,7 @@ function ProviderDialog(props: { onDismiss: () => void; initialProvider?: string
   const syncActions = useSyncActions();
   const [provider, setProvider] = createSignal(props.initialProvider ?? "");
   const [method, setMethod] = createSignal<AuthMethod | null>(null);
-  const [stage, setStage] = createSignal<"provider" | "method" | "api_key" | "oauth_auto" | "oauth_code" | "waiting">(props.initialProvider ? "method" : "provider");
+  const [stage, setStage] = createSignal<"provider" | "method" | "api_key" | "oauth_code" | "waiting">(props.initialProvider ? "method" : "provider");
   const [awaitingResult, setAwaitingResult] = createSignal(false);
   const [didAutoAdvanceInitial, setDidAutoAdvanceInitial] = createSignal(false);
 
@@ -80,14 +80,6 @@ function ProviderDialog(props: { onDismiss: () => void; initialProvider?: string
     return getMethodsForProvider(selected);
   });
 
-  const matchingChallenge = createMemo(() => {
-    const challenge = syncState.providerAuthChallenge;
-    if (!challenge) return null;
-    if (challenge.provider !== provider()) return null;
-    if (challenge.methodId !== method()?.id) return null;
-    return challenge.challenge;
-  });
-
   const matchingResult = createMemo(() => {
     const result = syncState.providerAuthResult;
     if (!result) return null;
@@ -103,24 +95,6 @@ function ProviderDialog(props: { onDismiss: () => void; initialProvider?: string
     const trimmed = mask.trim();
     return trimmed ? trimmed : null;
   };
-
-  const oauthAutoTitle = createMemo(() => {
-    const challenge = matchingChallenge();
-    if (challenge?.url) return `OAuth: ${challenge.url}`;
-    if (challenge?.command) return `OAuth: ${challenge.command}`;
-    return "OAuth: Continue";
-  });
-
-  const oauthAutoPlaceholder = createMemo(() => {
-    const challenge = matchingChallenge();
-    if (!challenge) return "Start OAuth to continue.";
-
-    const extras: string[] = [];
-    if (challenge.url) extras.push(`URL: ${challenge.url}`);
-    if (challenge.command) extras.push(`Command: ${challenge.command}`);
-
-    return [challenge.instructions, extras.join(" ")].filter(Boolean).join(" ");
-  });
 
   const apiKeyPlaceholder = createMemo(() => {
     const selectedMethod = method();
@@ -167,7 +141,13 @@ function ProviderDialog(props: { onDismiss: () => void; initialProvider?: string
       return;
     }
     syncActions.authorizeProviderAuth(selectedProvider, selectedMethod.id);
-    setStage(selectedMethod.oauthMode === "code" ? "oauth_code" : "oauth_auto");
+    if (selectedMethod.oauthMode === "code") {
+      setStage("oauth_code");
+      return;
+    }
+    setAwaitingResult(true);
+    setStage("waiting");
+    syncActions.callbackProviderAuth(selectedProvider, selectedMethod.id);
   };
 
   const handleProviderSelect = (item: SelectItem) => {
@@ -271,28 +251,6 @@ function ProviderDialog(props: { onDismiss: () => void; initialProvider?: string
         />
       </Match>
 
-      <Match when={stage() === "oauth_auto"}>
-        <DialogSelect
-          items={[
-            { label: "Continue", value: "continue", description: "Begin or continue OAuth flow" },
-            { label: "Cancel", value: "cancel", description: "Back out of this flow" },
-          ]}
-          onSelect={(item) => {
-            if (item.value === "cancel") {
-              props.onDismiss();
-              return;
-            }
-            const selectedMethod = method();
-            if (!selectedMethod) return;
-            setAwaitingResult(true);
-            setStage("waiting");
-            syncActions.callbackProviderAuth(provider(), selectedMethod.id);
-          }}
-          onDismiss={props.onDismiss}
-          title={oauthAutoTitle()}
-          placeholder={oauthAutoPlaceholder()}
-        />
-      </Match>
     </Switch>
   );
 }

--- a/apps/TUI/component/dialog-provider.tsx
+++ b/apps/TUI/component/dialog-provider.tsx
@@ -30,7 +30,9 @@ export function shouldStartAutoOauthCallback(opts: {
   currentChallenge: ProviderAuthChallengePayload | null;
   initialChallenge: ProviderAuthChallengePayload | null;
   handledChallenge: ProviderAuthChallengePayload | null;
+  awaitingResult?: boolean;
 }): boolean {
+  if (opts.awaitingResult) return false;
   if (!opts.selectedMethod || opts.selectedMethod.type !== "oauth" || opts.selectedMethod.oauthMode === "code") {
     return false;
   }
@@ -161,6 +163,7 @@ function ProviderDialog(props: { onDismiss: () => void; initialProvider?: string
       currentChallenge: challenge,
       initialChallenge: pendingAutoOauthChallenge(),
       handledChallenge: handledAutoOauthChallenge(),
+      awaitingResult: awaitingResult(),
     })) return;
 
     setHandledAutoOauthChallenge(challenge);

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -1,6 +1,5 @@
 {
   "provider": "google",
-  "runtime": "pi",
   "userName": "",
   "knowledgeCutoff": "End of May 2025",
   "toolOutputOverflowChars": 25000,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -74,14 +74,15 @@ User Message → System Prompt + History + Tools → AI Model → Tool Calls →
 
 **Turn Lifecycle:**
 1. Build system prompt with skills, memory, and context
-2. Call the configured LLM runtime (`pi`) with model, tools, and history
+2. Call the configured LLM runtime (`pi` for Google/Anthropic/OpenCode, `openai-responses` for OpenAI/Codex) with model, tools, and history
 3. Execute tool calls (with approval for risky operations)
 4. Stream results back to client via WebSocket events
 5. Update message history
 
 The runtime boundary lives in `src/runtime/`:
-- `createRuntime()` selects the PI runtime
-- `piRuntime` handles provider streaming/tool loops and maps events into the existing stream contract
+- `createRuntime()` selects either the PI runtime or the OpenAI Responses runtime, depending on provider/runtime config
+- `piRuntime` handles Google/Anthropic/OpenCode streaming/tool loops and maps events into the existing stream contract
+- `openaiResponsesRuntime` handles OpenAI and Codex Responses flows, including the ChatGPT Codex backend path
 
 ### 3. Tools (`src/tools/`)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -80,7 +80,7 @@ User Message → System Prompt + History + Tools → AI Model → Tool Calls →
 5. Update message history
 
 The runtime boundary lives in `src/runtime/`:
-- `createRuntime()` selects either the PI runtime or the OpenAI Responses runtime, depending on provider/runtime config
+- `createRuntime()` selects either the PI runtime or the OpenAI Responses runtime; OpenAI and Codex are always routed through `openai-responses`, and legacy `runtime: "pi"` config is normalized away for those providers
 - `piRuntime` handles Google/Anthropic/OpenCode streaming/tool loops and maps events into the existing stream contract
 - `openaiResponsesRuntime` handles OpenAI and Codex Responses flows, including the ChatGPT Codex backend path
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -80,7 +80,7 @@ User Message → System Prompt + History + Tools → AI Model → Tool Calls →
 5. Update message history
 
 The runtime boundary lives in `src/runtime/`:
-- `createRuntime()` selects either the PI runtime or the OpenAI Responses runtime; OpenAI and Codex are always routed through `openai-responses`, and legacy `runtime: "pi"` config is normalized away for those providers
+- `createRuntime()` selects either the PI runtime or the OpenAI Responses runtime; OpenAI and Codex are always routed through `openai-responses`, and incompatible saved runtime values are normalized back to the provider default
 - `piRuntime` handles Google/Anthropic/OpenCode streaming/tool loops and maps events into the existing stream contract
 - `openaiResponsesRuntime` handles OpenAI and Codex Responses flows, including the ChatGPT Codex backend path
 

--- a/docs/websocket-protocol.md
+++ b/docs/websocket-protocol.md
@@ -948,7 +948,7 @@ Clear the saved auth state for a provider.
 Complete a provider OAuth callback flow.
 
 ```json
-{ "type": "provider_auth_callback", "sessionId": "...", "provider": "codex-cli", "methodId": "oauth_cli", "code": "abc123" }
+{ "type": "provider_auth_callback", "sessionId": "...", "provider": "codex-cli", "methodId": "oauth_cli" }
 ```
 
 | Field | Type | Required | Description |
@@ -957,7 +957,7 @@ Complete a provider OAuth callback flow.
 | `sessionId` | `string` | Yes | Non-empty session ID |
 | `provider` | `ProviderName` | Yes | Must be a valid provider |
 | `methodId` | `string` | Yes | Non-empty. Must be a registered auth method for the given provider |
-| `code` | `string` | No | Authorization code for OAuth flows that require it |
+| `code` | `string` | No | Authorization code for providers that use a code-paste OAuth flow. Codex browser sign-in does not use this field |
 
 **Response:** `provider_auth_result`, then `provider_status` and `provider_catalog` on success.
 
@@ -2182,10 +2182,8 @@ Auth challenge payload returned after `provider_auth_authorize`.
   "provider": "codex-cli",
   "methodId": "oauth_cli",
   "challenge": {
-    "method": "code",
-    "instructions": "Visit the URL and paste the code.",
-    "url": "https://auth.example.com/authorize?...",
-    "command": null
+    "method": "auto",
+    "instructions": "Cowork will open the browser sign-in flow and save the returned token locally."
   }
 }
 ```

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,7 +9,11 @@ import { getAiCoworkerPaths } from "./connect";
 import { parseConnectionStoreJson } from "./store/connections";
 import { defaultModelForProvider, getModelForProvider, getProviderKeyCandidates } from "./providers";
 import { DEFAULT_TOOL_OUTPUT_OVERFLOW_CHARS } from "./shared/toolOutputOverflow";
-import { resolveProviderName, resolveRuntimeName as resolveRuntimeNameFromValue } from "./types";
+import {
+  defaultRuntimeNameForProvider,
+  resolveProviderName,
+  resolveRuntimeName as resolveRuntimeNameFromValue,
+} from "./types";
 import type { AgentConfig, CommandTemplateConfig, ProviderName, RuntimeName } from "./types";
 import { resolveCoworkHomedir } from "./utils/coworkHome";
 import { assertSupportedModel, defaultSupportedModel, getSupportedModel } from "./models/registry";
@@ -311,12 +315,15 @@ export async function loadConfig(options: LoadConfigOptions = {}): Promise<Agent
     asProviderName(userConfig.provider) ??
     asProviderName(builtInDefaults.provider) ??
     "google";
-  const runtime =
+  const rawRuntime =
     asRuntimeName(env.AGENT_RUNTIME) ??
     asRuntimeName(projectConfig.runtime) ??
     asRuntimeName(userConfig.runtime) ??
-    asRuntimeName(builtInDefaults.runtime) ??
-    "pi";
+    asRuntimeName(builtInDefaults.runtime);
+  const runtime =
+    rawRuntime === "pi" && (provider === "openai" || provider === "codex-cli")
+      ? "openai-responses"
+      : rawRuntime ?? defaultRuntimeNameForProvider(provider);
 
   const workingDirectory = env.AGENT_WORKING_DIR || cwd;
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,7 +10,7 @@ import { parseConnectionStoreJson } from "./store/connections";
 import { defaultModelForProvider, getModelForProvider, getProviderKeyCandidates } from "./providers";
 import { DEFAULT_TOOL_OUTPUT_OVERFLOW_CHARS } from "./shared/toolOutputOverflow";
 import {
-  defaultRuntimeNameForProvider,
+  normalizeRuntimeNameForProvider,
   resolveProviderName,
   resolveRuntimeName as resolveRuntimeNameFromValue,
 } from "./types";
@@ -320,10 +320,7 @@ export async function loadConfig(options: LoadConfigOptions = {}): Promise<Agent
     asRuntimeName(projectConfig.runtime) ??
     asRuntimeName(userConfig.runtime) ??
     asRuntimeName(builtInDefaults.runtime);
-  const runtime =
-    provider === "openai" || provider === "codex-cli"
-      ? "openai-responses"
-      : rawRuntime ?? defaultRuntimeNameForProvider(provider);
+  const runtime = normalizeRuntimeNameForProvider(provider, rawRuntime);
 
   const workingDirectory = env.AGENT_WORKING_DIR || cwd;
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -321,7 +321,7 @@ export async function loadConfig(options: LoadConfigOptions = {}): Promise<Agent
     asRuntimeName(userConfig.runtime) ??
     asRuntimeName(builtInDefaults.runtime);
   const runtime =
-    rawRuntime === "pi" && (provider === "openai" || provider === "codex-cli")
+    provider === "openai" || provider === "codex-cli"
       ? "openai-responses"
       : rawRuntime ?? defaultRuntimeNameForProvider(provider);
 

--- a/src/connect.ts
+++ b/src/connect.ts
@@ -1,9 +1,4 @@
-import { loginOpenAICodex } from "@mariozechner/pi-ai";
-
 import {
-  CODEX_OAUTH_CLIENT_ID,
-  CODEX_OAUTH_ISSUER,
-  CODEX_OAUTH_ORIGINATOR,
   clearCodexAuthMaterial,
   codexAuthFilePath,
   isTokenExpiring,
@@ -15,6 +10,7 @@ import {
 import {
   completeCodexBrowserOAuth,
   isOauthCliProvider,
+  runCodexBrowserOAuth,
   type CodexBrowserOAuthPending,
 } from "./providers/codex-oauth-flows";
 import {
@@ -58,7 +54,7 @@ export type {
 const connectOauthDepsDefaults = {
   completeCodexBrowserOAuth,
   isOauthCliProvider,
-  runCodexLogin: runPiNativeCodexLogin,
+  runCodexLogin: runCoworkCodexLogin,
 };
 
 const connectOauthDeps = {
@@ -101,60 +97,20 @@ export type DisconnectProviderResult =
     }
   | { ok: false; provider: ConnectService; message: string };
 
-async function runPiNativeCodexLogin(opts: {
+async function runCoworkCodexLogin(opts: {
   paths: AiCoworkerPaths;
   code?: string;
   onOauthLine?: (line: string) => void;
   openUrl?: UrlOpener;
+  fetchImpl?: typeof fetch;
 }): Promise<CodexAuthMaterial> {
-  const opener = opts.openUrl ?? openExternalUrl;
-  const manualCode = opts.code?.trim() || undefined;
-  let openUrlTask: Promise<void> | null = null;
-
-  opts.onOauthLine?.("[auth] starting Codex-native login flow.");
-  const credentials = await loginOpenAICodex({
-    originator: CODEX_OAUTH_ORIGINATOR,
-    onAuth: ({ url, instructions }) => {
-      opts.onOauthLine?.("[auth] opening browser for Codex login");
-      if (instructions?.trim()) {
-        opts.onOauthLine?.(`[auth] ${instructions.trim()}`);
-      }
-      openUrlTask = (async () => {
-        const opened = await opener(url);
-        if (!opened) {
-          opts.onOauthLine?.(`[auth] open this URL to continue: ${url}`);
-        }
-      })().catch((error) => {
-        const message = error instanceof Error ? error.message : String(error);
-        opts.onOauthLine?.(`[auth] failed to open browser automatically: ${message}`);
-      });
-    },
-    onProgress: (message) => {
-      if (message.trim()) opts.onOauthLine?.(`[auth] ${message.trim()}`);
-    },
-    onManualCodeInput: manualCode ? async () => manualCode : undefined,
-    onPrompt: async (prompt) => {
-      if (manualCode) return manualCode;
-      throw new Error(`${prompt.message} Automatic browser callback did not complete.`);
-    },
+  opts.onOauthLine?.("[auth] starting Cowork-owned Codex browser login.");
+  return await runCodexBrowserOAuth({
+    paths: opts.paths,
+    fetchImpl: opts.fetchImpl ?? fetch,
+    onLine: opts.onOauthLine,
+    openUrl: opts.openUrl ?? openExternalUrl,
   });
-
-  if (openUrlTask) {
-    await openUrlTask;
-  }
-
-  return {
-    file: codexAuthFilePath(opts.paths),
-    issuer: CODEX_OAUTH_ISSUER,
-    clientId: CODEX_OAUTH_CLIENT_ID,
-    accessToken: credentials.access,
-    refreshToken: credentials.refresh,
-    expiresAtMs: credentials.expires,
-    accountId:
-      typeof credentials.accountId === "string" && credentials.accountId.trim()
-        ? credentials.accountId.trim()
-        : undefined,
-  };
 }
 
 async function persistCoworkCodexAuth(
@@ -292,6 +248,7 @@ export async function connectProvider(opts: {
         paths,
         onOauthLine: opts.onOauthLine,
         openUrl: opts.openUrl,
+        fetchImpl,
       });
     }
     const persistedAuth = await persistCoworkCodexAuth(paths, oauthCredentials);

--- a/src/connect.ts
+++ b/src/connect.ts
@@ -8,10 +8,8 @@ import {
   writeCodexAuthMaterial,
 } from "./providers/codex-auth";
 import {
-  completeCodexBrowserOAuth,
   isOauthCliProvider,
   runCodexBrowserOAuth,
-  type CodexBrowserOAuthPending,
 } from "./providers/codex-oauth-flows";
 import {
   getAiCoworkerPaths,
@@ -52,7 +50,6 @@ export type {
 };
 
 const connectOauthDepsDefaults = {
-  completeCodexBrowserOAuth,
   isOauthCliProvider,
   runCodexLogin: runCoworkCodexLogin,
 };
@@ -99,7 +96,6 @@ export type DisconnectProviderResult =
 
 async function runCoworkCodexLogin(opts: {
   paths: AiCoworkerPaths;
-  code?: string;
   onOauthLine?: (line: string) => void;
   openUrl?: UrlOpener;
   fetchImpl?: typeof fetch;
@@ -135,7 +131,6 @@ export async function connectProvider(opts: {
   provider: ConnectService;
   methodId?: string;
   code?: string;
-  codexBrowserAuthPending?: CodexBrowserOAuthPending;
   apiKey?: string;
   cwd?: string;
   paths?: AiCoworkerPaths;
@@ -230,27 +225,15 @@ export async function connectProvider(opts: {
     if (methodId !== "oauth_cli") {
       opts.onOauthLine?.(`[auth] deprecated Codex auth method "${methodId}" requested; using Codex-native browser login.`);
     }
-    const code = opts.code?.trim() || "";
-    let oauthCredentials: CodexAuthMaterial;
-    if (opts.codexBrowserAuthPending && code) {
-      oauthCredentials = await connectOauthDeps.completeCodexBrowserOAuth({
-        paths,
-        pending: opts.codexBrowserAuthPending,
-        fetchImpl,
-        code,
-        onLine: opts.onOauthLine,
-        openUrl: opts.openUrl,
-      });
-    } else if (code) {
-      throw new Error("Authorization code requires an active Codex OAuth challenge. Start authorization first.");
-    } else {
-      oauthCredentials = await connectOauthDeps.runCodexLogin({
-        paths,
-        onOauthLine: opts.onOauthLine,
-        openUrl: opts.openUrl,
-        fetchImpl,
-      });
+    if (opts.code?.trim()) {
+      throw new Error("Codex OAuth is browser-managed by Cowork. Start sign-in without a pasted authorization code.");
     }
+    const oauthCredentials = await connectOauthDeps.runCodexLogin({
+      paths,
+      onOauthLine: opts.onOauthLine,
+      openUrl: opts.openUrl,
+      fetchImpl,
+    });
     const persistedAuth = await persistCoworkCodexAuth(paths, oauthCredentials);
 
     store.services[provider] = {

--- a/src/providers/authRegistry.ts
+++ b/src/providers/authRegistry.ts
@@ -8,7 +8,6 @@ import {
   type DisconnectProviderResult,
   type OauthStdioMode,
 } from "../connect";
-import type { CodexBrowserOAuthPending } from "./codex-oauth-flows";
 import { PROVIDER_NAMES, type ProviderName } from "../types";
 
 export type ProviderAuthMethodType = "api" | "oauth";
@@ -31,7 +30,6 @@ export type ConnectProviderHandler = (opts: {
   provider: ProviderName;
   methodId?: string;
   code?: string;
-  codexBrowserAuthPending?: CodexBrowserOAuthPending;
   apiKey?: string;
   cwd?: string;
   paths?: AiCoworkerPaths;
@@ -92,7 +90,7 @@ export function authorizeProviderAuth(opts: {
       ok: true,
       challenge: {
         method: method.oauthMode ?? "auto",
-        instructions: "Continue to open browser-based ChatGPT OAuth and finish sign-in. The app will open the official Codex sign-in flow automatically.",
+        instructions: "Continue to browser-based ChatGPT sign-in. Cowork will open the official Codex OAuth flow and save the returned token locally.",
       },
     };
   }
@@ -201,7 +199,6 @@ export async function callbackProviderAuth(opts: {
   provider: ProviderName;
   methodId: string;
   code?: string;
-  codexBrowserAuthPending?: CodexBrowserOAuthPending;
   cwd?: string;
   paths?: AiCoworkerPaths;
   connect: ConnectProviderHandler;
@@ -215,15 +212,22 @@ export async function callbackProviderAuth(opts: {
   if (method.type !== "oauth") {
     return { ok: false, provider: opts.provider, message: `Method "${opts.methodId}" is not an OAuth method.` };
   }
-  if (method.oauthMode === "code" && !opts.code?.trim()) {
+  const code = opts.code?.trim();
+  if (method.oauthMode === "code" && !code) {
     return { ok: false, provider: opts.provider, message: "Authorization code is required." };
+  }
+  if (method.oauthMode !== "code" && code) {
+    return {
+      ok: false,
+      provider: opts.provider,
+      message: `Method "${opts.methodId}" manages OAuth in-app and does not accept a pasted authorization code.`,
+    };
   }
 
   return await opts.connect({
     provider: opts.provider,
     methodId: opts.methodId,
-    code: opts.code?.trim() || undefined,
-    codexBrowserAuthPending: opts.codexBrowserAuthPending,
+    code,
     cwd: opts.cwd,
     paths: opts.paths,
     oauthStdioMode: opts.oauthStdioMode,

--- a/src/providers/codex-auth.ts
+++ b/src/providers/codex-auth.ts
@@ -397,19 +397,19 @@ function parseCodexAuthJson(file: string, json: unknown): CodexAuthMaterial {
   const accessClaims = decodeJwtPayload(accessToken);
 
   const accountId =
-    doc.account?.account_id ??
     (idClaims ? extractAccountIdFromClaims(idClaims) : undefined) ??
-    (accessClaims ? extractAccountIdFromClaims(accessClaims) : undefined);
+    (accessClaims ? extractAccountIdFromClaims(accessClaims) : undefined) ??
+    doc.account?.account_id;
 
   const email =
-    doc.account?.email ??
     (idClaims ? extractEmailFromClaims(idClaims) : undefined) ??
-    (accessClaims ? extractEmailFromClaims(accessClaims) : undefined);
+    (accessClaims ? extractEmailFromClaims(accessClaims) : undefined) ??
+    doc.account?.email;
 
   const planType =
-    doc.account?.plan_type ??
     (idClaims ? extractPlanTypeFromClaims(idClaims) : undefined) ??
-    (accessClaims ? extractPlanTypeFromClaims(accessClaims) : undefined);
+    (accessClaims ? extractPlanTypeFromClaims(accessClaims) : undefined) ??
+    doc.account?.plan_type;
 
   return {
     file,
@@ -451,20 +451,20 @@ function parseLegacyCodexAuthJson(file: string, json: unknown): CodexAuthMateria
   const accessClaims = decodeJwtPayload(accessToken);
 
   const accountId =
-    readStringAtPath(json, ["account", "account_id"]) ??
-    readStringAtPath(json, ["chatgpt_account_id"]) ??
     (idClaims ? extractAccountIdFromClaims(idClaims) : undefined) ??
-    (accessClaims ? extractAccountIdFromClaims(accessClaims) : undefined);
+    (accessClaims ? extractAccountIdFromClaims(accessClaims) : undefined) ??
+    readStringAtPath(json, ["account", "account_id"]) ??
+    readStringAtPath(json, ["chatgpt_account_id"]);
 
   const email =
-    readStringAtPath(json, ["account", "email"]) ??
     (idClaims ? extractEmailFromClaims(idClaims) : undefined) ??
-    (accessClaims ? extractEmailFromClaims(accessClaims) : undefined);
+    (accessClaims ? extractEmailFromClaims(accessClaims) : undefined) ??
+    readStringAtPath(json, ["account", "email"]);
 
   const planType =
-    readStringAtPath(json, ["account", "plan_type"]) ??
     (idClaims ? extractPlanTypeFromClaims(idClaims) : undefined) ??
-    (accessClaims ? extractPlanTypeFromClaims(accessClaims) : undefined);
+    (accessClaims ? extractPlanTypeFromClaims(accessClaims) : undefined) ??
+    readStringAtPath(json, ["account", "plan_type"]);
 
   return {
     file,

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -1,4 +1,4 @@
-import type { AgentConfig, RuntimeName } from "../types";
+import { defaultRuntimeNameForProvider, type AgentConfig, type RuntimeName } from "../types";
 
 import { createPiRuntime } from "./piRuntime";
 import { createOpenAiResponsesRuntime } from "./openaiResponsesRuntime";
@@ -6,16 +6,21 @@ import { createOpenAiResponsesRuntime } from "./openaiResponsesRuntime";
 import type { LlmRuntime } from "./types";
 
 export function resolveRuntimeName(config: AgentConfig): RuntimeName {
-  return config.runtime ?? "pi";
+  if (config.runtime === "pi" && (config.provider === "openai" || config.provider === "codex-cli")) {
+    return "openai-responses";
+  }
+  return config.runtime ?? defaultRuntimeNameForProvider(config.provider);
 }
 
 export function createRuntime(config: AgentConfig): LlmRuntime {
   const runtimeName = resolveRuntimeName(config);
   switch (runtimeName) {
-    case "pi":
-      if (config.provider === "openai" || config.provider === "codex-cli") {
-        return createOpenAiResponsesRuntime();
+    case "openai-responses":
+      if (config.provider !== "openai" && config.provider !== "codex-cli") {
+        throw new Error(`Provider ${config.provider} does not support the OpenAI Responses runtime.`);
       }
+      return createOpenAiResponsesRuntime();
+    case "pi":
       return createPiRuntime();
   }
 }

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -6,7 +6,7 @@ import { createOpenAiResponsesRuntime } from "./openaiResponsesRuntime";
 import type { LlmRuntime } from "./types";
 
 export function resolveRuntimeName(config: AgentConfig): RuntimeName {
-  if (config.runtime === "pi" && (config.provider === "openai" || config.provider === "codex-cli")) {
+  if (config.provider === "openai" || config.provider === "codex-cli") {
     return "openai-responses";
   }
   return config.runtime ?? defaultRuntimeNameForProvider(config.provider);

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -1,4 +1,4 @@
-import { defaultRuntimeNameForProvider, type AgentConfig, type RuntimeName } from "../types";
+import { normalizeRuntimeNameForProvider, type AgentConfig, type RuntimeName } from "../types";
 
 import { createPiRuntime } from "./piRuntime";
 import { createOpenAiResponsesRuntime } from "./openaiResponsesRuntime";
@@ -6,10 +6,7 @@ import { createOpenAiResponsesRuntime } from "./openaiResponsesRuntime";
 import type { LlmRuntime } from "./types";
 
 export function resolveRuntimeName(config: AgentConfig): RuntimeName {
-  if (config.provider === "openai" || config.provider === "codex-cli") {
-    return "openai-responses";
-  }
-  return config.runtime ?? defaultRuntimeNameForProvider(config.provider);
+  return normalizeRuntimeNameForProvider(config.provider, config.runtime);
 }
 
 export function createRuntime(config: AgentConfig): LlmRuntime {

--- a/src/runtime/openaiResponsesModel.ts
+++ b/src/runtime/openaiResponsesModel.ts
@@ -14,8 +14,33 @@ import { pickKnownPiModel, type PiModel } from "./piRuntimeOptions";
 import type { RuntimeRunTurnParams } from "./types";
 
 const OPENAI_RESPONSES_BASE_URL = "https://api.openai.com/v1";
-const DEFAULT_CONTEXT_WINDOW = 0;
-const DEFAULT_MAX_TOKENS = 0;
+
+type SupportedResponsesModelLimits = Pick<PiModel, "contextWindow" | "maxTokens">;
+
+// Keep runtime token limits pinned to the supported registry surface so we do not
+// inherit unrelated fallback values from PI's broader model catalog.
+const SUPPORTED_OPENAI_RESPONSES_MODEL_LIMITS = {
+  "gpt-5-mini": { contextWindow: 400_000, maxTokens: 128_000 },
+  "gpt-5.1": { contextWindow: 400_000, maxTokens: 128_000 },
+  "gpt-5.2": { contextWindow: 400_000, maxTokens: 128_000 },
+  "gpt-5.2-codex": { contextWindow: 400_000, maxTokens: 128_000 },
+  "gpt-5.2-pro": { contextWindow: 400_000, maxTokens: 128_000 },
+  "gpt-5.4": { contextWindow: 400_000, maxTokens: 128_000 },
+  "gpt-5-codex": { contextWindow: 400_000, maxTokens: 128_000 },
+  "gpt-5.1-codex": { contextWindow: 400_000, maxTokens: 128_000 },
+  "gpt-5.1-codex-mini": { contextWindow: 400_000, maxTokens: 128_000 },
+  "gpt-5.1-codex-max": { contextWindow: 400_000, maxTokens: 128_000 },
+} as const satisfies Record<string, SupportedResponsesModelLimits>;
+
+const SUPPORTED_CODEX_BACKEND_MODEL_LIMITS = {
+  "gpt-5.1": { contextWindow: 272_000, maxTokens: 128_000 },
+  "gpt-5.4": { contextWindow: 272_000, maxTokens: 128_000 },
+  "gpt-5-codex": { contextWindow: 272_000, maxTokens: 128_000 },
+  "gpt-5.1-codex": { contextWindow: 272_000, maxTokens: 128_000 },
+  "gpt-5.1-codex-mini": { contextWindow: 272_000, maxTokens: 128_000 },
+  "gpt-5.1-codex-max": { contextWindow: 272_000, maxTokens: 128_000 },
+  "gpt-5.2-codex": { contextWindow: 272_000, maxTokens: 128_000 },
+} as const satisfies Record<string, SupportedResponsesModelLimits>;
 
 type ResolvedOpenAiResponsesModel = {
   model: PiModel;
@@ -73,11 +98,19 @@ function applySupportedOpenAiResponsesModel(
   model: PiModel,
 ): PiModel {
   const supported = assertSupportedModel(provider, modelId, "model");
+  const supportedLimits =
+    provider === "openai"
+      ? SUPPORTED_OPENAI_RESPONSES_MODEL_LIMITS[supported.id]
+      : undefined;
+  if (provider === "openai" && !supportedLimits) {
+    throw new Error(`Missing supported OpenAI Responses model limits for openai model ${supported.id}.`);
+  }
   return {
     ...model,
     id: supported.id,
     name: supported.id,
     input: supported.supportsImageInput ? ["text", "image"] : ["text"],
+    ...(supportedLimits ?? {}),
   };
 }
 
@@ -88,6 +121,15 @@ function buildSupportedCodexResponsesModel(opts: {
   baseUrl: string;
   headers?: Record<string, string>;
 }): PiModel {
+  const supportedLimits =
+    opts.api === "openai-codex-responses"
+      ? SUPPORTED_CODEX_BACKEND_MODEL_LIMITS[opts.modelId]
+      : SUPPORTED_OPENAI_RESPONSES_MODEL_LIMITS[opts.modelId];
+
+  if (!supportedLimits) {
+    throw new Error(`Missing supported OpenAI Responses model limits for codex-cli model ${opts.modelId}.`);
+  }
+
   return applySupportedOpenAiResponsesModel("codex-cli", opts.modelId, {
     id: opts.modelId,
     name: opts.modelId,
@@ -96,8 +138,7 @@ function buildSupportedCodexResponsesModel(opts: {
     baseUrl: opts.baseUrl,
     reasoning: true,
     input: ["text"],
-    contextWindow: DEFAULT_CONTEXT_WINDOW,
-    maxTokens: DEFAULT_MAX_TOKENS,
+    ...supportedLimits,
     ...(opts.headers ? { headers: { ...opts.headers } } : {}),
   });
 }

--- a/src/runtime/openaiResponsesModel.ts
+++ b/src/runtime/openaiResponsesModel.ts
@@ -1,0 +1,156 @@
+import { getSavedProviderApiKey } from "../config";
+import { getAiCoworkerPaths } from "../connect";
+import { assertSupportedModel } from "../models/registry";
+import {
+  CODEX_BACKEND_BASE_URL,
+  isTokenExpiring,
+  readCodexAuthMaterial,
+  refreshCodexAuthMaterialCoalesced,
+} from "../providers/codex-auth";
+import type { AgentConfig } from "../types";
+import { resolveCoworkHomedir } from "../utils/coworkHome";
+
+import { pickKnownPiModel, type PiModel } from "./piRuntimeOptions";
+import type { RuntimeRunTurnParams } from "./types";
+
+const OPENAI_RESPONSES_BASE_URL = "https://api.openai.com/v1";
+const DEFAULT_CONTEXT_WINDOW = 0;
+const DEFAULT_MAX_TOKENS = 0;
+
+type ResolvedOpenAiResponsesModel = {
+  model: PiModel;
+  apiKey?: string;
+  headers?: Record<string, string>;
+  accountId?: string;
+};
+
+type ResolvedCodexAuth = {
+  accessToken: string;
+  accountId?: string;
+};
+
+function runtimeHomeFromConfig(config: AgentConfig): string | undefined {
+  return resolveCoworkHomedir(config.userAgentDir);
+}
+
+async function resolveCodexAccessToken(
+  config: AgentConfig,
+  log?: (line: string) => void,
+): Promise<ResolvedCodexAuth> {
+  const paths = getAiCoworkerPaths({ homedir: runtimeHomeFromConfig(config) });
+  let material = await readCodexAuthMaterial(paths);
+  if (!material?.accessToken) {
+    throw new Error("Codex auth is missing. Run /connect codex-cli to authenticate.");
+  }
+
+  if (isTokenExpiring(material) && material.refreshToken) {
+    try {
+      material = await refreshCodexAuthMaterialCoalesced({
+        paths,
+        material,
+        fetchImpl: fetch,
+      });
+      log?.("[auth] refreshed Codex runtime token");
+    } catch (error) {
+      log?.(`[warn] failed to refresh Codex runtime token: ${String(error)}`);
+    }
+  }
+
+  if (isTokenExpiring(material, 0)) {
+    throw new Error("Codex token is expired. Run /connect codex-cli to re-authenticate.");
+  }
+
+  const accountId = material.accountId?.trim();
+  return {
+    accessToken: material.accessToken,
+    ...(accountId ? { accountId } : {}),
+  };
+}
+
+function applySupportedOpenAiResponsesModel(
+  provider: "openai" | "codex-cli",
+  modelId: string,
+  model: PiModel,
+): PiModel {
+  const supported = assertSupportedModel(provider, modelId, "model");
+  return {
+    ...model,
+    id: supported.id,
+    name: supported.id,
+    input: supported.supportsImageInput ? ["text", "image"] : ["text"],
+  };
+}
+
+function buildSupportedCodexResponsesModel(opts: {
+  modelId: string;
+  api: "openai-responses" | "openai-codex-responses";
+  provider: "openai" | "openai-codex";
+  baseUrl: string;
+  headers?: Record<string, string>;
+}): PiModel {
+  return applySupportedOpenAiResponsesModel("codex-cli", opts.modelId, {
+    id: opts.modelId,
+    name: opts.modelId,
+    api: opts.api,
+    provider: opts.provider,
+    baseUrl: opts.baseUrl,
+    reasoning: true,
+    input: ["text"],
+    contextWindow: DEFAULT_CONTEXT_WINDOW,
+    maxTokens: DEFAULT_MAX_TOKENS,
+    ...(opts.headers ? { headers: { ...opts.headers } } : {}),
+  });
+}
+
+export async function resolveOpenAiResponsesModel(
+  params: RuntimeRunTurnParams,
+): Promise<ResolvedOpenAiResponsesModel> {
+  const modelId = params.config.model;
+  const provider = params.config.provider;
+
+  if (provider === "openai") {
+    const model = pickKnownPiModel("openai", modelId);
+    if (!model) {
+      throw new Error(`No OpenAI Responses model metadata available for provider openai (model: ${modelId}).`);
+    }
+    return {
+      model: applySupportedOpenAiResponsesModel(provider, modelId, model),
+      apiKey: getSavedProviderApiKey(params.config, "openai"),
+    };
+  }
+
+  if (provider !== "codex-cli") {
+    throw new Error(`Unsupported provider for OpenAI Responses runtime: ${provider}`);
+  }
+
+  const savedKey = getSavedProviderApiKey(params.config, "codex-cli");
+  if (savedKey) {
+    return {
+      model: buildSupportedCodexResponsesModel({
+        modelId,
+        api: "openai-responses",
+        provider: "openai",
+        baseUrl: OPENAI_RESPONSES_BASE_URL,
+      }),
+      apiKey: savedKey,
+    };
+  }
+
+  const codexAuth = await resolveCodexAccessToken(params.config, params.log);
+  const codexHeaders = codexAuth.accountId
+    ? { "ChatGPT-Account-ID": codexAuth.accountId }
+    : undefined;
+
+  return {
+    model: buildSupportedCodexResponsesModel({
+      modelId,
+      api: "openai-codex-responses",
+      provider: "openai-codex",
+      baseUrl: CODEX_BACKEND_BASE_URL,
+      ...(codexHeaders ? { headers: codexHeaders } : {}),
+    }),
+    apiKey: codexAuth.accessToken,
+    ...(codexAuth.accountId ? { accountId: codexAuth.accountId } : {}),
+    ...(codexHeaders ? { headers: codexHeaders } : {}),
+  };
+}

--- a/src/runtime/openaiResponsesModel.ts
+++ b/src/runtime/openaiResponsesModel.ts
@@ -19,7 +19,7 @@ type SupportedResponsesModelLimits = Pick<PiModel, "contextWindow" | "maxTokens"
 
 // Keep runtime token limits pinned to the supported registry surface so we do not
 // inherit unrelated fallback values from PI's broader model catalog.
-const SUPPORTED_OPENAI_RESPONSES_MODEL_LIMITS = {
+const SUPPORTED_OPENAI_RESPONSES_MODEL_LIMITS: Record<string, SupportedResponsesModelLimits> = {
   "gpt-5-mini": { contextWindow: 400_000, maxTokens: 128_000 },
   "gpt-5.1": { contextWindow: 400_000, maxTokens: 128_000 },
   "gpt-5.2": { contextWindow: 400_000, maxTokens: 128_000 },
@@ -30,9 +30,9 @@ const SUPPORTED_OPENAI_RESPONSES_MODEL_LIMITS = {
   "gpt-5.1-codex": { contextWindow: 400_000, maxTokens: 128_000 },
   "gpt-5.1-codex-mini": { contextWindow: 400_000, maxTokens: 128_000 },
   "gpt-5.1-codex-max": { contextWindow: 400_000, maxTokens: 128_000 },
-} as const satisfies Record<string, SupportedResponsesModelLimits>;
+};
 
-const SUPPORTED_CODEX_BACKEND_MODEL_LIMITS = {
+const SUPPORTED_CODEX_BACKEND_MODEL_LIMITS: Record<string, SupportedResponsesModelLimits> = {
   "gpt-5.1": { contextWindow: 272_000, maxTokens: 128_000 },
   "gpt-5.4": { contextWindow: 272_000, maxTokens: 128_000 },
   "gpt-5-codex": { contextWindow: 272_000, maxTokens: 128_000 },
@@ -40,7 +40,7 @@ const SUPPORTED_CODEX_BACKEND_MODEL_LIMITS = {
   "gpt-5.1-codex-mini": { contextWindow: 272_000, maxTokens: 128_000 },
   "gpt-5.1-codex-max": { contextWindow: 272_000, maxTokens: 128_000 },
   "gpt-5.2-codex": { contextWindow: 272_000, maxTokens: 128_000 },
-} as const satisfies Record<string, SupportedResponsesModelLimits>;
+};
 
 type ResolvedOpenAiResponsesModel = {
   model: PiModel;

--- a/src/runtime/openaiResponsesRuntime.ts
+++ b/src/runtime/openaiResponsesRuntime.ts
@@ -9,12 +9,12 @@ import {
   matchingProviderState,
   nextProviderState,
   parseTelemetrySettings,
-  resolvePiModel,
   splitStepOverrides,
   startModelCallSpan,
   supportsProviderManagedContinuation,
   toolMapToPiTools,
 } from "./piRuntime";
+import { resolveOpenAiResponsesModel } from "./openaiResponsesModel";
 import { asNonEmptyString, asRecord, asString, extractToolCallsFromAssistant } from "./piRuntimeOptions";
 import {
   extractPiAssistantText,
@@ -43,7 +43,7 @@ export function createOpenAiResponsesRuntime(
 ): LlmRuntime {
   const runStepImpl = overrides.runStepImpl ?? runOpenAiNativeResponseStep;
   return {
-    name: "pi",
+    name: "openai-responses",
     runTurn: async (params: RuntimeRunTurnParams): Promise<RuntimeRunTurnResult> => {
       const emitPart = async (part: unknown) => {
         if (!params.onModelStreamPart) return;
@@ -51,7 +51,7 @@ export function createOpenAiResponsesRuntime(
       };
 
       try {
-        const resolved = await resolvePiModel(params);
+        const resolved = await resolveOpenAiResponsesModel(params);
         const telemetry = parseTelemetrySettings(params.telemetry);
         const piTools = toolMapToPiTools(params.tools);
         const includeUnknownRawParts = params.includeRawChunks ?? true;

--- a/src/runtime/piRuntime.ts
+++ b/src/runtime/piRuntime.ts
@@ -16,13 +16,6 @@ import {
 import { mapPiEventToRawParts } from "./piStreamParts";
 
 import { getSavedProviderApiKey } from "../config";
-import { getAiCoworkerPaths } from "../connect";
-import {
-  CODEX_BACKEND_BASE_URL,
-  isTokenExpiring,
-  readCodexAuthMaterial,
-  refreshCodexAuthMaterialCoalesced,
-} from "../providers/codex-auth";
 import {
   getOpenCodeModelPricing,
   getOpenCodeModelSpec,
@@ -32,7 +25,7 @@ import {
   resolveOpenCodeApiKey,
   type OpenCodeProviderName,
 } from "../providers/opencodeShared";
-import type { AgentConfig, ModelMessage, ProviderName } from "../types";
+import type { ModelMessage, ProviderName } from "../types";
 import { assertSupportedModel } from "../models/registry";
 import type { TelemetrySettings } from "../observability/runtime";
 import {
@@ -52,7 +45,6 @@ import {
 } from "./piMessageBridge";
 import { maybeSpillToolOutputToWorkspace } from "./toolOutputOverflow";
 import type { LlmRuntime, RuntimeRunTurnParams, RuntimeRunTurnResult, RuntimeStepOverride, RuntimeToolDefinition } from "./types";
-import { resolveCoworkHomedir } from "../utils/coworkHome";
 
 function safeJsonStringify(value: unknown): string {
   try {
@@ -153,19 +145,10 @@ export function isAbortLikeError(error: unknown, signal?: AbortSignal): boolean 
   return false;
 }
 
-function runtimeHomeFromConfig(config: AgentConfig): string | undefined {
-  return resolveCoworkHomedir(config.userAgentDir);
-}
-
 export type ResolvedPiRuntimeModel = {
   model: PiModel;
   apiKey?: string;
   headers?: Record<string, string>;
-  accountId?: string;
-};
-
-type ResolvedCodexAuth = {
-  accessToken: string;
   accountId?: string;
 };
 
@@ -219,40 +202,6 @@ type RuntimeStepState = {
   piMessages: Array<Record<string, unknown>>;
 };
 
-async function resolveCodexAccessToken(
-  config: AgentConfig,
-  log?: (line: string) => void
-): Promise<ResolvedCodexAuth> {
-  const paths = getAiCoworkerPaths({ homedir: runtimeHomeFromConfig(config) });
-  let material = await readCodexAuthMaterial(paths);
-  if (!material?.accessToken) {
-    throw new Error("Codex auth is missing. Run /connect codex-cli to authenticate.");
-  }
-
-  if (isTokenExpiring(material) && material.refreshToken) {
-    try {
-      material = await refreshCodexAuthMaterialCoalesced({
-        paths,
-        material,
-        fetchImpl: fetch,
-      });
-      log?.("[auth] refreshed Codex runtime token");
-    } catch (error) {
-      log?.(`[warn] failed to refresh Codex runtime token: ${String(error)}`);
-    }
-  }
-
-  if (isTokenExpiring(material, 0)) {
-    throw new Error("Codex token is expired. Run /connect codex-cli to re-authenticate.");
-  }
-
-  const accountId = material.accountId?.trim();
-  return {
-    accessToken: material.accessToken,
-    ...(accountId ? { accountId } : {}),
-  };
-}
-
 export async function resolvePiModel(params: RuntimeRunTurnParams): Promise<ResolvedPiRuntimeModel> {
   const modelId = params.config.model;
   const provider = params.config.provider;
@@ -296,47 +245,7 @@ export async function resolvePiModel(params: RuntimeRunTurnParams): Promise<Reso
   }
 
   if (provider === "codex-cli") {
-    const savedKey = getSavedProviderApiKey(params.config, "codex-cli");
-    if (savedKey) {
-      const openaiModel = pickKnownPiModel("openai", modelId);
-      if (!openaiModel) {
-        throw new Error(`No PI model metadata available for provider codex-cli/openai (model: ${modelId}).`);
-      }
-      return {
-        model: applySupportedModelMetadata({
-          ...openaiModel,
-          id: modelId,
-          name: modelId,
-          provider: "openai",
-          api: "openai-responses",
-        }, provider, modelId),
-        apiKey: savedKey,
-      };
-    }
-
-    const codexModel = pickKnownPiModel("openai-codex", modelId);
-    if (!codexModel) {
-      throw new Error(`No PI model metadata available for provider codex-cli/openai-codex (model: ${modelId}).`);
-    }
-    const codexAuth = await resolveCodexAccessToken(params.config, params.log);
-    const codexHeaders = codexAuth.accountId
-      ? { "ChatGPT-Account-ID": codexAuth.accountId }
-      : undefined;
-
-    return {
-      model: applySupportedModelMetadata({
-        ...codexModel,
-        id: modelId,
-        name: modelId,
-        provider: "openai-codex",
-        api: "openai-codex-responses",
-        baseUrl: CODEX_BACKEND_BASE_URL,
-        ...(codexHeaders ? { headers: { ...(codexModel.headers ?? {}), ...codexHeaders } } : {}),
-      }, provider, modelId),
-      apiKey: codexAuth.accessToken,
-      ...(codexAuth.accountId ? { accountId: codexAuth.accountId } : {}),
-      ...(codexHeaders ? { headers: codexHeaders } : {}),
-    };
+    throw new Error("codex-cli is handled by the OpenAI Responses runtime model resolver.");
   }
 
   const exhaustive: never = provider;

--- a/src/server/session/ProviderAuthManager.ts
+++ b/src/server/session/ProviderAuthManager.ts
@@ -1,5 +1,4 @@
 import type { getAiCoworkerPaths } from "../../connect";
-import { createCodexBrowserOAuthChallenge, type CodexBrowserOAuthPending } from "../../providers/codex-oauth-flows";
 import {
   type ConnectProviderHandler,
   authorizeProviderAuth,
@@ -17,8 +16,6 @@ import type { ServerEvent } from "../protocol";
 import { assertSupportedModel } from "../../models/registry";
 
 export class ProviderAuthManager {
-  private pendingCodexBrowserAuth: CodexBrowserOAuthPending | null = null;
-
   constructor(
     private readonly opts: {
       sessionId: string;
@@ -52,11 +49,6 @@ export class ProviderAuthManager {
       runProviderConnect: ConnectProviderHandler;
     }
   ) {}
-
-  private clearPendingCodexBrowserAuth(): void {
-    this.pendingCodexBrowserAuth?.close();
-    this.pendingCodexBrowserAuth = null;
-  }
 
   async setModel(modelIdRaw: string, providerRaw?: AgentConfig["provider"]) {
     const modelId = modelIdRaw.trim();
@@ -144,9 +136,6 @@ export class ProviderAuthManager {
       this.opts.emitError("validation_failed", "provider", `Unsupported auth method "${methodId}" for ${providerRaw}.`);
       return;
     }
-    if (providerRaw !== "codex-cli" || methodId !== "oauth_cli") {
-      this.clearPendingCodexBrowserAuth();
-    }
 
     const result = authorizeProviderAuth({ provider: providerRaw, methodId });
     if (!result.ok) {
@@ -159,34 +148,12 @@ export class ProviderAuthManager {
       });
       return;
     }
-    if (providerRaw === "codex-cli" && methodId === "oauth_cli") {
-      try {
-        this.clearPendingCodexBrowserAuth();
-        // Keep manual-code fallback state, but do not bind a localhost server at
-        // authorize time. The live browser-login flow starts during callback.
-        this.pendingCodexBrowserAuth = createCodexBrowserOAuthChallenge();
-      } catch (err) {
-        const message = this.opts.formatError(err);
-        this.opts.emitError("provider_error", "provider", `Codex OAuth initialization failed: ${message}`);
-        this.opts.emitTelemetry("provider.auth.authorize", "error", {
-          sessionId: this.opts.sessionId,
-          provider: providerRaw,
-          methodId,
-          error: message,
-        });
-        return;
-      }
-    }
     this.opts.emit({
       type: "provider_auth_challenge",
       sessionId: this.opts.sessionId,
       provider: providerRaw,
       methodId,
-      challenge: this.pendingCodexBrowserAuth && providerRaw === "codex-cli" && methodId === "oauth_cli"
-        ? {
-            ...result.challenge,
-          }
-        : result.challenge,
+      challenge: result.challenge,
     });
     this.opts.emitTelemetry("provider.auth.authorize", "ok", {
       sessionId: this.opts.sessionId,
@@ -220,8 +187,6 @@ export class ProviderAuthManager {
         provider: providerRaw,
         methodId,
         code,
-        codexBrowserAuthPending:
-          providerRaw === "codex-cli" && methodId === "oauth_cli" ? this.pendingCodexBrowserAuth ?? undefined : undefined,
         cwd: config.workingDirectory,
         paths: this.opts.getCoworkPaths(),
         connect: async (opts) => await this.opts.runProviderConnect(opts),
@@ -272,9 +237,6 @@ export class ProviderAuthManager {
         Date.now() - startedAt
       );
     } finally {
-      if (providerRaw === "codex-cli" && methodId === "oauth_cli") {
-        this.clearPendingCodexBrowserAuth();
-      }
       this.opts.setConnecting(false);
     }
   }
@@ -284,9 +246,6 @@ export class ProviderAuthManager {
     if (!isProviderName(providerRaw)) {
       this.opts.emitError("validation_failed", "provider", `Unsupported provider: ${String(providerRaw)}`);
       return;
-    }
-    if (providerRaw === "codex-cli") {
-      this.clearPendingCodexBrowserAuth();
     }
 
     this.opts.setConnecting(true);

--- a/src/server/session/ProviderAuthManager.ts
+++ b/src/server/session/ProviderAuthManager.ts
@@ -10,7 +10,7 @@ import {
 } from "../../providers/authRegistry";
 import { getOpenCodeDisplayName, isOpenCodeProviderName, isOpenCodeSiblingPair } from "../../providers/opencodeShared";
 import { supportsOpenAiContinuation } from "../../shared/openaiContinuation";
-import { isProviderName } from "../../types";
+import { defaultRuntimeNameForProvider, isProviderName } from "../../types";
 import type { AgentConfig, ServerErrorCode, ServerErrorSource } from "../../types";
 import type { ServerEvent } from "../protocol";
 import { assertSupportedModel } from "../../models/registry";
@@ -77,12 +77,16 @@ export class ProviderAuthManager {
     const nextSubAgentModel = currentConfig.provider !== nextProvider || currentConfig.subAgentModel === currentConfig.model
       ? modelId
       : currentConfig.subAgentModel;
+    const nextRuntime = currentConfig.provider === nextProvider
+      ? currentConfig.runtime
+      : defaultRuntimeNameForProvider(nextProvider);
     const shouldClearProviderState =
       currentConfig.provider !== nextProvider || currentConfig.model !== modelId;
 
     this.opts.setConfig({
       ...currentConfig,
       provider: nextProvider,
+      ...(nextRuntime !== undefined ? { runtime: nextRuntime } : {}),
       model: modelId,
       subAgentModel: nextSubAgentModel,
     });

--- a/src/server/startServer.ts
+++ b/src/server/startServer.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { getAiCoworkerPaths as getAiCoworkerPathsDefault } from "../connect";
 import type { connectProvider as connectModelProvider, getAiCoworkerPaths } from "../connect";
 import type { runTurn as runTurnFn } from "../agent";
-import type { AgentConfig } from "../types";
+import { defaultRuntimeNameForProvider, type AgentConfig } from "../types";
 import { loadConfig } from "../config";
 import { loadSubAgentPrompt, loadSystemPromptWithSkills } from "../prompt";
 import type { OpenAiCompatibleProviderOptionsByProvider } from "../shared/openaiCompatibleOptions";
@@ -156,6 +156,9 @@ function mergeConfigPatch(
 ): AgentConfig {
   const { clearToolOutputOverflowChars: _clearToolOutputOverflowChars, ...configPatch } = patch;
   const next: AgentConfig = { ...config, ...configPatch };
+  if (patch.provider !== undefined && patch.provider !== config.provider) {
+    next.runtime = defaultRuntimeNameForProvider(patch.provider);
+  }
   if (patch.toolOutputOverflowChars !== undefined) {
     next.projectConfigOverrides = {
       ...config.projectConfigOverrides,

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,7 @@ export function resolveProviderName(v: unknown): ProviderName | null {
 
 export const RUNTIME_NAMES = [
   "pi",
+  "openai-responses",
 ] as const;
 
 export type RuntimeName = (typeof RUNTIME_NAMES)[number];
@@ -37,6 +38,13 @@ const runtimeNameSchema = z.enum(RUNTIME_NAMES);
 export function resolveRuntimeName(v: unknown): RuntimeName | null {
   const parsed = runtimeNameSchema.safeParse(v);
   return parsed.success ? parsed.data : null;
+}
+
+export function defaultRuntimeNameForProvider(provider: ProviderName): RuntimeName {
+  if (provider === "openai" || provider === "codex-cli") {
+    return "openai-responses";
+  }
+  return "pi";
 }
 
 export type CommandSource = "command" | "mcp" | "skill";

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,6 +47,19 @@ export function defaultRuntimeNameForProvider(provider: ProviderName): RuntimeNa
   return "pi";
 }
 
+export function normalizeRuntimeNameForProvider(
+  provider: ProviderName,
+  runtime: RuntimeName | null | undefined,
+): RuntimeName {
+  if (provider === "openai" || provider === "codex-cli") {
+    return "openai-responses";
+  }
+  if (runtime === "openai-responses") {
+    return defaultRuntimeNameForProvider(provider);
+  }
+  return runtime ?? defaultRuntimeNameForProvider(provider);
+}
+
 export type CommandSource = "command" | "mcp" | "skill";
 
 export interface CommandInfo {

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -49,6 +49,7 @@
 - For Electron main-process dependencies that publish CommonJS, do not use named ESM imports in packaged code paths; load them through CommonJS interop (`createRequire` or equivalent) and verify packaged startup before shipping a release.
 - When the user asks to remove a broken platform from a release, do not assume they want CI packaging changed too; separate public release asset cleanup from the build matrix unless they explicitly ask to stop building it.
 - For Codex auth bugs, verify the entire acquisition stack end to end; removing a broken OAuth link is not enough if `connect.ts` still uses a different custom flow than the PI-native Codex login the runtime expects.
+- When the user wants Cowork to own the Codex OAuth handoff, remove pasted-code/manual callback branches from the product flow and start the browser/login exchange through the in-app auto OAuth path instead.
 - For desktop auth regressions, clear stale `provider_auth_challenge` UI state when the live flow changes; an old cached challenge URL can keep surfacing a dead `Open link` even after the server-side OAuth path is fixed.
 - On Windows, never open OAuth URLs through `cmd /c start` without avoiding shell parsing; query-string `&` separators get split into separate commands and the browser receives a truncated auth URL.
 - When the user flags that the Windows version was not pushed, distinguish missing downloadable installer assets from missing auto-update metadata; a runtime updater fix does not satisfy release availability by itself.

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -92,7 +92,7 @@ describe("loadConfig", () => {
     expect(cfg.model).toBe("gpt-5.4");
   });
 
-  test("runtime defaults to pi and ignores unsupported AGENT_RUNTIME values", async () => {
+  test("runtime defaults follow the resolved provider and ignore unsupported AGENT_RUNTIME values", async () => {
     const { cwd, home } = await makeTmpDirs();
 
     const cfg = await loadConfig({
@@ -103,13 +103,25 @@ describe("loadConfig", () => {
     });
     expect(cfg.runtime).toBe("pi");
 
+    await writeJson(path.join(cwd, ".agent", "config.json"), {
+      provider: "openai",
+      model: "gpt-5.4",
+    });
+    const openAiCfg = await loadConfig({
+      cwd,
+      homedir: home,
+      builtInDir: repoRoot(),
+      env: {},
+    });
+    expect(openAiCfg.runtime).toBe("openai-responses");
+
     const cfg2 = await loadConfig({
       cwd,
       homedir: home,
       builtInDir: repoRoot(),
       env: { AGENT_RUNTIME: "legacy-runtime" },
     });
-    expect(cfg2.runtime).toBe("pi");
+    expect(cfg2.runtime).toBe("openai-responses");
   });
 
   // ---- New tests ----

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -124,6 +124,46 @@ describe("loadConfig", () => {
     expect(cfg2.runtime).toBe("openai-responses");
   });
 
+  test("legacy pi runtime config is normalized away for openai providers", async () => {
+    const { cwd, home } = await makeTmpDirs();
+
+    await writeJson(path.join(cwd, ".agent", "config.json"), {
+      provider: "openai",
+      model: "gpt-5.4",
+      runtime: "pi",
+    });
+
+    const cfg = await loadConfig({
+      cwd,
+      homedir: home,
+      builtInDir: repoRoot(),
+      env: {},
+    });
+
+    expect(cfg.provider).toBe("openai");
+    expect(cfg.runtime).toBe("openai-responses");
+  });
+
+  test("legacy pi runtime config is normalized away for codex-cli providers", async () => {
+    const { cwd, home } = await makeTmpDirs();
+
+    await writeJson(path.join(cwd, ".agent", "config.json"), {
+      provider: "codex-cli",
+      model: "gpt-5.4",
+      runtime: "pi",
+    });
+
+    const cfg = await loadConfig({
+      cwd,
+      homedir: home,
+      builtInDir: repoRoot(),
+      env: {},
+    });
+
+    expect(cfg.provider).toBe("codex-cli");
+    expect(cfg.runtime).toBe("openai-responses");
+  });
+
   // ---- New tests ----
 
   test("defaults loaded from built-in defaults.json", async () => {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -164,6 +164,26 @@ describe("loadConfig", () => {
     expect(cfg.runtime).toBe("openai-responses");
   });
 
+  test("stale OpenAI Responses runtime config is normalized away for non-OpenAI providers", async () => {
+    const { cwd, home } = await makeTmpDirs();
+
+    await writeJson(path.join(cwd, ".agent", "config.json"), {
+      provider: "google",
+      model: "gemini-3-flash-preview",
+      runtime: "openai-responses",
+    });
+
+    const cfg = await loadConfig({
+      cwd,
+      homedir: home,
+      builtInDir: repoRoot(),
+      env: {},
+    });
+
+    expect(cfg.provider).toBe("google");
+    expect(cfg.runtime).toBe("pi");
+  });
+
   // ---- New tests ----
 
   test("defaults loaded from built-in defaults.json", async () => {

--- a/test/connect.test.ts
+++ b/test/connect.test.ts
@@ -27,14 +27,6 @@ const runCodexLoginMock = mock(async (opts: any) => {
   return buildMockCodexMaterial(opts.paths);
 });
 
-const completeCodexBrowserOAuthMock = mock(async (opts: any) => {
-  return buildMockCodexMaterial(opts.paths, {
-    accessToken: "manual-access-token",
-    refreshToken: "manual-refresh-token",
-    accountId: "acc_manual",
-  });
-});
-
 const {
   connectProvider,
   getAiCoworkerPaths,
@@ -84,16 +76,8 @@ describe("connectProvider", () => {
   beforeEach(() => {
     connectInternal.setOauthDepsForTests({
       isOauthCliProvider: (provider: string) => provider === "codex-cli",
-      completeCodexBrowserOAuth: completeCodexBrowserOAuthMock,
       runCodexLogin: runCodexLoginMock,
     });
-    completeCodexBrowserOAuthMock.mockReset();
-    completeCodexBrowserOAuthMock.mockImplementation(async (opts: any) =>
-      buildMockCodexMaterial(opts.paths, {
-        accessToken: "manual-access-token",
-        refreshToken: "manual-refresh-token",
-        accountId: "acc_manual",
-      }));
     runCodexLoginMock.mockReset();
     runCodexLoginMock.mockImplementation(async (opts: any) => {
       await opts.openUrl?.(mockedAuthorizeUrl);
@@ -410,43 +394,20 @@ describe("connectProvider", () => {
     expect(persisted?.account?.account_id).toBe("acc_rewritten");
   });
 
-  test("codex-cli consumes a manual authorization code when a pending browser challenge exists", async () => {
+  test("codex-cli rejects pasted authorization codes because Cowork owns the browser handoff", async () => {
     const home = await makeTmpHome();
     const paths = getAiCoworkerPaths({ homedir: home });
-    const pending = {
-      authUrl: mockedAuthorizeUrl,
-      redirectUri: `http://${OAUTH_LOOPBACK_HOST}:1455/auth/callback`,
-      codeVerifier: "verifier_123",
-      waitForCode: Promise.resolve("unused-browser-code"),
-      close: () => {},
-    };
 
     const result = await connectProvider({
       provider: "codex-cli",
       code: "manual-auth-code",
-      codexBrowserAuthPending: pending,
       paths,
     });
 
-    expect(result.ok).toBe(true);
-    if (!result.ok) return;
-    expect(result.mode).toBe("oauth");
+    expect(result.ok).toBe(false);
     expect(runCodexLoginMock).not.toHaveBeenCalled();
-    expect(completeCodexBrowserOAuthMock).toHaveBeenCalledTimes(1);
-    expect(completeCodexBrowserOAuthMock.mock.calls[0]?.[0]).toMatchObject({
-      code: "manual-auth-code",
-      pending: {
-        redirectUri: pending.redirectUri,
-        codeVerifier: pending.codeVerifier,
-      },
-    });
-
-    const persisted = JSON.parse(
-      await fs.readFile(path.join(home, ".cowork", "auth", "codex-cli", "auth.json"), "utf-8"),
-    ) as any;
-    expect(persisted?.tokens?.access_token).toBe("manual-access-token");
-    expect(persisted?.tokens?.refresh_token).toBe("manual-refresh-token");
-    expect(persisted?.account?.account_id).toBe("acc_manual");
+    expect(result.message).toContain("browser-managed by Cowork");
+    await expect(fs.readFile(path.join(home, ".cowork", "auth", "codex-cli", "auth.json"), "utf-8")).rejects.toThrow();
   });
 
 });

--- a/test/providers/auth-registry.test.ts
+++ b/test/providers/auth-registry.test.ts
@@ -41,7 +41,7 @@ describe("providers/authRegistry", () => {
     if (!result.ok) return;
     expect(result.challenge.method).toBe("auto");
     expect(result.challenge.url).toBeUndefined();
-    expect(result.challenge.instructions).toContain("official Codex sign-in flow automatically");
+    expect(result.challenge.instructions).toContain("save the returned token locally");
   });
 
   test("authorizeProviderAuth fails for api key method", () => {
@@ -177,7 +177,7 @@ describe("providers/authRegistry", () => {
     expect(connect).toHaveBeenCalledTimes(1);
   });
 
-  test("callbackProviderAuth forwards the full oauth callback context to connect handler", async () => {
+  test("callbackProviderAuth rejects pasted codes for auto oauth methods", async () => {
     const connect = mock(async (opts: any) => ({
       ok: true as const,
       provider: opts.provider,
@@ -185,41 +185,17 @@ describe("providers/authRegistry", () => {
       storageFile: "/tmp/connections.json",
       message: "oauth complete",
     }));
-    const home = await fs.mkdtemp(path.join(os.tmpdir(), "cowork-auth-registry-callback-"));
-    const paths = getAiCoworkerPaths({ homedir: home });
-    const pending = {
-      authUrl: "https://example.test/oauth",
-      redirectUri: "http://localhost:9999/callback",
-      codeVerifier: "verifier-123",
-      waitForCode: Promise.resolve("browser-code"),
-      close: () => {},
-    };
-    const onOauthLine = mock((_line: string) => {});
 
     const result = await callbackProviderAuth({
       provider: "codex-cli",
       methodId: "oauth_cli",
       code: "  auth-code-123  ",
-      codexBrowserAuthPending: pending,
-      cwd: "/tmp/workspace",
-      paths,
       connect,
-      oauthStdioMode: "pipe",
-      onOauthLine,
     });
 
-    expect(result.ok).toBe(true);
-    expect(connect).toHaveBeenCalledTimes(1);
-    expect(connect.mock.calls[0]?.[0]).toMatchObject({
-      provider: "codex-cli",
-      methodId: "oauth_cli",
-      code: "auth-code-123",
-      codexBrowserAuthPending: pending,
-      cwd: "/tmp/workspace",
-      paths,
-      oauthStdioMode: "pipe",
-      onOauthLine,
-    });
+    expect(result.ok).toBe(false);
+    expect(connect).not.toHaveBeenCalled();
+    expect(result.message).toContain("does not accept a pasted authorization code");
   });
 
   test("copyProviderApiKey reuses a saved sibling key without exposing it", async () => {

--- a/test/providers/codex-auth.test.ts
+++ b/test/providers/codex-auth.test.ts
@@ -364,6 +364,56 @@ describe("readCodexAuthMaterial fallback behavior", () => {
     expect(material?.refreshToken).toBe("legacy-refresh-token");
   });
 
+  test("token claims override stale persisted account metadata", async () => {
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), "codex-auth-read-stale-account-"));
+    const paths = makePaths(home);
+    const coworkPath = path.join(paths.authDir, "codex-cli", "auth.json");
+    const accessToken = makeJwt({
+      exp: Math.floor(Date.now() / 1000) + 3600,
+      email: "token@example.com",
+    });
+    const idToken = makeJwt({
+      "https://api.openai.com/auth": {
+        chatgpt_account_id: "acct_token",
+        chatgpt_plan_type: "pro",
+      },
+      "https://api.openai.com/profile": {
+        email: "token@example.com",
+      },
+    });
+    await fs.mkdir(path.dirname(coworkPath), { recursive: true });
+    await fs.writeFile(
+      coworkPath,
+      JSON.stringify(
+        {
+          version: 1,
+          auth_mode: "chatgpt",
+          issuer: CODEX_OAUTH_ISSUER,
+          client_id: CODEX_OAUTH_CLIENT_ID,
+          tokens: {
+            access_token: accessToken,
+            refresh_token: "refresh-token",
+            id_token: idToken,
+          },
+          account: {
+            account_id: "acct_stale",
+            email: "stale@example.com",
+            plan_type: "free",
+          },
+        },
+        null,
+        2
+      ),
+      "utf-8"
+    );
+
+    const material = await readCodexAuthMaterial(paths);
+
+    expect(material?.accountId).toBe("acct_token");
+    expect(material?.email).toBe("token@example.com");
+    expect(material?.planType).toBe("pro");
+  });
+
   test("imports legacy ~/.codex auth into Cowork auth.json when Cowork auth is missing", async () => {
     const home = await fs.mkdtemp(path.join(os.tmpdir(), "codex-auth-import-legacy-"));
     const paths = makePaths(home);

--- a/test/runtime.openai-responses-runtime.test.ts
+++ b/test/runtime.openai-responses-runtime.test.ts
@@ -4,8 +4,8 @@ import os from "node:os";
 import path from "node:path";
 
 import { createOpenAiResponsesRuntime } from "../src/runtime/openaiResponsesRuntime";
+import { defaultSupportedModel } from "../src/models/registry";
 import { writeCodexAuthMaterial } from "../src/providers/codex-auth";
-import { getModels as getPiModels } from "@mariozechner/pi-ai";
 import { __internal as openAiNativeInternal } from "../src/runtime/openaiNativeResponses";
 import {
   MODEL_SCRATCHPAD_DIRNAME,
@@ -47,8 +47,7 @@ function makeParams(config: AgentConfig, overrides: Partial<RuntimeRunTurnParams
 }
 
 function pickCodexModelId(): string {
-  const models = (getPiModels("openai-codex" as any) as Array<{ id?: string }> | undefined) ?? [];
-  return models[0]?.id ?? "gpt-5-codex";
+  return defaultSupportedModel("codex-cli").id;
 }
 
 describe("openai responses runtime", () => {

--- a/test/runtime.pi-runtime.test.ts
+++ b/test/runtime.pi-runtime.test.ts
@@ -3,13 +3,14 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
-import { getModels as getPiModels } from "@mariozechner/pi-ai";
 import { z } from "zod";
 
 import type { RuntimeRunTurnParams } from "../src/runtime/types";
 import type { AgentConfig, ModelMessage } from "../src/types";
 import { getAiCoworkerPaths } from "../src/connect";
+import { defaultSupportedModel } from "../src/models/registry";
 import { CODEX_BACKEND_BASE_URL, writeCodexAuthMaterial } from "../src/providers/codex-auth";
+import { resolveOpenAiResponsesModel } from "../src/runtime/openaiResponsesModel";
 import { __internal as piRuntimeInternal, createPiRuntime } from "../src/runtime/piRuntime";
 import { MODEL_SCRATCHPAD_DIRNAME, TOOL_OUTPUT_OVERFLOW_PREVIEW_CHARS } from "../src/shared/toolOutputOverflow";
 
@@ -56,8 +57,7 @@ function makeParams(config: AgentConfig, overrides: Partial<RuntimeRunTurnParams
 }
 
 function pickCodexModelId(): string {
-  const models = (getPiModels("openai-codex" as any) as Array<{ id?: string }> | undefined) ?? [];
-  return models[0]?.id ?? "codex-mini-latest";
+  return defaultSupportedModel("codex-cli").id;
 }
 
 async function withEnv<T>(
@@ -116,7 +116,7 @@ describe("pi runtime regressions", () => {
       subAgentModel: pickCodexModelId(),
     });
 
-    const resolved = await piRuntimeInternal.resolvePiModel(makeParams(config));
+    const resolved = await resolveOpenAiResponsesModel(makeParams(config));
 
     expect(resolved.apiKey).toBe("tok_live");
     expect(resolved.headers).toEqual({ "ChatGPT-Account-ID": "acct_123" });
@@ -149,7 +149,7 @@ describe("pi runtime regressions", () => {
       subAgentModel: pickCodexModelId(),
     });
 
-    const resolved = await piRuntimeInternal.resolvePiModel(makeParams(config));
+    const resolved = await resolveOpenAiResponsesModel(makeParams(config));
 
     expect(resolved.apiKey).toBe("legacy-access-token");
     expect(resolved.accountId).toBe("acct_legacy");

--- a/test/runtime.pi-runtime.test.ts
+++ b/test/runtime.pi-runtime.test.ts
@@ -122,6 +122,8 @@ describe("pi runtime regressions", () => {
     expect(resolved.headers).toEqual({ "ChatGPT-Account-ID": "acct_123" });
     expect(resolved.model.baseUrl).toBe(CODEX_BACKEND_BASE_URL);
     expect(resolved.model.headers).toMatchObject({ "ChatGPT-Account-ID": "acct_123" });
+    expect(resolved.model.contextWindow).toBe(272000);
+    expect(resolved.model.maxTokens).toBe(128000);
   });
 
   test("codex runtime model resolution imports legacy ~/.codex auth into Cowork auth", async () => {
@@ -161,6 +163,57 @@ describe("pi runtime regressions", () => {
     const imported = JSON.parse(importedRaw) as Record<string, any>;
     expect(imported.tokens?.access_token).toBe("legacy-access-token");
     expect(imported.tokens?.refresh_token).toBe("legacy-refresh-token");
+  });
+
+  test("codex runtime model resolution keeps supported OpenAI token limits when using a saved API key", async () => {
+    const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-runtime-codex-saved-key-"));
+    const paths = getAiCoworkerPaths({ homedir: homeDir });
+    await fs.mkdir(path.dirname(paths.connectionsFile), { recursive: true });
+    await fs.writeFile(
+      paths.connectionsFile,
+      JSON.stringify({
+        version: 1,
+        updatedAt: new Date().toISOString(),
+        services: {
+          "codex-cli": {
+            service: "codex-cli",
+            mode: "api_key",
+            apiKey: "sk-codex",
+            updatedAt: new Date().toISOString(),
+          },
+        },
+      }),
+      "utf-8",
+    );
+
+    const config = makeConfig(homeDir, {
+      provider: "codex-cli",
+      model: "gpt-5.4",
+      subAgentModel: "gpt-5.4",
+    });
+
+    const resolved = await resolveOpenAiResponsesModel(makeParams(config));
+
+    expect(resolved.apiKey).toBe("sk-codex");
+    expect(resolved.model.api).toBe("openai-responses");
+    expect(resolved.model.baseUrl).toBe("https://api.openai.com/v1");
+    expect(resolved.model.contextWindow).toBe(400000);
+    expect(resolved.model.maxTokens).toBe(128000);
+  });
+
+  test("openai responses model resolution keeps supported token limits for gpt-5.4", async () => {
+    const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-runtime-openai-gpt54-"));
+    const config = makeConfig(homeDir, {
+      provider: "openai",
+      model: "gpt-5.4",
+      subAgentModel: "gpt-5.4",
+    });
+
+    const resolved = await resolveOpenAiResponsesModel(makeParams(config));
+
+    expect(resolved.model.api).toBe("openai-responses");
+    expect(resolved.model.contextWindow).toBe(400000);
+    expect(resolved.model.maxTokens).toBe(128000);
   });
 
   test("opencode-go runtime model resolution returns explicit GLM-5 PI metadata", async () => {

--- a/test/runtime.selection.test.ts
+++ b/test/runtime.selection.test.ts
@@ -80,7 +80,7 @@ describe("runtime selection", () => {
     expect(createRuntime(config).name).toBe("pi");
   });
 
-  test("rejects unsupported providers explicitly configured to use the OpenAI Responses runtime", () => {
+  test("normalizes stale OpenAI Responses runtime config away for unsupported providers", () => {
     const config = makeConfig({
       provider: "google",
       model: "gemini-3-flash-preview",
@@ -88,9 +88,7 @@ describe("runtime selection", () => {
       runtime: "openai-responses",
     });
 
-    expect(resolveRuntimeName(config)).toBe("openai-responses");
-    expect(() => createRuntime(config)).toThrow(
-      "Provider google does not support the OpenAI Responses runtime.",
-    );
+    expect(resolveRuntimeName(config)).toBe("pi");
+    expect(createRuntime(config).name).toBe("pi");
   });
 });

--- a/test/runtime.selection.test.ts
+++ b/test/runtime.selection.test.ts
@@ -49,6 +49,17 @@ describe("runtime selection", () => {
     expect(createRuntime(config).name).toBe("openai-responses");
   });
 
+  test("treats legacy pi runtime config as the OpenAI Responses runtime for codex-cli", () => {
+    const config = makeConfig({
+      provider: "codex-cli",
+      model: "gpt-5.4",
+      subAgentModel: "gpt-5.4",
+      runtime: "pi",
+    });
+    expect(resolveRuntimeName(config)).toBe("openai-responses");
+    expect(createRuntime(config).name).toBe("openai-responses");
+  });
+
   test("routes opencode-go through the pi runtime", () => {
     const config = makeConfig({
       provider: "opencode-go",
@@ -67,5 +78,19 @@ describe("runtime selection", () => {
     });
     expect(resolveRuntimeName(config)).toBe("pi");
     expect(createRuntime(config).name).toBe("pi");
+  });
+
+  test("rejects unsupported providers explicitly configured to use the OpenAI Responses runtime", () => {
+    const config = makeConfig({
+      provider: "google",
+      model: "gemini-3-flash-preview",
+      subAgentModel: "gemini-3-flash-preview",
+      runtime: "openai-responses",
+    });
+
+    expect(resolveRuntimeName(config)).toBe("openai-responses");
+    expect(() => createRuntime(config)).toThrow(
+      "Provider google does not support the OpenAI Responses runtime.",
+    );
   });
 });

--- a/test/runtime.selection.test.ts
+++ b/test/runtime.selection.test.ts
@@ -27,16 +27,26 @@ function makeConfig(overrides: Partial<AgentConfig> = {}): AgentConfig {
 }
 
 describe("runtime selection", () => {
-  test("defaults to pi runtime when config.runtime is missing", () => {
+  test("defaults openai provider to the OpenAI Responses runtime when config.runtime is missing", () => {
     const config = makeConfig();
-    expect(resolveRuntimeName(config)).toBe("pi");
-    expect(createRuntime(config).name).toBe("pi");
+    expect(resolveRuntimeName(config)).toBe("openai-responses");
+    expect(createRuntime(config).name).toBe("openai-responses");
   });
 
-  test("respects explicit pi runtime in config", () => {
+  test("treats legacy pi runtime config as the OpenAI Responses runtime for openai", () => {
     const config = makeConfig({ runtime: "pi" });
-    expect(resolveRuntimeName(config)).toBe("pi");
-    expect(createRuntime(config).name).toBe("pi");
+    expect(resolveRuntimeName(config)).toBe("openai-responses");
+    expect(createRuntime(config).name).toBe("openai-responses");
+  });
+
+  test("defaults codex-cli provider to the OpenAI Responses runtime", () => {
+    const config = makeConfig({
+      provider: "codex-cli",
+      model: "gpt-5.4",
+      subAgentModel: "gpt-5.4",
+    });
+    expect(resolveRuntimeName(config)).toBe("openai-responses");
+    expect(createRuntime(config).name).toBe("openai-responses");
   });
 
   test("routes opencode-go through the pi runtime", () => {

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -2651,6 +2651,62 @@ describe("Protocol Doc Parity", () => {
     }
   });
 
+  test("set_model normalizes runtime for future sessions after provider changes", async () => {
+    const tmpDir = await makeTmpProject();
+    const seenConfigs: Array<{ provider: string; runtime: string | undefined; model: string }> = [];
+    const runTurnImpl = async (params: any) => {
+      seenConfigs.push({
+        provider: params.config.provider,
+        runtime: params.config.runtime,
+        model: params.config.model,
+      });
+      return {
+        text: "ok",
+        responseMessages: [],
+      };
+    };
+    const { server, url } = await startAgentServer(serverOpts(tmpDir, {
+      env: {
+        AGENT_WORKING_DIR: tmpDir,
+        AGENT_PROVIDER: "openai",
+        AGENT_MODEL: "gpt-5.2",
+        COWORK_SKIP_DEFAULT_SKILLS_BOOTSTRAP: "1",
+      },
+      runTurnImpl: runTurnImpl as any,
+    }));
+
+    try {
+      const modelUpdate = await sendAndCollect(
+        url,
+        (sessionId) => ({ type: "set_model", sessionId, provider: "google", model: "gemini-3-flash-preview" }),
+        1,
+      );
+
+      expect(modelUpdate.responses[0].type).toBe("config_updated");
+      if (modelUpdate.responses[0].type === "config_updated") {
+        expect(modelUpdate.responses[0].config.provider).toBe("google");
+        expect(modelUpdate.responses[0].config.model).toBe("gemini-3-flash-preview");
+      }
+
+      const nextSession = await sendAndCollect(
+        url,
+        (sessionId) => ({ type: "user_message", sessionId, text: "runtime please" }),
+        0,
+      );
+
+      expect(nextSession.hello.config.provider).toBe("google");
+      expect(nextSession.hello.config.model).toBe("gemini-3-flash-preview");
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(seenConfigs).toContainEqual({
+        provider: "google",
+        runtime: "pi",
+        model: "gemini-3-flash-preview",
+      });
+    } finally {
+      server.stop();
+    }
+  });
+
   test("set_config deep-merges editable providerOptions into project config", async () => {
     const tmpDir = await makeTmpProject();
     await fs.writeFile(

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
+import { createRuntime } from "../src/runtime";
 import { SessionCostTracker } from "../src/session/costTracker";
 import type { AgentConfig, TodoItem } from "../src/types";
 import { ASK_SKIP_TOKEN, type ServerEvent } from "../src/server/protocol";
@@ -1322,6 +1323,24 @@ describe("AgentSession", () => {
         expect(updated.config.model).toBe("claude-sonnet-4-5");
       }
       expect(events.some((e) => e.type === "error")).toBe(false);
+    });
+
+    test("normalizes runtime when switching away from openai-family providers", async () => {
+      const { session } = makeSession({
+        config: {
+          ...makeConfig("/tmp/test-session-openai-runtime"),
+          provider: "openai",
+          runtime: "openai-responses",
+          model: "gpt-5.2",
+          subAgentModel: "gpt-5.2",
+        },
+      });
+
+      await session.setModel("gemini-3-flash-preview", "google");
+
+      expect((session as any).state.config.provider).toBe("google");
+      expect((session as any).state.config.runtime).toBe("pi");
+      expect(createRuntime((session as any).state.config).name).toBe("pi");
     });
 
     test("clears persisted OpenAI continuation state when provider/model changes", async () => {

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -1648,28 +1648,13 @@ describe("AgentSession", () => {
       expect((session as any).state.providerState).toBeNull();
     });
 
-    test("callbackProviderAuth accepts a manual codex auth code after authorize", async () => {
+    test("callbackProviderAuth rejects pasted auth codes for auto Codex oauth", async () => {
       const getProviderCatalogImpl = mock(async () => ({
         all: [{ id: "codex-cli", name: "Codex CLI", models: ["gpt-5.2"], defaultModel: "gpt-5.2" }],
         default: { "codex-cli": "gpt-5.2" },
         connected: ["codex-cli"],
       }));
       const getProviderStatusesImpl = mock(async () => []);
-      mockConnectModelProvider.mockImplementationOnce(async (opts: any) => {
-        expect(opts.provider).toBe("codex-cli");
-        expect(opts.methodId).toBe("oauth_cli");
-        expect(opts.code).toBe("manual-auth-code");
-        expect(opts.codexBrowserAuthPending).toBeDefined();
-        expect(typeof opts.codexBrowserAuthPending?.authUrl).toBe("string");
-        expect(opts.codexBrowserAuthPending?.authUrl).toContain("https://auth.openai.com/oauth/authorize");
-        return {
-          ok: true,
-          provider: "codex-cli",
-          mode: "oauth",
-          storageFile: "/tmp/mock-home/.cowork/auth/connections.json",
-          message: "OAuth sign-in completed.",
-        };
-      });
       const { session, events } = makeSession({
         connectProviderImpl: mockConnectModelProvider,
         getAiCoworkerPathsImpl: mockGetAiCoworkerPaths,
@@ -1685,24 +1670,17 @@ describe("AgentSession", () => {
       };
 
       await session.authorizeProviderAuth("codex-cli", "oauth_cli");
-
-      const challengeEvt = events.find((e) => e.type === "provider_auth_challenge");
-      expect(challengeEvt).toBeDefined();
-      if (challengeEvt && challengeEvt.type === "provider_auth_challenge") {
-        expect(challengeEvt.challenge.method).toBe("auto");
-        expect(challengeEvt.challenge.url).toBeUndefined();
-      }
-
       await session.callbackProviderAuth("codex-cli", "oauth_cli", "manual-auth-code");
 
       const authEvt = events.findLast((e) => e.type === "provider_auth_result");
       expect(authEvt).toBeDefined();
       if (authEvt && authEvt.type === "provider_auth_result") {
-        expect(authEvt.ok).toBe(true);
+        expect(authEvt.ok).toBe(false);
         expect(authEvt.provider).toBe("codex-cli");
         expect(authEvt.methodId).toBe("oauth_cli");
+        expect(authEvt.message).toContain("does not accept a pasted authorization code");
       }
-      expect((session as any).state.providerState).toBeNull();
+      expect(mockConnectModelProvider).not.toHaveBeenCalled();
     });
 
     test("logoutProviderAuth emits provider_auth_result and clears provider state", async () => {


### PR DESCRIPTION
This branch moves `openai` and `codex-cli` sessions onto the OpenAI Responses runtime, fixing the mismatch where Codex still depended on PI-owned model/auth wiring and could surface stale ChatGPT account metadata after auth material changed.

It adds a dedicated Responses model resolver for OpenAI and Codex, makes runtime defaults provider-aware, keeps Codex token refresh and `ChatGPT-Account-ID` handling on the Cowork-owned auth path, and updates the architecture/protocol docs to match the new runtime split.

It also simplifies Codex browser OAuth so Cowork owns the browser flow end to end: auth challenges now describe an auto-managed flow, pasted callback codes are rejected, the TUI moves directly from authorize to waiting, and the session/auth registry no longer carries pending manual-code challenge state.

Validation: `bun test`, `bun run typecheck`, `bun run build:server-binary`, `bun run build:desktop-resources`, and `bun run desktop:build`.
