### PR TITLE
feat(desktop): add first-run onboarding flow

### DIFF
--- a/apps/desktop/electron/services/persistence.ts
+++ b/apps/desktop/electron/services/persistence.ts
@@ -13,6 +13,7 @@ import type {
 } from "../../src/app/types";
 import { normalizeWorkspaceUserProfile } from "../../src/app/types";
 import { normalizeWorkspaceProviderOptions } from "../../src/app/openaiCompatibleProviderOptions";
+import { normalizePersistedOnboardingState } from "../../src/app/persistedOnboardingState";
 import { normalizePersistedProviderState } from "../../src/app/persistedProviderState";
 import type { TranscriptBatchInput } from "../../src/lib/desktopApi";
 
@@ -242,6 +243,7 @@ async function sanitizePersistedState(value: unknown): Promise<PersistedState> {
   const workspaceIds = new Set(workspaces.map((workspace) => workspace.id));
   const threads = sanitizeThreads(value.threads, workspaceIds);
   const providerState = normalizePersistedProviderState(value.providerState);
+  const onboardingState = normalizePersistedOnboardingState(value.onboarding);
   const parsedVersion =
     typeof value.version === "number" && Number.isFinite(value.version)
       ? Math.max(0, Math.floor(value.version))
@@ -253,6 +255,7 @@ async function sanitizePersistedState(value: unknown): Promise<PersistedState> {
     developerMode: typeof value.developerMode === "boolean" ? value.developerMode : false,
     showHiddenFiles: typeof value.showHiddenFiles === "boolean" ? value.showHiddenFiles : false,
     ...(providerState ? { providerState } : {}),
+    ...(onboardingState ? { onboarding: onboardingState } : {}),
   };
 }
 

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -15,6 +15,7 @@ import { ASK_SKIP_TOKEN } from "./lib/wsProtocol";
 import { ContextSidebar } from "./ui/ContextSidebar";
 import { PromptModal } from "./ui/PromptModal";
 import { Sidebar } from "./ui/Sidebar";
+import { DesktopOnboarding } from "./ui/onboarding/DesktopOnboarding";
 import { AppTopBar } from "./ui/layout/AppTopBar";
 import { PrimaryContent } from "./ui/layout/PrimaryContent";
 import { SettingsContent } from "./ui/layout/SettingsContent";
@@ -210,6 +211,7 @@ export default function App() {
           <SettingsContent init={init} ready={ready} startupError={startupError} />
         </div>
         <PromptModal />
+        <DesktopOnboarding />
       </div>
     );
   }
@@ -240,6 +242,7 @@ export default function App() {
       </div>
 
       <PromptModal />
+      <DesktopOnboarding />
     </div>
   );
 }

--- a/apps/desktop/src/app/persistedOnboardingState.ts
+++ b/apps/desktop/src/app/persistedOnboardingState.ts
@@ -1,0 +1,57 @@
+import type { OnboardingState, OnboardingStatus } from "./types";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function asNonEmptyString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function normalizeOnboardingStatus(value: unknown): OnboardingStatus {
+  if (value === "pending" || value === "dismissed" || value === "completed") {
+    return value;
+  }
+  return "pending";
+}
+
+export function normalizePersistedOnboardingState(value: unknown): OnboardingState | undefined {
+  if (!isRecord(value)) return undefined;
+
+  const status = normalizeOnboardingStatus(value.status);
+  const completedAt = value.completedAt === null ? null : (asNonEmptyString(value.completedAt) ?? null);
+  const dismissedAt = value.dismissedAt === null ? null : (asNonEmptyString(value.dismissedAt) ?? null);
+
+  // Only persist if status is not "pending" (i.e., user has interacted with onboarding)
+  if (status === "pending" && !completedAt && !dismissedAt) {
+    return undefined;
+  }
+
+  return {
+    status,
+    completedAt,
+    dismissedAt,
+  };
+}
+
+export function shouldShowOnboarding(opts: {
+  onboardingState?: OnboardingState;
+  hasWorkspaces: boolean;
+  hasThreads: boolean;
+  hasConnectedProviders: boolean;
+}): boolean {
+  // If onboarding is explicitly dismissed or completed, don't show it
+  if (opts.onboardingState?.status === "dismissed" || opts.onboardingState?.status === "completed") {
+    return false;
+  }
+
+  // If user has meaningful usage, treat as existing user and don't show onboarding
+  if (opts.hasWorkspaces || opts.hasThreads || opts.hasConnectedProviders) {
+    return false;
+  }
+
+  // Otherwise, show onboarding for new users
+  return true;
+}

--- a/apps/desktop/src/app/store.actions.ts
+++ b/apps/desktop/src/app/store.actions.ts
@@ -5,6 +5,7 @@ import { createBootstrapActions } from "./store.actions/bootstrap";
 import { createExplorerActions } from "./store.actions/explorer";
 import { createWorkspaceMcpActions } from "./store.actions/mcp";
 import { createWorkspaceMemoryActions } from "./store.actions/memory";
+import { createOnboardingActions } from "./store.actions/onboarding";
 import { createProviderActions } from "./store.actions/provider";
 import { createSkillActions } from "./store.actions/skills";
 import { createThreadActions } from "./store.actions/thread";
@@ -23,5 +24,6 @@ export function createAppActions(set: StoreSet, get: StoreGet): AppStoreActions 
     ...createWorkspaceMemoryActions(set, get),
     ...createProviderActions(set, get),
     ...createExplorerActions(set, get),
+    ...createOnboardingActions(set, get),
   };
 }

--- a/apps/desktop/src/app/store.actions/bootstrap.ts
+++ b/apps/desktop/src/app/store.actions/bootstrap.ts
@@ -48,6 +48,7 @@ import {
   normalizeThreadTitleSource,
   truncateTitle,
 } from "../store.helpers";
+import { normalizePersistedOnboardingState, shouldShowOnboarding } from "../persistedOnboardingState";
 import { deriveConnectedProviders, normalizePersistedProviderState } from "../persistedProviderState";
 import { normalizeWorkspaceProviderOptions } from "../openaiCompatibleProviderOptions";
 import {
@@ -163,6 +164,7 @@ const persistedStateSchema = z.object({
   showHiddenFiles: z.preprocess((value) => (typeof value === "boolean" ? value : false), z.boolean()),
 }).passthrough().transform((state) => {
   const providerState = normalizePersistedProviderState((state as { providerState?: unknown }).providerState);
+  const onboardingState = normalizePersistedOnboardingState((state as { onboarding?: unknown }).onboarding);
   const workspaceByRecency = [...state.workspaces].sort((a, b) => b.lastOpenedAt.localeCompare(a.lastOpenedAt));
   const selectedWorkspaceId = workspaceByRecency[0]?.id ?? null;
   const workspaceThreads = selectedWorkspaceId
@@ -182,6 +184,7 @@ const persistedStateSchema = z.object({
     developerMode: state.developerMode,
     showHiddenFiles: state.showHiddenFiles,
     providerState,
+    onboardingState,
   };
 });
 
@@ -197,6 +200,24 @@ export function createBootstrapActions(set: StoreSet, get: StoreGet): Pick<AppSt
         } catch (error) {
           console.warn("Desktop updater state load failed:", error);
         }
+        const hasWorkspaces = state.workspaces.length > 0;
+        const hasThreads = state.threads.length > 0;
+        const hasConnectedProviders = deriveConnectedProviders(state.providerState as PersistedProviderState | undefined).length > 0;
+
+        const loadedOnboardingState = state.onboardingState;
+
+        const shouldShow = shouldShowOnboarding({
+          onboardingState: loadedOnboardingState,
+          hasWorkspaces,
+          hasThreads,
+          hasConnectedProviders,
+        });
+
+        // If user has existing usage but onboarding state is missing, mark as completed
+        const finalOnboardingState = loadedOnboardingState ?? (hasWorkspaces || hasThreads || hasConnectedProviders
+          ? { status: "completed" as const, completedAt: null, dismissedAt: null }
+          : undefined);
+
         set({
           workspaces: state.workspaces,
           threads: state.threads,
@@ -208,9 +229,16 @@ export function createBootstrapActions(set: StoreSet, get: StoreGet): Pick<AppSt
           developerMode: state.developerMode,
           showHiddenFiles: state.showHiddenFiles,
           updateState,
+          onboardingVisible: shouldShow,
+          onboardingState: finalOnboardingState,
           ready: true,
           startupError: null,
         });
+
+        // Persist onboarding state if we auto-completed it for existing users
+        if (finalOnboardingState && !loadedOnboardingState) {
+          void persistNow(get);
+        }
 
         if (state.selectedThreadId) {
           await get().selectThread(state.selectedThreadId);

--- a/apps/desktop/src/app/store.actions/onboarding.ts
+++ b/apps/desktop/src/app/store.actions/onboarding.ts
@@ -1,0 +1,62 @@
+import type { AppStoreActions, StoreGet, StoreSet } from "../store.helpers";
+import type { OnboardingState, OnboardingStep } from "../types";
+import { nowIso, persistNow } from "../store.helpers";
+
+export function createOnboardingActions(set: StoreSet, get: StoreGet): Pick<AppStoreActions, "startOnboarding" | "dismissOnboarding" | "completeOnboarding" | "setOnboardingStep" | "nextOnboardingStep" | "previousOnboardingStep"> {
+  const steps: OnboardingStep[] = ["welcome", "workspace", "provider", "defaults", "firstThread"];
+
+  return {
+    startOnboarding: () => {
+      set({
+        onboardingVisible: true,
+        onboardingStep: "welcome",
+      });
+    },
+
+    dismissOnboarding: () => {
+      const onboardingState: OnboardingState = {
+        status: "dismissed",
+        completedAt: null,
+        dismissedAt: nowIso(),
+      };
+      set({
+        onboardingVisible: false,
+        onboardingState,
+      });
+      void persistNow(get);
+    },
+
+    completeOnboarding: () => {
+      const onboardingState: OnboardingState = {
+        status: "completed",
+        completedAt: nowIso(),
+        dismissedAt: null,
+      };
+      set({
+        onboardingVisible: false,
+        onboardingState,
+      });
+      void persistNow(get);
+    },
+
+    setOnboardingStep: (step: OnboardingStep) => {
+      set({ onboardingStep: step });
+    },
+
+    nextOnboardingStep: () => {
+      const current = get().onboardingStep;
+      const currentIndex = steps.indexOf(current);
+      if (currentIndex < steps.length - 1) {
+        set({ onboardingStep: steps[currentIndex + 1]! });
+      }
+    },
+
+    previousOnboardingStep: () => {
+      const current = get().onboardingStep;
+      const currentIndex = steps.indexOf(current);
+      if (currentIndex > 0) {
+        set({ onboardingStep: steps[currentIndex - 1]! });
+      }
+    },
+  };
+}

--- a/apps/desktop/src/app/store.helpers.ts
+++ b/apps/desktop/src/app/store.helpers.ts
@@ -6,6 +6,7 @@ import { PROVIDER_NAMES } from "../lib/wsProtocol";
 
 import type {
   Notification,
+  OnboardingStep,
   PromptModalState,
   SettingsPageId,
   ThreadRecord,
@@ -165,6 +166,10 @@ export type AppStoreState = {
   contextSidebarWidth: number;
   messageBarHeight: number;
 
+  onboardingVisible: boolean;
+  onboardingStep: OnboardingStep;
+  onboardingState?: import("./types").OnboardingState;
+
   init: () => Promise<void>;
 
   openSettings: (page?: SettingsPageId) => void;
@@ -265,11 +270,18 @@ export type AppStoreState = {
   createWorkspaceDirectory: (workspaceId: string, parentPath: string, name: string) => Promise<void>;
   renameWorkspacePath: (workspaceId: string, path: string, newName: string) => Promise<void>;
   trashWorkspacePath: (workspaceId: string, path: string) => Promise<void>;
+
+  startOnboarding: () => void;
+  dismissOnboarding: () => void;
+  completeOnboarding: () => void;
+  setOnboardingStep: (step: OnboardingStep) => void;
+  nextOnboardingStep: () => void;
+  previousOnboardingStep: () => void;
 };
 
 export type AppStoreActionKeys = {
   [K in keyof AppStoreState]: AppStoreState[K] extends (...args: any[]) => any ? K : never;
-}[keyof AppStoreState];
+}[keyof AppStoreState] & keyof AppStoreState;
 
 export type AppStoreActions = Pick<AppStoreState, AppStoreActionKeys>;
 export type AppStoreDataState = Omit<AppStoreState, AppStoreActionKeys>;

--- a/apps/desktop/src/app/store.helpers/persistence.ts
+++ b/apps/desktop/src/app/store.helpers/persistence.ts
@@ -1,7 +1,8 @@
 import { saveState } from "../../lib/desktopCommands";
+import { normalizePersistedOnboardingState } from "../persistedOnboardingState";
 import { normalizePersistedProviderState } from "../persistedProviderState";
 import type { AppStoreState } from "../store.helpers";
-import type { PersistedState } from "../types";
+import type { OnboardingState, PersistedState } from "../types";
 
 const PERSIST_DEBOUNCE_MS = 300;
 
@@ -13,6 +14,10 @@ function buildPersistedState(state: AppStoreState): PersistedState {
     statusLastUpdatedAt: state.providerStatusLastUpdatedAt,
   });
 
+  const onboardingState = state.onboardingState
+    ? normalizePersistedOnboardingState(state.onboardingState)
+    : undefined;
+
   return {
     version: 2,
     workspaces: state.workspaces,
@@ -20,6 +25,7 @@ function buildPersistedState(state: AppStoreState): PersistedState {
     developerMode: state.developerMode,
     showHiddenFiles: state.showHiddenFiles,
     ...(providerState ? { providerState } : {}),
+    ...(onboardingState ? { onboarding: onboardingState } : {}),
   };
 }
 

--- a/apps/desktop/src/app/store.ts
+++ b/apps/desktop/src/app/store.ts
@@ -47,6 +47,10 @@ const initialState: AppStoreDataState = {
   contextSidebarWidth: 300,
   messageBarHeight: 120,
   sidebarWidth: 248,
+
+  onboardingVisible: false,
+  onboardingStep: "welcome",
+  onboardingState: undefined,
 };
 
 export const useAppStore = create<AppStoreState>((set, get) => ({

--- a/apps/desktop/src/app/types.ts
+++ b/apps/desktop/src/app/types.ts
@@ -91,6 +91,14 @@ export type PersistedProviderState = {
   statusLastUpdatedAt?: string | null;
 };
 
+export type OnboardingStatus = "pending" | "dismissed" | "completed";
+
+export type OnboardingState = {
+  status: OnboardingStatus;
+  completedAt: string | null;
+  dismissedAt: string | null;
+};
+
 export type PersistedState = {
   version: number;
   workspaces: WorkspaceRecord[];
@@ -98,6 +106,7 @@ export type PersistedState = {
   developerMode?: boolean;
   showHiddenFiles?: boolean;
   providerState?: PersistedProviderState;
+  onboarding?: OnboardingState;
 };
 
 export type TranscriptDirection = "server" | "client";
@@ -230,3 +239,5 @@ export type Notification = {
   title: string;
   detail?: string;
 };
+
+export type OnboardingStep = "welcome" | "workspace" | "provider" | "defaults" | "firstThread";

--- a/apps/desktop/src/lib/desktopSchemas.ts
+++ b/apps/desktop/src/lib/desktopSchemas.ts
@@ -151,6 +151,18 @@ const persistedThreadSchema = z.object({
   ),
 }).passthrough();
 
+const persistedOnboardingSchema = z.object({
+  status: z.enum(["pending", "dismissed", "completed"]),
+  completedAt: z.preprocess(
+    (value) => (value === null ? null : typeof value === "string" && value.trim() ? value.trim() : null),
+    z.string().nullable(),
+  ),
+  dismissedAt: z.preprocess(
+    (value) => (value === null ? null : typeof value === "string" && value.trim() ? value.trim() : null),
+    z.string().nullable(),
+  ),
+}).passthrough().optional();
+
 export const persistedStateInputSchema: z.ZodType<PersistedState> = z.object({
   workspaces: z.array(persistedWorkspaceSchema),
   threads: z.array(persistedThreadSchema),
@@ -160,6 +172,7 @@ export const persistedStateInputSchema: z.ZodType<PersistedState> = z.object({
     (value) => (typeof value === "number" && Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 2),
     z.number().int().nonnegative(),
   ),
+  onboarding: persistedOnboardingSchema,
 }).passthrough() as z.ZodType<PersistedState>;
 
 export const confirmActionInputSchema: z.ZodType<ConfirmActionInput> = z.object({

--- a/apps/desktop/src/ui/onboarding/DesktopOnboarding.tsx
+++ b/apps/desktop/src/ui/onboarding/DesktopOnboarding.tsx
@@ -1,0 +1,580 @@
+import { useEffect, useMemo, useState } from "react";
+
+import { useAppStore } from "../../app/store";
+import { Button } from "../../components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../../components/ui/card";
+import { Checkbox } from "../../components/ui/checkbox";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../../components/ui/select";
+import { defaultModelForProvider } from "@cowork/providers/catalog";
+import { modelChoicesFromCatalog } from "../../lib/modelChoices";
+import type { ProviderName } from "../../lib/wsProtocol";
+import { cn } from "../../lib/utils";
+
+function displayProviderName(provider: ProviderName): string {
+  const names: Partial<Record<ProviderName, string>> = {
+    google: "Google",
+    openai: "OpenAI",
+    anthropic: "Anthropic",
+    baseten: "Baseten",
+    together: "Together AI",
+    nvidia: "NVIDIA",
+    "opencode-go": "OpenCode Go",
+    "opencode-zen": "OpenCode Zen",
+    "codex-cli": "Codex CLI",
+  };
+  return names[provider] ?? provider;
+}
+
+function toBoolean(checked: boolean | "indeterminate"): boolean {
+  return checked === true;
+}
+
+function WelcomeStep({ onContinue, onDismiss }: { onContinue: () => void; onDismiss: () => void }) {
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <h2 className="text-2xl font-semibold">Welcome to Cowork</h2>
+        <p className="text-sm text-muted-foreground">
+          Let's get you set up in just a few steps. Cowork is a local-first AI coding assistant that runs entirely on your machine.
+        </p>
+      </div>
+
+      <div className="space-y-4">
+        <div className="space-y-1">
+          <div className="text-sm font-medium">What you'll do:</div>
+          <ul className="list-disc list-inside space-y-1 text-sm text-muted-foreground ml-2">
+            <li>Choose a workspace directory on your disk</li>
+            <li>Connect a model provider (OpenAI, Anthropic, Google, etc.)</li>
+            <li>Review default settings for your workspace</li>
+            <li>Start your first conversation</li>
+          </ul>
+        </div>
+
+        <div className="rounded-lg border border-border/70 bg-muted/20 p-4 text-sm text-muted-foreground">
+          <div className="font-medium mb-1">Note:</div>
+          Command approvals are enabled by default to keep your system safe. You can adjust this later in settings.
+        </div>
+      </div>
+
+      <div className="flex gap-3">
+        <Button onClick={onContinue} className="flex-1">
+          Continue
+        </Button>
+        <Button variant="outline" onClick={onDismiss}>
+          Not now
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function WorkspaceStep({ onContinue, onBack }: { onContinue: () => void; onBack: () => void }) {
+  const addWorkspace = useAppStore((s) => s.addWorkspace);
+  const workspaces = useAppStore((s) => s.workspaces);
+  const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId);
+  const workspaceRuntimeById = useAppStore((s) => s.workspaceRuntimeById);
+  const selectWorkspace = useAppStore((s) => s.selectWorkspace);
+
+  const selectedWorkspace = useMemo(
+    () => workspaces.find((w) => w.id === selectedWorkspaceId) ?? null,
+    [workspaces, selectedWorkspaceId],
+  );
+  const runtime = selectedWorkspaceId ? workspaceRuntimeById[selectedWorkspaceId] : null;
+  const isStarting = runtime?.starting === true;
+
+  const canContinue = selectedWorkspace !== null && !isStarting;
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <h2 className="text-2xl font-semibold">Add a Workspace</h2>
+        <p className="text-sm text-muted-foreground">
+          Choose a directory on your computer where Cowork will work. This is where your conversations and project context live.
+        </p>
+      </div>
+
+      {selectedWorkspace ? (
+        <Card className="border-border/80 bg-card/85">
+          <CardContent className="p-4">
+            <div className="space-y-2">
+              <div className="text-sm font-medium">{selectedWorkspace.name}</div>
+              <div className="text-xs text-muted-foreground font-mono">{selectedWorkspace.path}</div>
+              {isStarting ? (
+                <div className="text-xs text-muted-foreground">Starting workspace server...</div>
+              ) : null}
+            </div>
+          </CardContent>
+        </Card>
+      ) : (
+        <Card className="border-border/80 bg-card/85">
+          <CardContent className="p-6 text-center text-sm text-muted-foreground">
+            No workspace selected. Click "Add Workspace" to choose a directory.
+          </CardContent>
+        </Card>
+      )}
+
+      <div className="flex gap-3">
+        <Button variant="outline" onClick={onBack}>
+          Back
+        </Button>
+        <Button onClick={() => void addWorkspace()} variant="outline" className="flex-1">
+          {selectedWorkspace ? "Change Workspace" : "Add Workspace"}
+        </Button>
+        <Button onClick={onContinue} disabled={!canContinue}>
+          Continue
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function ProviderStep({ onContinue, onBack }: { onContinue: () => void; onBack: () => void }) {
+  const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId);
+  const providerCatalog = useAppStore((s) => s.providerCatalog);
+  const providerStatusByName = useAppStore((s) => s.providerStatusByName);
+  const providerConnected = useAppStore((s) => s.providerConnected);
+  const requestProviderCatalog = useAppStore((s) => s.requestProviderCatalog);
+  const requestProviderAuthMethods = useAppStore((s) => s.requestProviderAuthMethods);
+  const refreshProviderStatus = useAppStore((s) => s.refreshProviderStatus);
+  const connectProvider = useAppStore((s) => s.connectProvider);
+
+  const modelChoices = useMemo(() => modelChoicesFromCatalog(providerCatalog), [providerCatalog]);
+
+  const modelProviders = useMemo(() => {
+    return providerCatalog
+      .map((entry) => entry.id)
+      .filter((provider): provider is ProviderName => {
+        if (typeof provider !== "string") return false;
+        const choices = modelChoices[provider as ProviderName];
+        return choices !== undefined && choices.length > 0;
+      });
+  }, [providerCatalog, modelChoices]);
+
+  useEffect(() => {
+    if (selectedWorkspaceId) {
+      void requestProviderCatalog();
+      void requestProviderAuthMethods();
+      void refreshProviderStatus();
+    }
+  }, [selectedWorkspaceId, requestProviderCatalog, requestProviderAuthMethods, refreshProviderStatus]);
+
+  const hasConnectedProvider = providerConnected.length > 0;
+  const canContinue = hasConnectedProvider;
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <h2 className="text-2xl font-semibold">Connect a Model Provider</h2>
+        <p className="text-sm text-muted-foreground">
+          Choose a provider to power Cowork. You'll need an API key or to sign in with OAuth.
+        </p>
+      </div>
+
+      <div className="space-y-3">
+        {modelProviders.length === 0 ? (
+          <Card className="border-border/80 bg-card/85">
+            <CardContent className="p-6 text-center text-sm text-muted-foreground">
+              Loading providers...
+            </CardContent>
+          </Card>
+        ) : (
+          modelProviders.map((provider) => {
+            const status = providerStatusByName[provider];
+            const connected = status?.authorized || status?.verified;
+            const displayName = providerCatalog.find((e) => e.id === provider)?.name ?? displayProviderName(provider);
+
+            return (
+              <Card
+                key={provider}
+                className={cn("border-border/80 bg-card/85", connected && "border-primary/35")}
+              >
+                <CardContent className="p-4">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <div className="text-sm font-medium">{displayName}</div>
+                      <div className="text-xs text-muted-foreground">
+                        {connected ? "Connected" : "Not connected"}
+                      </div>
+                    </div>
+                    {!connected ? (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => void connectProvider(provider)}
+                      >
+                        Connect
+                      </Button>
+                    ) : (
+                      <div className="text-xs text-muted-foreground">✓</div>
+                    )}
+                  </div>
+                </CardContent>
+              </Card>
+            );
+          })
+        )}
+      </div>
+
+      {!hasConnectedProvider ? (
+        <div className="rounded-lg border border-border/70 bg-muted/20 p-4 text-sm text-muted-foreground">
+          Connect at least one provider to continue.
+        </div>
+      ) : null}
+
+      <div className="flex gap-3">
+        <Button variant="outline" onClick={onBack}>
+          Back
+        </Button>
+        <Button onClick={onContinue} disabled={!canContinue} className="flex-1">
+          Continue
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function DefaultsStep({ onContinue, onBack }: { onContinue: () => void; onBack: () => void }) {
+  const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId);
+  const workspaces = useAppStore((s) => s.workspaces);
+  const providerCatalog = useAppStore((s) => s.providerCatalog);
+  const providerStatusByName = useAppStore((s) => s.providerStatusByName);
+  const providerConnected = useAppStore((s) => s.providerConnected);
+  const updateWorkspaceDefaults = useAppStore((s) => s.updateWorkspaceDefaults);
+
+  const workspace = useMemo(
+    () => workspaces.find((w) => w.id === selectedWorkspaceId) ?? null,
+    [workspaces, selectedWorkspaceId],
+  );
+
+  const modelChoices = useMemo(() => modelChoicesFromCatalog(providerCatalog), [providerCatalog]);
+
+  const connectedProviders = useMemo(() => {
+    return providerConnected.filter((provider) => {
+      const choices = modelChoices[provider];
+      return choices !== undefined && choices.length > 0;
+    });
+  }, [providerConnected, modelChoices]);
+
+  const [defaultProvider, setDefaultProvider] = useState<ProviderName | null>(
+    workspace?.defaultProvider ?? null,
+  );
+  const [defaultModel, setDefaultModel] = useState<string | null>(workspace?.defaultModel ?? null);
+  const [defaultSubAgentModel, setDefaultSubAgentModel] = useState<string | null>(
+    workspace?.defaultSubAgentModel ?? null,
+  );
+  const [defaultEnableMcp, setDefaultEnableMcp] = useState(workspace?.defaultEnableMcp ?? true);
+  const [defaultBackupsEnabled, setDefaultBackupsEnabled] = useState(
+    workspace?.defaultBackupsEnabled ?? true,
+  );
+
+  useEffect(() => {
+    if (workspace) {
+      setDefaultProvider(workspace.defaultProvider ?? null);
+      setDefaultModel(workspace.defaultModel ?? null);
+      setDefaultSubAgentModel(workspace.defaultSubAgentModel ?? null);
+      setDefaultEnableMcp(workspace.defaultEnableMcp);
+      setDefaultBackupsEnabled(workspace.defaultBackupsEnabled);
+    }
+  }, [workspace?.id]);
+
+  // Auto-select first connected provider if current default is not connected
+  useEffect(() => {
+    if (
+      workspace &&
+      defaultProvider &&
+      !connectedProviders.includes(defaultProvider) &&
+      connectedProviders.length > 0
+    ) {
+      const firstConnected = connectedProviders[0]!;
+      setDefaultProvider(firstConnected);
+      setDefaultModel(defaultModelForProvider(firstConnected));
+      setDefaultSubAgentModel(defaultModelForProvider(firstConnected));
+    }
+  }, [workspace, defaultProvider, connectedProviders]);
+
+  const availableModels = defaultProvider ? modelChoices[defaultProvider] ?? [] : [];
+  const availableSubAgentModels = defaultProvider ? modelChoices[defaultProvider] ?? [] : [];
+
+  const canContinue =
+    workspace !== null &&
+    defaultProvider !== null &&
+    connectedProviders.includes(defaultProvider) &&
+    defaultModel !== null;
+
+  const handleSave = async () => {
+    if (!workspace || !defaultProvider || !defaultModel) return;
+
+    await updateWorkspaceDefaults(workspace.id, {
+      defaultProvider,
+      defaultModel,
+      defaultSubAgentModel: defaultSubAgentModel ?? defaultModel,
+      defaultEnableMcp,
+      defaultBackupsEnabled,
+    });
+  };
+
+  if (!workspace) {
+    return (
+      <div className="space-y-6">
+        <div className="space-y-2">
+          <h2 className="text-2xl font-semibold">Workspace Defaults</h2>
+          <p className="text-sm text-muted-foreground">No workspace selected.</p>
+        </div>
+        <div className="flex gap-3">
+          <Button variant="outline" onClick={onBack}>
+            Back
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <h2 className="text-2xl font-semibold">Workspace Defaults</h2>
+        <p className="text-sm text-muted-foreground">
+          Configure default settings for this workspace. You can change these later.
+        </p>
+      </div>
+
+      <div className="space-y-4">
+        <div className="space-y-2">
+          <label className="text-sm font-medium">Default Provider</label>
+          <Select
+            value={defaultProvider ?? ""}
+            onValueChange={(value) => {
+              const provider = value as ProviderName;
+              setDefaultProvider(provider);
+              setDefaultModel(defaultModelForProvider(provider));
+              setDefaultSubAgentModel(defaultModelForProvider(provider));
+            }}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Select a provider" />
+            </SelectTrigger>
+            <SelectContent>
+              {connectedProviders.map((provider) => {
+                const displayName =
+                  providerCatalog.find((e) => e.id === provider)?.name ?? displayProviderName(provider);
+                return (
+                  <SelectItem key={provider} value={provider}>
+                    {displayName}
+                  </SelectItem>
+                );
+              })}
+            </SelectContent>
+          </Select>
+        </div>
+
+        {defaultProvider && availableModels.length > 0 ? (
+          <div className="space-y-2">
+            <label className="text-sm font-medium">Primary Model</label>
+            <Select value={defaultModel ?? ""} onValueChange={setDefaultModel}>
+              <SelectTrigger>
+                <SelectValue placeholder="Select a model" />
+              </SelectTrigger>
+              <SelectContent>
+                {availableModels.map((model) => (
+                  <SelectItem key={model} value={model}>
+                    {model}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        ) : null}
+
+        {defaultProvider && availableSubAgentModels.length > 0 ? (
+          <div className="space-y-2">
+            <label className="text-sm font-medium">Subagent Model</label>
+            <Select
+              value={defaultSubAgentModel ?? defaultModel ?? ""}
+              onValueChange={setDefaultSubAgentModel}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Select a model" />
+              </SelectTrigger>
+              <SelectContent>
+                {availableSubAgentModels.map((model) => (
+                  <SelectItem key={model} value={model}>
+                    {model}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        ) : null}
+
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <div className="text-sm font-medium">Enable MCP</div>
+            <div className="text-xs text-muted-foreground">
+              Allow Model Context Protocol servers to extend Cowork's capabilities.
+            </div>
+          </div>
+          <Checkbox
+            checked={defaultEnableMcp}
+            onCheckedChange={(checked) => setDefaultEnableMcp(toBoolean(checked))}
+          />
+        </div>
+
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <div className="text-sm font-medium">Enable Backups</div>
+            <div className="text-xs text-muted-foreground">
+              Automatically backup session state for recovery.
+            </div>
+          </div>
+          <Checkbox
+            checked={defaultBackupsEnabled}
+            onCheckedChange={(checked) => setDefaultBackupsEnabled(toBoolean(checked))}
+          />
+        </div>
+      </div>
+
+      <div className="flex gap-3">
+        <Button variant="outline" onClick={onBack}>
+          Back
+        </Button>
+        <Button
+          onClick={async () => {
+            await handleSave();
+            onContinue();
+          }}
+          disabled={!canContinue}
+          className="flex-1"
+        >
+          Continue
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function FirstThreadStep({ onComplete, onBack }: { onComplete: () => void; onBack: () => void }) {
+  const newThread = useAppStore((s) => s.newThread);
+  const [creating, setCreating] = useState(false);
+
+  const starterPrompts = [
+    { label: "Summarize this repo", message: "Summarize this repository. What does it do?" },
+    { label: "Find setup risks", message: "Review this codebase and identify any setup or configuration risks." },
+    { label: "Plan first tasks", message: "Help me plan the first tasks for this project." },
+  ];
+
+  const handleStartBlank = async () => {
+    setCreating(true);
+    try {
+      await newThread();
+      onComplete();
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const handleStartWithPrompt = async (message: string) => {
+    setCreating(true);
+    try {
+      await newThread({ firstMessage: message, titleHint: message.split(".")[0] ?? "New thread" });
+      onComplete();
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <h2 className="text-2xl font-semibold">Start Your First Thread</h2>
+        <p className="text-sm text-muted-foreground">
+          Create your first conversation with Cowork. You can start with a blank thread or use one of these prompts.
+        </p>
+      </div>
+
+      <div className="space-y-3">
+        <Button
+          onClick={handleStartBlank}
+          disabled={creating}
+          variant="outline"
+          className="w-full justify-start"
+        >
+          Start blank thread
+        </Button>
+
+        {starterPrompts.map((prompt) => (
+          <Button
+            key={prompt.label}
+            onClick={() => void handleStartWithPrompt(prompt.message)}
+            disabled={creating}
+            variant="outline"
+            className="w-full justify-start text-left"
+          >
+            {prompt.label}
+          </Button>
+        ))}
+      </div>
+
+      <div className="flex gap-3">
+        <Button variant="outline" onClick={onBack} disabled={creating}>
+          Back
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export function DesktopOnboarding() {
+  const onboardingVisible = useAppStore((s) => s.onboardingVisible);
+  const onboardingStep = useAppStore((s) => s.onboardingStep);
+  const startOnboarding = useAppStore((s) => s.startOnboarding);
+  const dismissOnboarding = useAppStore((s) => s.dismissOnboarding);
+  const completeOnboarding = useAppStore((s) => s.completeOnboarding);
+  const nextOnboardingStep = useAppStore((s) => s.nextOnboardingStep);
+  const previousOnboardingStep = useAppStore((s) => s.previousOnboardingStep);
+
+  if (!onboardingVisible) {
+    return null;
+  }
+
+  const steps = ["welcome", "workspace", "provider", "defaults", "firstThread"] as const;
+  const currentStepIndex = steps.indexOf(onboardingStep);
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm">
+      <div className="app-window-drag-strip absolute top-0 left-0 right-0 h-8" aria-hidden="true" />
+      <Card className="w-full max-w-2xl mx-4 border-border/80 bg-card/95 shadow-lg">
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <CardTitle>Getting Started</CardTitle>
+            <div className="text-xs text-muted-foreground">
+              Step {currentStepIndex + 1} of {steps.length}
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {onboardingStep === "welcome" && (
+            <WelcomeStep onContinue={nextOnboardingStep} onDismiss={dismissOnboarding} />
+          )}
+          {onboardingStep === "workspace" && (
+            <WorkspaceStep onContinue={nextOnboardingStep} onBack={previousOnboardingStep} />
+          )}
+          {onboardingStep === "provider" && (
+            <ProviderStep onContinue={nextOnboardingStep} onBack={previousOnboardingStep} />
+          )}
+          {onboardingStep === "defaults" && (
+            <DefaultsStep onContinue={nextOnboardingStep} onBack={previousOnboardingStep} />
+          )}
+          {onboardingStep === "firstThread" && (
+            <FirstThreadStep onComplete={completeOnboarding} onBack={previousOnboardingStep} />
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/desktop/src/ui/settings/pages/DeveloperPage.tsx
+++ b/apps/desktop/src/ui/settings/pages/DeveloperPage.tsx
@@ -32,6 +32,7 @@ export function DeveloperPage() {
 
   const showHiddenFiles = useAppStore((s) => s.showHiddenFiles);
   const setShowHiddenFiles = useAppStore((s) => s.setShowHiddenFiles);
+  const startOnboarding = useAppStore((s) => s.startOnboarding);
   const workspaces = useAppStore((s) => s.workspaces);
   const workspaceRuntimeById = useAppStore((s) => s.workspaceRuntimeById);
   const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId);
@@ -130,6 +131,18 @@ export function DeveloperPage() {
               onCheckedChange={(checked) => setDeveloperMode(toBoolean(checked))}
             />
           </div>
+        </CardContent>
+      </Card>
+
+      <Card className="border-border/80 bg-card/85">
+        <CardHeader>
+          <CardTitle>Onboarding</CardTitle>
+          <CardDescription>Run the first-time setup flow again.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Button variant="outline" onClick={startOnboarding}>
+            Run onboarding again
+          </Button>
         </CardContent>
       </Card>
 

--- a/apps/desktop/test/onboarding.test.ts
+++ b/apps/desktop/test/onboarding.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, test } from "bun:test";
+
+import { normalizePersistedOnboardingState, shouldShowOnboarding } from "../src/app/persistedOnboardingState";
+import type { OnboardingState } from "../src/app/types";
+
+describe("onboarding state normalization", () => {
+  test("normalizes valid onboarding state", () => {
+    const input = {
+      status: "completed",
+      completedAt: "2024-01-01T00:00:00.000Z",
+      dismissedAt: null,
+    };
+    const result = normalizePersistedOnboardingState(input);
+    expect(result).toEqual({
+      status: "completed",
+      completedAt: "2024-01-01T00:00:00.000Z",
+      dismissedAt: null,
+    });
+  });
+
+  test("normalizes dismissed state", () => {
+    const input = {
+      status: "dismissed",
+      completedAt: null,
+      dismissedAt: "2024-01-01T00:00:00.000Z",
+    };
+    const result = normalizePersistedOnboardingState(input);
+    expect(result).toEqual({
+      status: "dismissed",
+      completedAt: null,
+      dismissedAt: "2024-01-01T00:00:00.000Z",
+    });
+  });
+
+  test("returns undefined for pending state with no timestamps", () => {
+    const input = {
+      status: "pending",
+      completedAt: null,
+      dismissedAt: null,
+    };
+    const result = normalizePersistedOnboardingState(input);
+    expect(result).toBeUndefined();
+  });
+
+  test("returns undefined for invalid input", () => {
+    expect(normalizePersistedOnboardingState(null)).toBeUndefined();
+    expect(normalizePersistedOnboardingState(undefined)).toBeUndefined();
+    expect(normalizePersistedOnboardingState("invalid")).toBeUndefined();
+    expect(normalizePersistedOnboardingState([])).toBeUndefined();
+  });
+
+  test("normalizes invalid status to pending", () => {
+    const input = {
+      status: "invalid",
+      completedAt: null,
+      dismissedAt: null,
+    };
+    const result = normalizePersistedOnboardingState(input);
+    expect(result).toBeUndefined(); // pending with no timestamps returns undefined
+  });
+});
+
+describe("shouldShowOnboarding", () => {
+  test("returns false for dismissed onboarding", () => {
+    const onboardingState: OnboardingState = {
+      status: "dismissed",
+      completedAt: null,
+      dismissedAt: "2024-01-01T00:00:00.000Z",
+    };
+    expect(
+      shouldShowOnboarding({
+        onboardingState,
+        hasWorkspaces: false,
+        hasThreads: false,
+        hasConnectedProviders: false,
+      }),
+    ).toBe(false);
+  });
+
+  test("returns false for completed onboarding", () => {
+    const onboardingState: OnboardingState = {
+      status: "completed",
+      completedAt: "2024-01-01T00:00:00.000Z",
+      dismissedAt: null,
+    };
+    expect(
+      shouldShowOnboarding({
+        onboardingState,
+        hasWorkspaces: false,
+        hasThreads: false,
+        hasConnectedProviders: false,
+      }),
+    ).toBe(false);
+  });
+
+  test("returns false for existing users with workspaces", () => {
+    expect(
+      shouldShowOnboarding({
+        onboardingState: undefined,
+        hasWorkspaces: true,
+        hasThreads: false,
+        hasConnectedProviders: false,
+      }),
+    ).toBe(false);
+  });
+
+  test("returns false for existing users with threads", () => {
+    expect(
+      shouldShowOnboarding({
+        onboardingState: undefined,
+        hasWorkspaces: false,
+        hasThreads: true,
+        hasConnectedProviders: false,
+      }),
+    ).toBe(false);
+  });
+
+  test("returns false for existing users with connected providers", () => {
+    expect(
+      shouldShowOnboarding({
+        onboardingState: undefined,
+        hasWorkspaces: false,
+        hasThreads: false,
+        hasConnectedProviders: true,
+      }),
+    ).toBe(false);
+  });
+
+  test("returns true for new users", () => {
+    expect(
+      shouldShowOnboarding({
+        onboardingState: undefined,
+        hasWorkspaces: false,
+        hasThreads: false,
+        hasConnectedProviders: false,
+      }),
+    ).toBe(true);
+  });
+
+  test("returns true for pending state with new users", () => {
+    const onboardingState: OnboardingState = {
+      status: "pending",
+      completedAt: null,
+      dismissedAt: null,
+    };
+    expect(
+      shouldShowOnboarding({
+        onboardingState,
+        hasWorkspaces: false,
+        hasThreads: false,
+        hasConnectedProviders: false,
+      }),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements a polished first-run onboarding flow for the desktop app that guides new users through:
1. Welcome screen
2. Adding a workspace
3. Connecting a model provider
4. Configuring workspace defaults
5. Starting their first thread

## Changes

- **Onboarding State Management**: Added persisted onboarding state (`pending`/`dismissed`/`completed`) and UI state for step navigation
- **5-Step Onboarding Flow**: 
  - Welcome: Explains Cowork and what the user will do
  - Workspace: Add/select workspace directory with server status
  - Provider: Connect model providers (shows only model-capable providers)
  - Defaults: Configure workspace defaults (provider, model, MCP, backups)
  - First Thread: Start blank thread or use starter prompts
- **Smart Visibility Logic**: 
  - Auto-shows for new users (no workspaces/threads/providers)
  - Suppresses for existing users
  - Auto-completes onboarding for existing users on first load
- **Persistence**: Onboarding status is persisted and survives app restarts
- **Rerun Support**: "Run onboarding again" button in Developer settings page

## Implementation Details

- All changes are desktop-only (`apps/desktop/`)
- No websocket/server protocol changes
- Uses existing actions: `addWorkspace()`, provider auth actions, `updateWorkspaceDefaults()`, `newThread()`
- Respects native drag strip area
- Tests added for state normalization and visibility logic

## Testing

- ✅ All onboarding tests pass (12 tests)
- ✅ Typecheck passes
- ✅ No websocket protocol changes

## Follow-up Considerations

- Could extract reusable provider auth UI component from `ProvidersPage.tsx` for better code reuse
- Could add more sophisticated provider connection status handling in the provider step
- Could add progress indicator/step navigation dots for better UX
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-26d6a670-8205-413f-a690-ceac942c5876"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-26d6a670-8205-413f-a690-ceac942c5876"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

