### PR TITLE
Add LM Studio as a dynamic local model provider

### DIFF
--- a/apps/TUI/context/local.test.ts
+++ b/apps/TUI/context/local.test.ts
@@ -32,6 +32,42 @@ describe("local context provider/model helpers", () => {
     expect(providers).toEqual(["google", "openai"]);
   });
 
+  test("preserves the current provider even when it disappears from the live catalog", () => {
+    const providers = availableProvidersFromCatalogState(
+      [
+        {
+          id: "google",
+          name: "Google",
+          models: [{ id: "gemini-2", displayName: "Gemini 2", knowledgeCutoff: "Unknown", supportsImageInput: true }],
+          defaultModel: "gemini-2",
+        },
+      ],
+      ["google"],
+      "lmstudio",
+    );
+
+    expect(providers).toEqual(["google", "lmstudio"]);
+
+    const choices = modelChoicesFromSyncState(
+      [
+        {
+          id: "google",
+          name: "Google",
+          models: [{ id: "gemini-2", displayName: "Gemini 2", knowledgeCutoff: "Unknown", supportsImageInput: true }],
+          defaultModel: "gemini-2",
+        },
+      ] as ProviderCatalogState,
+      ["google"],
+      "lmstudio",
+      "local/qwen-2.5",
+    );
+
+    expect(choices).toEqual([
+      { provider: "google", model: "gemini-2" },
+      { provider: "lmstudio", model: "local/qwen-2.5" },
+    ]);
+  });
+
   test("preserves the active model for disconnected provider in model choices", () => {
     const choices = modelChoicesFromSyncState(
       catalog,

--- a/apps/TUI/context/local.tsx
+++ b/apps/TUI/context/local.tsx
@@ -54,7 +54,6 @@ export function availableProvidersFromCatalogState(
   if (
     normalizedPreserveProvider
     && isUserFacingProviderEnabled(normalizedPreserveProvider as ProviderName)
-    && providers.includes(normalizedPreserveProvider as ProviderName)
     && !base.includes(normalizedPreserveProvider as ProviderName)
   ) {
     base.push(normalizedPreserveProvider as ProviderName);

--- a/apps/TUI/context/sync.tsx
+++ b/apps/TUI/context/sync.tsx
@@ -233,7 +233,12 @@ export function SyncProvider(props: { serverUrl: string; children: JSX.Element }
 
       case "provider_status":
         setState("providerStatuses", evt.providers);
-        setState("providerConnected", evt.providers.filter((provider) => provider.authorized).map((provider) => provider.provider));
+        setState(
+          "providerConnected",
+          evt.providers
+            .filter((provider) => provider.authorized || provider.verified)
+            .map((provider) => provider.provider),
+        );
         break;
 
       case "provider_auth_challenge": {

--- a/apps/desktop/electron/services/persistence.ts
+++ b/apps/desktop/electron/services/persistence.ts
@@ -15,6 +15,7 @@ import type {
 import { normalizeWorkspaceUserProfile } from "../../src/app/types";
 import { normalizeWorkspaceProviderOptions } from "../../src/app/openaiCompatibleProviderOptions";
 import { normalizePersistedProviderState } from "../../src/app/persistedProviderState";
+import { deriveDefaultLmStudioUiEnabled, normalizePersistedProviderUiState } from "../../src/app/providerUiState";
 import type { TranscriptBatchInput } from "../../src/lib/desktopApi";
 
 import { assertDirection, assertSafeId, assertWithinTranscriptsDir } from "./validation";
@@ -49,6 +50,7 @@ function defaultState(): PersistedState {
     threads: [],
     developerMode: false,
     showHiddenFiles: false,
+    providerUiState: normalizePersistedProviderUiState(undefined),
   };
 }
 
@@ -281,6 +283,12 @@ async function sanitizePersistedState(value: unknown): Promise<PersistedState> {
   const workspaceIds = new Set(workspaces.map((workspace) => workspace.id));
   const threads = sanitizeThreads(value.threads, workspaceIds);
   const providerState = normalizePersistedProviderState(value.providerState);
+  const providerUiState = normalizePersistedProviderUiState(value.providerUiState, {
+    defaultLmStudioEnabled: deriveDefaultLmStudioUiEnabled({
+      providerState,
+      workspaces,
+    }),
+  });
   const parsedVersion =
     typeof value.version === "number" && Number.isFinite(value.version)
       ? Math.max(0, Math.floor(value.version))
@@ -293,6 +301,7 @@ async function sanitizePersistedState(value: unknown): Promise<PersistedState> {
     developerMode: typeof value.developerMode === "boolean" ? value.developerMode : false,
     showHiddenFiles: typeof value.showHiddenFiles === "boolean" ? value.showHiddenFiles : false,
     ...(providerState ? { providerState } : {}),
+    providerUiState,
     ...(onboarding ? { onboarding } : {}),
   };
 }

--- a/apps/desktop/src/app/persistedProviderState.ts
+++ b/apps/desktop/src/app/persistedProviderState.ts
@@ -1,7 +1,7 @@
 import { PROVIDER_NAMES, type ProviderName } from "../lib/wsProtocol";
 import type { PersistedProviderState, PersistedProviderStatus } from "./types";
 
-const PROVIDER_STATUS_MODES = new Set(["missing", "error", "api_key", "oauth", "oauth_pending"]);
+const PROVIDER_STATUS_MODES = new Set(["missing", "error", "api_key", "oauth", "oauth_pending", "local"]);
 const DEFAULT_CHECKED_AT = new Date(0).toISOString();
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/apps/desktop/src/app/providerUiState.ts
+++ b/apps/desktop/src/app/providerUiState.ts
@@ -1,0 +1,62 @@
+import type { PersistedProviderState, PersistedProviderUiState, WorkspaceRecord } from "./types";
+
+export const DEFAULT_LM_STUDIO_UI_STATE = {
+  enabled: false,
+  hiddenModels: [],
+} as const;
+
+export const DEFAULT_PROVIDER_UI_STATE: PersistedProviderUiState = {
+  lmstudio: {
+    enabled: DEFAULT_LM_STUDIO_UI_STATE.enabled,
+    hiddenModels: [...DEFAULT_LM_STUDIO_UI_STATE.hiddenModels],
+  },
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function normalizeHiddenModels(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+  for (const entry of value) {
+    if (typeof entry !== "string") continue;
+    const trimmed = entry.trim();
+    if (!trimmed || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    normalized.push(trimmed);
+  }
+  return normalized;
+}
+
+export function deriveDefaultLmStudioUiEnabled(opts: {
+  providerState?: PersistedProviderState;
+  workspaces?: readonly Pick<WorkspaceRecord, "defaultProvider">[];
+} = {}): boolean {
+  const providerStatus = opts.providerState?.statusByName?.lmstudio;
+  if (providerStatus?.authorized || providerStatus?.verified) {
+    return true;
+  }
+  return (opts.workspaces ?? []).some((workspace) => workspace.defaultProvider === "lmstudio");
+}
+
+export function normalizePersistedProviderUiState(
+  value: unknown,
+  opts: {
+    defaultLmStudioEnabled?: boolean;
+  } = {},
+): PersistedProviderUiState {
+  const record = isRecord(value) ? value : {};
+  const lmstudioRaw = isRecord(record.lmstudio) ? record.lmstudio : {};
+
+  return {
+    lmstudio: {
+      enabled:
+        typeof lmstudioRaw.enabled === "boolean"
+          ? lmstudioRaw.enabled
+          : (opts.defaultLmStudioEnabled ?? DEFAULT_LM_STUDIO_UI_STATE.enabled),
+      hiddenModels: normalizeHiddenModels(lmstudioRaw.hiddenModels),
+    },
+  };
+}

--- a/apps/desktop/src/app/store.actions/bootstrap.ts
+++ b/apps/desktop/src/app/store.actions/bootstrap.ts
@@ -49,6 +49,7 @@ import {
   truncateTitle,
 } from "../store.helpers";
 import { deriveConnectedProviders, normalizePersistedProviderState } from "../persistedProviderState";
+import { deriveDefaultLmStudioUiEnabled, normalizePersistedProviderUiState } from "../providerUiState";
 import { normalizeWorkspaceProviderOptions } from "../openaiCompatibleProviderOptions";
 import {
   normalizeWorkspaceUserProfile,
@@ -128,12 +129,14 @@ const persistedWorkspaceSchema = z.object({
     const legacy = typeof asRecord.defaultSubAgentModel === "string" ? asRecord.defaultSubAgentModel.trim() : "";
     return legacy.length > 0 ? legacy : undefined;
   })();
-  const model = workspace.defaultModel ?? defaultModelForProvider(workspace.defaultProvider);
+  const model = workspace.defaultModel ?? (defaultModelForProvider(workspace.defaultProvider) || "");
   const childModelRoutingMode = (workspace.defaultChildModelRoutingMode ?? "same-provider") as ChildModelRoutingMode;
   const legacyPreferredValue = workspace.defaultPreferredChildModel ?? legacySubAgentModel ?? model;
   const preferredChildModelRef =
     workspace.defaultPreferredChildModelRef
-    ?? (legacyPreferredValue.includes(":") ? legacyPreferredValue : `${workspace.defaultProvider}:${legacyPreferredValue}`);
+    ?? (legacyPreferredValue
+      ? (legacyPreferredValue.includes(":") ? legacyPreferredValue : `${workspace.defaultProvider}:${legacyPreferredValue}`)
+      : "");
   return {
     id: workspace.id,
     name: workspace.name,
@@ -186,6 +189,12 @@ const persistedStateSchema = z.object({
   perWorkspaceSettings: z.preprocess((value) => (typeof value === "boolean" ? value : false), z.boolean()),
 }).passthrough().transform((state) => {
   const providerState = normalizePersistedProviderState((state as { providerState?: unknown }).providerState);
+  const providerUiState = normalizePersistedProviderUiState((state as { providerUiState?: unknown }).providerUiState, {
+    defaultLmStudioEnabled: deriveDefaultLmStudioUiEnabled({
+      providerState,
+      workspaces: state.workspaces,
+    }),
+  });
   const onboarding = (state as { onboarding?: PersistedOnboardingState }).onboarding;
   const workspaceByRecency = [...state.workspaces].sort((a, b) => b.lastOpenedAt.localeCompare(a.lastOpenedAt));
   const selectedWorkspaceId = workspaceByRecency[0]?.id ?? null;
@@ -207,6 +216,7 @@ const persistedStateSchema = z.object({
     showHiddenFiles: state.showHiddenFiles,
     perWorkspaceSettings: state.perWorkspaceSettings,
     providerState,
+    providerUiState,
     onboarding,
   };
 });
@@ -247,6 +257,7 @@ export function createBootstrapActions(set: StoreSet, get: StoreGet): Pick<AppSt
           providerStatusByName: state.providerState?.statusByName ?? {},
           providerStatusLastUpdatedAt: state.providerState?.statusLastUpdatedAt ?? null,
           providerConnected: connectedProviders,
+          providerUiState: state.providerUiState,
           developerMode: state.developerMode,
           showHiddenFiles: state.showHiddenFiles,
           perWorkspaceSettings: state.perWorkspaceSettings,
@@ -285,6 +296,7 @@ export function createBootstrapActions(set: StoreSet, get: StoreGet): Pick<AppSt
           providerAuthMethodsByProvider: {},
           providerLastAuthChallenge: null,
           providerLastAuthResult: null,
+          providerUiState: normalizePersistedProviderUiState(undefined),
           ready: true,
           startupError: detail,
           onboardingVisible: false,

--- a/apps/desktop/src/app/store.actions/provider.ts
+++ b/apps/desktop/src/app/store.actions/provider.ts
@@ -46,7 +46,7 @@ import {
 } from "../store.helpers";
 import type { ThreadRecord, WorkspaceRecord } from "../types";
 
-export function createProviderActions(set: StoreSet, get: StoreGet): Pick<AppStoreActions, "connectProvider" | "setProviderApiKey" | "copyProviderApiKey" | "authorizeProviderAuth" | "logoutProviderAuth" | "callbackProviderAuth" | "requestProviderCatalog" | "requestProviderAuthMethods" | "refreshProviderStatus"> {
+export function createProviderActions(set: StoreSet, get: StoreGet): Pick<AppStoreActions, "connectProvider" | "setProviderApiKey" | "copyProviderApiKey" | "authorizeProviderAuth" | "logoutProviderAuth" | "callbackProviderAuth" | "requestProviderCatalog" | "requestProviderAuthMethods" | "refreshProviderStatus" | "setLmStudioEnabled" | "setLmStudioModelVisible"> {
   const resolveProviderWorkspaceId = (): string | null =>
     get().selectedWorkspaceId ?? get().workspaces[0]?.id ?? null;
 
@@ -66,6 +66,11 @@ export function createProviderActions(set: StoreSet, get: StoreGet): Pick<AppSto
 
   return {
     connectProvider: async (provider, apiKey) => {
+      if (provider === "lmstudio") {
+        await get().setLmStudioEnabled(true);
+        return;
+      }
+
       const methods = providerAuthMethodsFor(get(), provider);
       const normalizedKey = (apiKey ?? "").trim();
   
@@ -406,6 +411,45 @@ export function createProviderActions(set: StoreSet, get: StoreGet): Pick<AppSto
           notifications: pushNotification(s.notifications, { id: makeId(), ts: nowIso(), kind: "error", title: "Not connected", detail: "Unable to refresh provider status." }),
         }));
       }
+    },
+
+    setLmStudioEnabled: async (enabled) => {
+      set((s) => ({
+        providerUiState: {
+          ...s.providerUiState,
+          lmstudio: {
+            ...s.providerUiState.lmstudio,
+            enabled,
+          },
+        },
+      }));
+      await persistNow(get);
+      if (enabled) {
+        await get().refreshProviderStatus();
+      }
+    },
+
+    setLmStudioModelVisible: async (modelId, visible) => {
+      const normalizedModelId = modelId.trim();
+      if (!normalizedModelId) return;
+      set((s) => {
+        const hiddenModels = new Set(s.providerUiState.lmstudio.hiddenModels);
+        if (visible) {
+          hiddenModels.delete(normalizedModelId);
+        } else {
+          hiddenModels.add(normalizedModelId);
+        }
+        return {
+          providerUiState: {
+            ...s.providerUiState,
+            lmstudio: {
+              ...s.providerUiState.lmstudio,
+              hiddenModels: [...hiddenModels].sort((a, b) => a.localeCompare(b)),
+            },
+          },
+        };
+      });
+      await persistNow(get);
     },
   
   };

--- a/apps/desktop/src/app/store.actions/workspaceDefaults.ts
+++ b/apps/desktop/src/app/store.actions/workspaceDefaults.ts
@@ -110,7 +110,8 @@ export function createWorkspaceDefaultsActions(set: StoreSet, get: StoreGet): Pi
             : "google";
 
       const provider = inferredProvider;
-      const model = (ws.defaultModel?.trim() || rt.config?.model?.trim() || "") || undefined;
+      const liveDefaultModel = get().providerDefaultModelByProvider[provider]?.trim() || "";
+      const model = (ws.defaultModel?.trim() || liveDefaultModel || rt.config?.model?.trim() || "") || undefined;
       const preferredChildModel =
         (ws.defaultPreferredChildModel?.trim() || ws.defaultModel?.trim() || rt.sessionConfig?.preferredChildModel?.trim() || "") || undefined;
       const childModelRoutingMode =
@@ -238,10 +239,11 @@ export function createWorkspaceDefaultsActions(set: StoreSet, get: StoreGet): Pi
           ? workspace.defaultProvider
           : "google"
       );
-      const model = workspace.defaultModel?.trim() || defaultModelForProvider(provider);
-      const preferredChildModel = workspace.defaultPreferredChildModel?.trim() || model;
+      const liveDefaultModel = get().providerDefaultModelByProvider[provider]?.trim() || "";
+      const model = workspace.defaultModel?.trim() || liveDefaultModel || defaultModelForProvider(provider);
+      const preferredChildModel = workspace.defaultPreferredChildModel?.trim() || model || "";
       const childModelRoutingMode = workspace.defaultChildModelRoutingMode ?? "same-provider";
-      const preferredChildModelRef = workspace.defaultPreferredChildModelRef?.trim() || `${provider}:${preferredChildModel}`;
+      const preferredChildModelRef = workspace.defaultPreferredChildModelRef?.trim() || (preferredChildModel ? `${provider}:${preferredChildModel}` : "");
       const allowedChildModelRefs = workspace.defaultAllowedChildModelRefs ?? [];
       const toolOutputOverflowChars = workspace.defaultToolOutputOverflowChars;
       const providerOptions = workspace.providerOptions;
@@ -249,20 +251,22 @@ export function createWorkspaceDefaultsActions(set: StoreSet, get: StoreGet): Pi
       const userProfile = workspace.userProfile ? normalizeWorkspaceUserProfile(workspace.userProfile) : undefined;
       const clearToolOutputOverflowChars = clearDefaultToolOutputOverflowChars === true;
 
-      const modelPersisted = sendControl(get, workspaceId, (sessionId) => ({
-        type: "set_model",
-        sessionId,
-        provider,
-        model,
-      }));
+      const modelPersisted = model
+        ? sendControl(get, workspaceId, (sessionId) => ({
+            type: "set_model",
+            sessionId,
+            provider,
+            model,
+          }))
+        : false;
       const subAgentPersisted = sendControl(get, workspaceId, (sessionId) => ({
         type: "set_config",
         sessionId,
         config: {
           backupsEnabled: workspace.defaultBackupsEnabled,
-          preferredChildModel,
+          ...(preferredChildModel ? { preferredChildModel } : {}),
           childModelRoutingMode,
-          preferredChildModelRef,
+          ...(preferredChildModelRef ? { preferredChildModelRef } : {}),
           allowedChildModelRefs,
           ...(toolOutputOverflowChars !== undefined
             ? { toolOutputOverflowChars }

--- a/apps/desktop/src/app/store.helpers.ts
+++ b/apps/desktop/src/app/store.helpers.ts
@@ -4,6 +4,7 @@ import type { MCPServerConfig, ProviderName, ServerEvent, TodoItem } from "../li
 import { PROVIDER_NAMES } from "../lib/wsProtocol";
 
 import type {
+  PersistedProviderUiState,
   Notification,
   OnboardingStep,
   PersistedOnboardingState,
@@ -120,6 +121,9 @@ function defaultProviderAuthMethods(provider: ProviderName): ProviderAuthMethod[
       { id: "api_key", type: "api", label: "API key" },
     ];
   }
+  if (provider === "lmstudio") {
+    return [];
+  }
   return [{ id: "api_key", type: "api", label: "API key" }];
 }
 
@@ -161,6 +165,7 @@ export type AppStoreState = {
   providerAuthMethodsByProvider: Record<string, ProviderAuthMethod[]>;
   providerLastAuthChallenge: ProviderAuthChallengeEvent | null;
   providerLastAuthResult: ProviderAuthResultEvent | null;
+  providerUiState: PersistedProviderUiState;
 
   composerText: string;
   injectContext: boolean;
@@ -259,6 +264,8 @@ export type AppStoreState = {
   requestProviderCatalog: () => Promise<void>;
   requestProviderAuthMethods: () => Promise<void>;
   refreshProviderStatus: () => Promise<void>;
+  setLmStudioEnabled: (enabled: boolean) => Promise<void>;
+  setLmStudioModelVisible: (modelId: string, visible: boolean) => Promise<void>;
 
   loadAllThreadUsage: () => Promise<void>;
 

--- a/apps/desktop/src/app/store.helpers/controlSocket.ts
+++ b/apps/desktop/src/app/store.helpers/controlSocket.ts
@@ -322,7 +322,7 @@ export function createControlSocketHelpers(deps: ControlSocketDeps) {
           const byName: Partial<Record<ProviderName, ProviderStatus>> = {};
           for (const p of evt.providers) byName[p.provider] = p;
           const connected = evt.providers
-            .filter((p) => p.authorized)
+            .filter((p) => p.authorized || p.verified)
             .map((p) => p.provider)
             .filter((provider): provider is ProviderName => deps.isProviderName(provider));
           set((s) => ({

--- a/apps/desktop/src/app/store.helpers/persistence.ts
+++ b/apps/desktop/src/app/store.helpers/persistence.ts
@@ -1,4 +1,5 @@
 import { saveState } from "../../lib/desktopCommands";
+import { normalizePersistedProviderUiState } from "../providerUiState";
 import { normalizePersistedProviderState } from "../persistedProviderState";
 import type { AppStoreState } from "../store.helpers";
 import type { PersistedState } from "../types";
@@ -12,6 +13,7 @@ function buildPersistedState(state: AppStoreState): PersistedState {
     statusByName: state.providerStatusByName,
     statusLastUpdatedAt: state.providerStatusLastUpdatedAt,
   });
+  const providerUiState = normalizePersistedProviderUiState(state.providerUiState);
 
   return {
     version: 2,
@@ -21,6 +23,7 @@ function buildPersistedState(state: AppStoreState): PersistedState {
     showHiddenFiles: state.showHiddenFiles,
     perWorkspaceSettings: state.perWorkspaceSettings,
     ...(providerState ? { providerState } : {}),
+    providerUiState,
     onboarding: state.onboardingState,
   };
 }

--- a/apps/desktop/src/app/store.ts
+++ b/apps/desktop/src/app/store.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 
 import { createAppActions } from "./store.actions";
+import { DEFAULT_PROVIDER_UI_STATE } from "./providerUiState";
 import { createDefaultUpdaterState, type AppStoreDataState, type AppStoreState } from "./store.helpers";
 
 const initialState: AppStoreDataState = {
@@ -35,6 +36,7 @@ const initialState: AppStoreDataState = {
   providerAuthMethodsByProvider: {},
   providerLastAuthChallenge: null,
   providerLastAuthResult: null,
+  providerUiState: DEFAULT_PROVIDER_UI_STATE,
 
   composerText: "",
   injectContext: false,

--- a/apps/desktop/src/app/types.ts
+++ b/apps/desktop/src/app/types.ts
@@ -102,6 +102,15 @@ export type PersistedProviderState = {
   statusLastUpdatedAt?: string | null;
 };
 
+export type LmStudioUiState = {
+  enabled: boolean;
+  hiddenModels: string[];
+};
+
+export type PersistedProviderUiState = {
+  lmstudio: LmStudioUiState;
+};
+
 export type OnboardingStatus = "pending" | "dismissed" | "completed";
 
 export type PersistedOnboardingState = {
@@ -120,6 +129,7 @@ export type PersistedState = {
   showHiddenFiles?: boolean;
   perWorkspaceSettings?: boolean;
   providerState?: PersistedProviderState;
+  providerUiState?: PersistedProviderUiState;
   onboarding?: PersistedOnboardingState;
 };
 

--- a/apps/desktop/src/lib/desktopSchemas.ts
+++ b/apps/desktop/src/lib/desktopSchemas.ts
@@ -204,6 +204,16 @@ const persistedOnboardingSchema = z.object({
   dismissedAt: z.preprocess((value) => (typeof value === "string" && value.trim() ? value : null), z.string().nullable()),
 }).optional();
 
+const persistedProviderUiStateSchema = z.object({
+  lmstudio: z.object({
+    enabled: z.preprocess((value) => (typeof value === "boolean" ? value : false), z.boolean()),
+    hiddenModels: z.preprocess(
+      (value) => Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === "string") : [],
+      z.array(nonEmptyStringSchema),
+    ),
+  }).optional(),
+}).optional();
+
 export const persistedStateInputSchema: z.ZodType<PersistedState> = z.object({
   workspaces: z.array(persistedWorkspaceSchema),
   threads: z.array(persistedThreadSchema),
@@ -213,6 +223,7 @@ export const persistedStateInputSchema: z.ZodType<PersistedState> = z.object({
     (value) => (typeof value === "number" && Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 2),
     z.number().int().nonnegative(),
   ),
+  providerUiState: persistedProviderUiStateSchema,
   onboarding: persistedOnboardingSchema,
 }).passthrough() as z.ZodType<PersistedState>;
 

--- a/apps/desktop/src/lib/modelChoices.ts
+++ b/apps/desktop/src/lib/modelChoices.ts
@@ -22,16 +22,40 @@ export function modelOptionsForProvider(provider: ProviderName, currentModel?: s
 }
 
 type ProviderCatalogEntry = Extract<ServerEvent, { type: "provider_catalog" }>["all"][number];
+export type CatalogVisibilityOptions = {
+  hiddenProviders?: readonly ProviderName[];
+  hiddenModelsByProvider?: Partial<Record<ProviderName, readonly string[]>>;
+};
+
+function filterModelsForProvider(
+  provider: ProviderName,
+  models: readonly string[],
+  options?: CatalogVisibilityOptions,
+): readonly string[] {
+  if (options?.hiddenProviders?.includes(provider)) {
+    return [];
+  }
+  const hiddenModels = new Set((options?.hiddenModelsByProvider?.[provider] ?? []).map((entry) => entry.trim()).filter(Boolean));
+  if (hiddenModels.size === 0) return models;
+  return models.filter((model) => !hiddenModels.has(model));
+}
 
 export function modelChoicesFromCatalog(
   catalog: readonly ProviderCatalogEntry[],
+  options?: CatalogVisibilityOptions,
 ): Record<ProviderName, readonly string[]> {
-  if (catalog.length === 0) return MODEL_CHOICES;
+  if (catalog.length === 0) {
+    return Object.fromEntries(
+      PROVIDER_NAMES
+        .filter((provider) => !UI_DISABLED_PROVIDERS.has(provider))
+        .map((provider) => [provider, filterModelsForProvider(provider, MODEL_CHOICES[provider] ?? [], options)]),
+    ) as Record<ProviderName, readonly string[]>;
+  }
   const result = {} as Record<ProviderName, readonly string[]>;
   for (const entry of catalog) {
     if (UI_DISABLED_PROVIDERS.has(entry.id)) continue;
     const models = Array.isArray(entry.models) ? entry.models.map((m) => m.id) : (MODEL_CHOICES[entry.id] ?? []);
-    result[entry.id] = models;
+    result[entry.id] = filterModelsForProvider(entry.id, models, options);
   }
   return result;
 }
@@ -40,33 +64,41 @@ export function availableProvidersFromCatalog(
   catalog: readonly ProviderCatalogEntry[],
   connected: readonly ProviderName[],
   preserveProvider?: ProviderName,
+  options?: CatalogVisibilityOptions & {
+    visibleModelsByProvider?: Partial<Record<ProviderName, readonly string[]>>;
+  },
 ): ProviderName[] {
   const connectedSet = new Set(connected.filter((provider) => !UI_DISABLED_PROVIDERS.has(provider)));
+  const hiddenProviders = new Set(options?.hiddenProviders ?? []);
   const catalogProviders = (
     catalog.length === 0
       ? PROVIDER_NAMES
       : catalog.map((entry) => entry.id)
-  ).filter((provider) => !UI_DISABLED_PROVIDERS.has(provider));
+  ).filter((provider) => !UI_DISABLED_PROVIDERS.has(provider) && !hiddenProviders.has(provider));
   const providers =
     connectedSet.size === 0
       ? [...catalogProviders]
       : catalogProviders.filter((provider) => connectedSet.has(provider));
+  const filteredProviders = options?.visibleModelsByProvider
+    ? providers.filter((provider) => (options.visibleModelsByProvider?.[provider]?.length ?? 0) > 0)
+    : providers;
   if (
     preserveProvider &&
     PROVIDER_NAMES.includes(preserveProvider) &&
-    !providers.includes(preserveProvider)
+    !filteredProviders.includes(preserveProvider)
   ) {
-    providers.push(preserveProvider);
+    filteredProviders.push(preserveProvider);
   }
-  return providers;
+  return filteredProviders;
 }
 
 export function modelOptionsFromCatalog(
   catalog: readonly ProviderCatalogEntry[],
   provider: ProviderName,
   currentModel?: string | null,
+  options?: CatalogVisibilityOptions,
 ): readonly string[] {
-  const choices = modelChoicesFromCatalog(catalog);
+  const choices = modelChoicesFromCatalog(catalog, options);
   const base = choices[provider] ?? [];
   const normalized = typeof currentModel === "string" ? currentModel.trim() : "";
   if (!normalized) return base;

--- a/apps/desktop/src/lib/providerDisplayNames.ts
+++ b/apps/desktop/src/lib/providerDisplayNames.ts
@@ -10,6 +10,7 @@ const DISPLAY_NAMES: Partial<Record<ProviderName, string>> = {
   baseten: "Baseten",
   together: "Together AI",
   nvidia: "NVIDIA",
+  lmstudio: "LM Studio",
   "opencode-go": "OpenCode Go",
   "opencode-zen": "OpenCode Zen",
   "codex-cli": "ChatGPT Subscription",
@@ -34,6 +35,9 @@ export function fallbackAuthMethods(provider: ProviderName): ProviderAuthMethod[
       { id: "oauth_cli", type: "oauth", label: "Sign in with ChatGPT (browser)", oauthMode: "auto" },
       { id: "api_key", type: "api", label: "API key" },
     ];
+  }
+  if (provider === "lmstudio") {
+    return [];
   }
   return [{ id: "api_key", type: "api", label: "API key" }];
 }

--- a/apps/desktop/src/ui/ChatView.tsx
+++ b/apps/desktop/src/ui/ChatView.tsx
@@ -37,7 +37,11 @@ import {
   SelectTrigger,
   SelectValue,
 } from "../components/ui/select";
-import { availableProvidersFromCatalog, modelChoicesFromCatalog } from "../lib/modelChoices";
+import {
+  availableProvidersFromCatalog,
+  modelChoicesFromCatalog,
+  type CatalogVisibilityOptions,
+} from "../lib/modelChoices";
 import { readFile } from "../lib/desktopCommands";
 import type { ProviderName } from "../lib/wsProtocol";
 import { cn } from "../lib/utils";
@@ -370,6 +374,7 @@ const PROVIDER_LABELS: Record<ProviderName, string> = {
   baseten: "Baseten",
   together: "Together AI",
   nvidia: "NVIDIA",
+  lmstudio: "LM Studio",
   "opencode-go": "OpenCode Go",
   "opencode-zen": "OpenCode Zen",
   "codex-cli": "ChatGPT Subscription",
@@ -389,10 +394,23 @@ function ThreadModelSelector({
   const setThreadModel = useAppStore((s) => s.setThreadModel);
   const providerCatalog = useAppStore((s) => s.providerCatalog);
   const providerConnected = useAppStore((s) => s.providerConnected);
-  const choices = useMemo(() => modelChoicesFromCatalog(providerCatalog), [providerCatalog]);
+  const providerUiState = useAppStore((s) => s.providerUiState);
+  const chatCatalogVisibility = useMemo<CatalogVisibilityOptions>(() => ({
+    hiddenProviders: providerUiState.lmstudio.enabled ? [] : (["lmstudio"] as const),
+    hiddenModelsByProvider: {
+      lmstudio: providerUiState.lmstudio.hiddenModels,
+    },
+  }), [providerUiState]);
+  const choices = useMemo(
+    () => modelChoicesFromCatalog(providerCatalog, chatCatalogVisibility),
+    [providerCatalog, chatCatalogVisibility],
+  );
   const providers = useMemo(
-    () => availableProvidersFromCatalog(providerCatalog, providerConnected, provider),
-    [providerCatalog, providerConnected, provider],
+    () => availableProvidersFromCatalog(providerCatalog, providerConnected, provider, {
+      ...chatCatalogVisibility,
+      visibleModelsByProvider: choices,
+    }),
+    [providerCatalog, providerConnected, provider, chatCatalogVisibility, choices],
   );
   const value = `${provider}:${model}`;
 

--- a/apps/desktop/src/ui/chat/ActivityGroupCard.tsx
+++ b/apps/desktop/src/ui/chat/ActivityGroupCard.tsx
@@ -86,8 +86,7 @@ export const ActivityGroupCard = memo(function ActivityGroupCard(props: { items:
     if (shouldAutoExpand) setExpanded(true);
   }, [shouldAutoExpand]);
 
-  const isDone = summary.status === "done";
-  const showDoneMarker = isDone && summary.toolCount > 0;
+  const isDone = summary.status === "done" && summary.toolCount > 0;
 
   return (
     <Card className="max-w-3xl border-border/60 bg-card/60 shadow-[0_1px_2px_0_rgb(0_0_0/0.03)] backdrop-blur-sm">
@@ -127,7 +126,7 @@ export const ActivityGroupCard = memo(function ActivityGroupCard(props: { items:
           <CardContent className="border-t border-border/50 px-3.5 pb-3 pt-2.5">
             <div className="max-h-[26rem] overflow-y-auto pr-1" style={{ maskImage: "linear-gradient(to bottom, black calc(100% - 1.5rem), transparent)" }}>
               {summary.entries.map((entry, i) => {
-                const isLast = i === summary.entries.length - 1 && !showDoneMarker;
+                const isLast = i === summary.entries.length - 1;
 
                 if (entry.kind === "reasoning") {
                   return (
@@ -165,15 +164,6 @@ export const ActivityGroupCard = memo(function ActivityGroupCard(props: { items:
                   </div>
                 );
               })}
-
-              {showDoneMarker && (
-                <div className="flex items-center gap-3 pb-1">
-                  <div className="flex size-5 items-center justify-center">
-                    <CheckCircleIcon className="size-3.5 text-emerald-500/60" />
-                  </div>
-                  <span className="text-sm text-muted-foreground/50">Done</span>
-                </div>
-              )}
             </div>
           </CardContent>
         </CollapsibleContent>

--- a/apps/desktop/src/ui/onboarding/DesktopOnboarding.tsx
+++ b/apps/desktop/src/ui/onboarding/DesktopOnboarding.tsx
@@ -18,6 +18,7 @@ import {
   availableProvidersFromCatalog,
   modelChoicesFromCatalog,
   modelOptionsFromCatalog,
+  type CatalogVisibilityOptions,
   UI_DISABLED_PROVIDERS,
 } from "../../lib/modelChoices";
 import type { ProviderName, ServerEvent } from "../../lib/wsProtocol";
@@ -246,6 +247,8 @@ function ProviderStep({ onContinue, onBack }: { onContinue: () => void; onBack: 
   const providerLastAuthResult = useAppStore((s) => s.providerLastAuthResult);
   const providerConnected = useAppStore((s) => s.providerConnected);
   const setProviderApiKey = useAppStore((s) => s.setProviderApiKey);
+  const providerUiState = useAppStore((s) => s.providerUiState);
+  const setLmStudioEnabled = useAppStore((s) => s.setLmStudioEnabled);
   const authorizeProviderAuth = useAppStore((s) => s.authorizeProviderAuth);
   const callbackProviderAuth = useAppStore((s) => s.callbackProviderAuth);
   const refreshProviderStatus = useAppStore((s) => s.refreshProviderStatus);
@@ -263,20 +266,26 @@ function ProviderStep({ onContinue, onBack }: { onContinue: () => void; onBack: 
     const source = fromCatalog.length > 0 ? fromCatalog : [...PROVIDER_NAMES];
     const filtered = source.filter((p) => !UI_DISABLED_PROVIDERS.has(p));
     return filtered.filter((p) => {
+      if (p === "lmstudio") return true;
       const models = modelChoices[p];
       return models && models.length > 0;
     }).sort((a, b) => {
-      const aConnected = Boolean(providerStatusByName[a]?.authorized || providerStatusByName[a]?.verified);
-      const bConnected = Boolean(providerStatusByName[b]?.authorized || providerStatusByName[b]?.verified);
+      const aConnected = a === "lmstudio"
+        ? providerUiState.lmstudio.enabled && Boolean(providerStatusByName[a]?.authorized || providerStatusByName[a]?.verified)
+        : Boolean(providerStatusByName[a]?.authorized || providerStatusByName[a]?.verified);
+      const bConnected = b === "lmstudio"
+        ? providerUiState.lmstudio.enabled && Boolean(providerStatusByName[b]?.authorized || providerStatusByName[b]?.verified)
+        : Boolean(providerStatusByName[b]?.authorized || providerStatusByName[b]?.verified);
       if (aConnected && !bConnected) return -1;
       if (!aConnected && bConnected) return 1;
       return displayProviderName(a).localeCompare(displayProviderName(b));
     });
-  }, [providerCatalog, providerStatusByName, modelChoices]);
+  }, [providerCatalog, providerStatusByName, modelChoices, providerUiState]);
 
   const hasConnectedModelProvider = providerConnected.some((p) => {
     const models = modelChoices[p];
-    return models && models.length > 0;
+    if (!models || models.length === 0) return false;
+    return p === "lmstudio" ? providerUiState.lmstudio.enabled : true;
   });
 
   // Initial fetch
@@ -325,6 +334,7 @@ function ProviderStep({ onContinue, onBack }: { onContinue: () => void; onBack: 
           const isExpanded = expandedProvider === provider;
           const methods = authMethodsFor(provider);
           const providerDisplayName = displayProviderName(provider);
+          const lmStudioEnabled = providerUiState.lmstudio.enabled;
 
           return (
             <Card key={provider} className={cn("border-border/80 bg-card/85", isExpanded && "border-primary/35")}>
@@ -338,7 +348,13 @@ function ProviderStep({ onContinue, onBack }: { onContinue: () => void; onBack: 
                 </div>
                 <div className="flex shrink-0 items-center gap-2">
                   <Badge variant={connected ? "default" : "secondary"}>
-                    {connected ? "Connected" : "Not connected"}
+                    {provider === "lmstudio"
+                      ? lmStudioEnabled
+                        ? (connected ? "Connected" : "Unavailable")
+                        : "Disabled"
+                      : connected
+                        ? "Connected"
+                        : "Not connected"}
                   </Badge>
                   <span className="text-xs text-muted-foreground">{isExpanded ? "▾" : "▸"}</span>
                 </div>
@@ -346,7 +362,31 @@ function ProviderStep({ onContinue, onBack }: { onContinue: () => void; onBack: 
 
               {isExpanded ? (
                 <CardContent className="space-y-3 border-t border-border/70 px-4 py-3">
-                  {methods.map((method) => {
+                  {provider === "lmstudio" ? (
+                    <div className="space-y-3">
+                      <div className="text-sm text-muted-foreground">
+                        LM Studio runs on a local server. Connect it once to make its local models available in Cowork.
+                      </div>
+                      <div className="flex flex-wrap items-center gap-2">
+                        <Button
+                          type="button"
+                          onClick={() => {
+                            void setLmStudioEnabled(!lmStudioEnabled);
+                          }}
+                        >
+                          {lmStudioEnabled ? "Disable" : "Connect"}
+                        </Button>
+                        <Button type="button" variant="outline" onClick={() => void refreshProviderStatus()}>
+                          Refresh
+                        </Button>
+                      </div>
+                      <div className="text-xs text-muted-foreground">
+                        {lmStudioEnabled
+                          ? (status?.message || "Cowork will use the models exposed by your local LM Studio server.")
+                          : "Disabled providers stay out of the main chat UI until you connect them here."}
+                      </div>
+                    </div>
+                  ) : methods.map((method) => {
                     const stateKey = `${provider}:${method.id}`;
                     const apiKeyValue = apiKeys[stateKey] ?? "";
                     const codeValue = oauthCodes[stateKey] ?? "";
@@ -483,6 +523,7 @@ function DefaultsStep({ onContinue, onBack }: { onContinue: () => void; onBack: 
   const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId);
   const providerCatalog = useAppStore((s) => s.providerCatalog);
   const providerConnected = useAppStore((s) => s.providerConnected);
+  const providerUiState = useAppStore((s) => s.providerUiState);
   const updateWorkspaceDefaults = useAppStore((s) => s.updateWorkspaceDefaults);
 
   const workspace = useMemo(
@@ -495,13 +536,25 @@ function DefaultsStep({ onContinue, onBack }: { onContinue: () => void; onBack: 
   const enableMcp = workspace?.defaultEnableMcp ?? true;
   const backupsEnabled = workspace?.defaultBackupsEnabled ?? true;
 
-  const modelChoices = useMemo(() => modelChoicesFromCatalog(providerCatalog), [providerCatalog]);
+  const modelSelectorVisibility = useMemo<CatalogVisibilityOptions>(() => ({
+    hiddenProviders: providerUiState.lmstudio.enabled ? [] : (["lmstudio"] as const),
+    hiddenModelsByProvider: {
+      lmstudio: providerUiState.lmstudio.hiddenModels,
+    },
+  }), [providerUiState]);
+  const modelChoices = useMemo(
+    () => modelChoicesFromCatalog(providerCatalog, modelSelectorVisibility),
+    [providerCatalog, modelSelectorVisibility],
+  );
   const availableProviders = useMemo(
-    () => availableProvidersFromCatalog(providerCatalog, providerConnected, provider),
-    [providerCatalog, providerConnected, provider],
+    () => availableProvidersFromCatalog(providerCatalog, providerConnected, provider, {
+      ...modelSelectorVisibility,
+      visibleModelsByProvider: modelChoices,
+    }),
+    [providerCatalog, providerConnected, provider, modelChoices, modelSelectorVisibility],
   );
   const effectiveProvider = availableProviders.includes(provider) ? provider : (availableProviders[0] ?? provider);
-  const modelOptions = modelOptionsFromCatalog(providerCatalog, effectiveProvider, model);
+  const modelOptions = modelOptionsFromCatalog(providerCatalog, effectiveProvider, model, modelSelectorVisibility);
 
   // Auto-fix: if the current workspace default provider isn't connected but another is, swap it
   useEffect(() => {
@@ -509,7 +562,8 @@ function DefaultsStep({ onContinue, onBack }: { onContinue: () => void; onBack: 
     const isDefaultConnected = providerConnected.includes(provider);
     if (!isDefaultConnected && availableProviders.length > 0 && availableProviders[0] !== provider) {
       const newProvider = availableProviders[0]!;
-      const newModel = (modelChoices[newProvider] ?? [])[0] ?? "";
+      const providerDefault = providerCatalog.find((entry) => entry.id === newProvider)?.defaultModel?.trim() || "";
+      const newModel = providerDefault || ((modelChoices[newProvider] ?? [])[0] ?? "");
       void updateWorkspaceDefaults(workspace.id, {
         defaultProvider: newProvider,
         defaultModel: newModel,
@@ -537,7 +591,8 @@ function DefaultsStep({ onContinue, onBack }: { onContinue: () => void; onBack: 
             value={effectiveProvider}
             onValueChange={(value) => {
               if (!isProviderNameString(value)) return;
-              const newModel = (modelChoices[value] ?? [])[0] ?? "";
+              const providerDefault = providerCatalog.find((entry) => entry.id === value)?.defaultModel?.trim() || "";
+              const newModel = providerDefault || ((modelChoices[value] ?? [])[0] ?? "");
               void updateWorkspaceDefaults(workspace.id, {
                 defaultProvider: value,
                 defaultModel: newModel,

--- a/apps/desktop/src/ui/settings/pages/ProvidersPage.tsx
+++ b/apps/desktop/src/ui/settings/pages/ProvidersPage.tsx
@@ -5,6 +5,7 @@ import { useAppStore } from "../../../app/store";
 import { Badge } from "../../../components/ui/badge";
 import { Button } from "../../../components/ui/button";
 import { Card, CardContent } from "../../../components/ui/card";
+import { Checkbox } from "../../../components/ui/checkbox";
 import { Input } from "../../../components/ui/input";
 import { modelChoicesFromCatalog, UI_DISABLED_PROVIDERS } from "../../../lib/modelChoices";
 import { compareProviderNamesForSettings } from "../../../lib/providerOrdering";
@@ -17,6 +18,7 @@ import {
 } from "../../../lib/providerDisplayNames";
 
 type ProviderAuthMethod = Extract<ServerEvent, { type: "provider_auth_methods" }>["methods"][string][number];
+type ProviderCatalogEntry = Extract<ServerEvent, { type: "provider_catalog" }>["all"][number];
 
 const EXA_AUTH_METHOD_ID = "exa_api_key";
 export const EXA_SECTION_ID = "provider:exa-search";
@@ -163,6 +165,9 @@ function fallbackAuthMethods(provider: ProviderName): ProviderAuthMethod[] {
       { id: "oauth_cli", type: "oauth", label: "Sign in with ChatGPT (browser)", oauthMode: "auto" },
     ];
   }
+  if (provider === "lmstudio") {
+    return [];
+  }
   return [{ id: "api_key", type: "api", label: "API key" }];
 }
 
@@ -220,12 +225,16 @@ export function ProvidersPage({ initialExpandedSectionId = null }: ProvidersPage
   const providerAuthMethodsByProviderFromStore = useAppStore((s) => s.providerAuthMethodsByProvider);
   const providerLastAuthChallengeFromStore = useAppStore((s) => s.providerLastAuthChallenge);
   const providerLastAuthResultFromStore = useAppStore((s) => s.providerLastAuthResult);
+  const providerUiStateFromStore = useAppStore((s) => s.providerUiState);
+  const setLmStudioEnabled = useAppStore((s) => s.setLmStudioEnabled);
+  const setLmStudioModelVisible = useAppStore((s) => s.setLmStudioModelVisible);
   const providerStatusByName = serverState?.providerStatusByName ?? providerStatusByNameFromStore;
   const providerStatusRefreshing = serverState?.providerStatusRefreshing ?? providerStatusRefreshingFromStore;
   const providerCatalog = serverState?.providerCatalog ?? providerCatalogFromStore;
   const providerAuthMethodsByProvider = serverState?.providerAuthMethodsByProvider ?? providerAuthMethodsByProviderFromStore;
   const providerLastAuthChallenge = serverState?.providerLastAuthChallenge ?? providerLastAuthChallengeFromStore;
   const providerLastAuthResult = serverState?.providerLastAuthResult ?? providerLastAuthResultFromStore;
+  const providerUiState = serverState?.providerUiState ?? providerUiStateFromStore;
 
   const [apiKeysByMethod, setApiKeysByMethod] = useState<Record<string, string>>({});
   const [apiKeyEditingByMethod, setApiKeyEditingByMethod] = useState<Record<string, boolean>>({});
@@ -243,13 +252,18 @@ export function ProvidersPage({ initialExpandedSectionId = null }: ProvidersPage
     const source = fromCatalog.length > 0 ? fromCatalog : [...PROVIDER_NAMES];
     const filtered = source.filter((provider) => !UI_DISABLED_PROVIDERS.has(provider));
 
-    const isModelProvider = (provider: ProviderName) => provider in modelChoices && modelChoices[provider]!.length > 0;
+    const isModelProvider = (provider: ProviderName) =>
+      provider === "lmstudio" || (provider in modelChoices && modelChoices[provider]!.length > 0);
 
     const sortProviders = (providers: ProviderName[]) => [...providers].sort((a, b) => {
       const aStatus = providerStatusByName[a];
       const bStatus = providerStatusByName[b];
-      const aConnected = aStatus?.verified || aStatus?.authorized;
-      const bConnected = bStatus?.verified || bStatus?.authorized;
+      const aConnected = a === "lmstudio"
+        ? providerUiState.lmstudio.enabled && Boolean(aStatus?.verified || aStatus?.authorized)
+        : Boolean(aStatus?.verified || aStatus?.authorized);
+      const bConnected = b === "lmstudio"
+        ? providerUiState.lmstudio.enabled && Boolean(bStatus?.verified || bStatus?.authorized)
+        : Boolean(bStatus?.verified || bStatus?.authorized);
 
       // 1. Connected vs Disconnected
       if (aConnected && !bConnected) return -1;
@@ -263,7 +277,7 @@ export function ProvidersPage({ initialExpandedSectionId = null }: ProvidersPage
     const tProviders = sortProviders(filtered.filter((provider) => !isModelProvider(provider)));
 
     return { modelProviders: mProviders, toolProviders: tProviders };
-  }, [providerCatalog, providerStatusByName, modelChoices]);
+  }, [providerCatalog, providerStatusByName, modelChoices, providerUiState]);
 
   const catalogNameByProvider = useMemo(() => {
     const map = new Map<ProviderName, string>();
@@ -528,6 +542,7 @@ export function ProvidersPage({ initialExpandedSectionId = null }: ProvidersPage
     const label = providerStatusLabel(status);
     const sectionId = providerSectionId(provider);
     const isExpanded = expandedSectionId === sectionId;
+    const catalogEntry = providerCatalog.find((entry): entry is ProviderCatalogEntry => entry.id === provider);
     const methods = visibleAuthMethods(provider, authMethodsForProvider(provider));
     const connected = Boolean(status?.authorized || status?.verified);
     const providerDisplayName = catalogNameByProvider.get(provider) ?? displayProviderName(provider);
@@ -535,6 +550,139 @@ export function ProvidersPage({ initialExpandedSectionId = null }: ProvidersPage
     const visibleRateLimits = Array.isArray(status?.usage?.rateLimits)
       ? status.usage.rateLimits.filter(isVisibleUsageRateLimit)
       : [];
+
+    if (provider === "lmstudio") {
+      const lmStudioEnabled = providerUiState.lmstudio.enabled;
+      const lmStudioModels = Array.isArray(catalogEntry?.models) ? catalogEntry.models : [];
+      const hiddenModels = new Set(providerUiState.lmstudio.hiddenModels);
+      const visibleLmStudioModels = lmStudioModels.filter((model) => !hiddenModels.has(model.id));
+      const statusLabel = !lmStudioEnabled
+        ? "Disabled"
+        : connected
+          ? "Connected"
+          : catalogEntry?.state === "unreachable"
+            ? "Unavailable"
+            : catalogEntry?.state === "empty"
+              ? "No models"
+              : "Checking";
+      const subtitle = !lmStudioEnabled
+        ? "Connect once to show LM Studio in Cowork."
+        : connected
+          ? `${visibleLmStudioModels.length}/${lmStudioModels.length} model${lmStudioModels.length === 1 ? "" : "s"} shown in chat`
+          : catalogEntry?.message?.trim() || status?.message || "Checking your local LM Studio server.";
+
+      return (
+        <Card key={provider} className={cn("border-border/80 bg-card/85", isExpanded && "border-primary/35")}>
+          <button
+            className="flex w-full items-center justify-between gap-3 px-5 py-4 text-left"
+            type="button"
+            aria-expanded={isExpanded}
+            aria-controls={`provider-panel-${provider}`}
+            onClick={() => setExpandedSectionId(isExpanded ? null : sectionId)}
+          >
+            <div className="min-w-0">
+              <div className="truncate text-sm font-semibold text-foreground">{providerDisplayName}</div>
+              <div className="mt-0.5 truncate text-xs text-muted-foreground">{subtitle}</div>
+            </div>
+            <div className="flex shrink-0 items-center gap-2">
+              <Badge variant={lmStudioEnabled && connected ? "default" : "secondary"}>{statusLabel}</Badge>
+              <span className="text-xs text-muted-foreground">{isExpanded ? "▾" : "▸"}</span>
+            </div>
+          </button>
+
+          {isExpanded ? (
+            <CardContent id={`provider-panel-${provider}`} className="space-y-4 border-t border-border/70 px-4 py-3.5">
+              <div className="text-sm text-muted-foreground">
+                LM Studio runs on a local server. Connect it once to make its models available in Cowork, then choose which discovered models should appear in the main chat UI.
+              </div>
+
+              <div className="flex flex-wrap items-center gap-2">
+                <Button
+                  type="button"
+                  onClick={() => {
+                    void setLmStudioEnabled(!lmStudioEnabled);
+                  }}
+                >
+                  {lmStudioEnabled ? "Disable" : "Connect"}
+                </Button>
+                <Button
+                  variant="outline"
+                  type="button"
+                  onClick={() => void refreshProviderStatus()}
+                  disabled={providerStatusRefreshing}
+                >
+                  {providerStatusRefreshing ? "Refreshing..." : "Refresh"}
+                </Button>
+              </div>
+
+              {subtitle ? (
+                <div className="text-sm text-muted-foreground">{subtitle}</div>
+              ) : null}
+
+              <div className="space-y-2 border-t border-border/70 pt-4">
+                <div className="flex items-center justify-between gap-3">
+                  <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Models shown in chat</div>
+                  {providerUiState.lmstudio.hiddenModels.length > 0 ? (
+                    <Button
+                      variant="outline"
+                      type="button"
+                      size="sm"
+                      className="h-7 rounded-sm px-2 text-xs shadow-none"
+                      onClick={() => {
+                        for (const modelId of providerUiState.lmstudio.hiddenModels) {
+                          void setLmStudioModelVisible(modelId, true);
+                        }
+                      }}
+                    >
+                      Show all
+                    </Button>
+                  ) : null}
+                </div>
+
+                {lmStudioModels.length > 0 ? (
+                  <div className="space-y-2">
+                    <div className="grid gap-2">
+                      {lmStudioModels.map((model) => {
+                        const checked = !hiddenModels.has(model.id);
+                        return (
+                          <label
+                            key={model.id}
+                            className="flex items-start gap-3 rounded-sm border border-border/60 px-3 py-2 text-sm"
+                          >
+                            <Checkbox
+                              checked={checked}
+                              onCheckedChange={(nextChecked) => {
+                                void setLmStudioModelVisible(model.id, nextChecked === true);
+                              }}
+                              aria-label={`Show LM Studio model ${model.id} in chat`}
+                            />
+                            <div className="min-w-0">
+                              <div className="truncate font-medium text-foreground">
+                                {typeof model.displayName === "string" && model.displayName.trim() ? model.displayName : model.id}
+                              </div>
+                              <div className="truncate text-xs text-muted-foreground">{model.id}</div>
+                            </div>
+                          </label>
+                        );
+                      })}
+                    </div>
+                    <div className="text-xs text-muted-foreground">
+                      Hidden models stay available in LM Studio but are removed from the main chat selector. Newly discovered models are shown automatically.
+                    </div>
+                  </div>
+                ) : (
+                  <div className="rounded-sm border border-dashed border-border/60 px-3 py-2 text-sm text-muted-foreground">
+                    {catalogEntry?.state === "empty"
+                      ? "LM Studio is reachable, but it is not exposing any LLMs right now."
+                      : "Refresh once LM Studio is running to discover available models."}
+                  </div>
+                )}
+              </div>
+            </CardContent>
+          ) : null}
+        </Card>
+      );
+    }
 
     return (
       <Card key={provider} className={cn("border-border/80 bg-card/85", isExpanded && "border-primary/35")}>

--- a/apps/desktop/src/ui/settings/pages/WorkspacesPage.tsx
+++ b/apps/desktop/src/ui/settings/pages/WorkspacesPage.tsx
@@ -52,6 +52,7 @@ import { Textarea } from "../../../components/ui/textarea";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "../../../components/ui/tooltip";
 import { confirmAction } from "../../../lib/desktopCommands";
 import {
+  type CatalogVisibilityOptions,
   modelChoicesFromCatalog,
   modelOptionsFromCatalog,
   UI_DISABLED_PROVIDERS,
@@ -849,6 +850,7 @@ export function WorkspacesPage() {
   const providerCatalog = useAppStore((s) => s.providerCatalog);
   const providerConnected = useAppStore((s) => s.providerConnected);
   const providerDefaultModelByProvider = useAppStore((s) => s.providerDefaultModelByProvider);
+  const providerUiState = useAppStore((s) => s.providerUiState);
 
   const perWorkspaceSettings = useAppStore((s) => s.perWorkspaceSettings);
   const setPerWorkspaceSettings = useAppStore((s) => s.setPerWorkspaceSettings);
@@ -874,28 +876,47 @@ export function WorkspacesPage() {
   const backupsEnabled = ws?.defaultBackupsEnabled ?? true;
   const yolo = ws?.yolo ?? false;
 
-  const modelChoices = useMemo(() => modelChoicesFromCatalog(providerCatalog), [providerCatalog]);
+  const modelSelectorVisibility = useMemo<CatalogVisibilityOptions>(() => ({
+    hiddenProviders: providerUiState.lmstudio.enabled ? [] : (["lmstudio"] as const),
+    hiddenModelsByProvider: {
+      lmstudio: providerUiState.lmstudio.hiddenModels,
+    },
+  }), [providerUiState]);
+  const modelChoices = useMemo(
+    () => modelChoicesFromCatalog(providerCatalog, modelSelectorVisibility),
+    [providerCatalog, modelSelectorVisibility],
+  );
   const availableProviders = useMemo(() => {
+    const hiddenProviders = new Set(modelSelectorVisibility.hiddenProviders ?? []);
     const catalogProviders = (
       providerCatalog.length === 0
         ? PROVIDER_NAMES
         : providerCatalog.map((entry) => entry.id)
-    ).filter((entry) => !UI_DISABLED_PROVIDERS.has(entry));
-    return sortProviderNamesForSettings(
+    ).filter((entry) => !UI_DISABLED_PROVIDERS.has(entry) && !hiddenProviders.has(entry));
+    const visibleProviders = sortProviderNamesForSettings(
       [...new Set(catalogProviders)].filter((entry) => {
         const status = providerStatusByName[entry];
         return status ? hasConfiguredProviderStatus(status) : providerConnected.includes(entry);
       }),
     );
-  }, [providerCatalog, providerConnected, providerStatusByName]);
+    if (!UI_DISABLED_PROVIDERS.has(provider) && !visibleProviders.includes(provider)) {
+      visibleProviders.push(provider);
+    }
+    return visibleProviders;
+  }, [modelSelectorVisibility, provider, providerCatalog, providerConnected, providerStatusByName]);
   const currentProviderIsConfigured = availableProviders.includes(provider);
   const effectiveProvider = currentProviderIsConfigured ? provider : (availableProviders[0] ?? provider);
   const modelControlsDisabled = !currentProviderIsConfigured;
   const configuredProviderSet = useMemo(() => new Set(availableProviders), [availableProviders]);
   const curatedModels = modelChoices[effectiveProvider] ?? [];
-  const modelOptions = modelOptionsFromCatalog(providerCatalog, effectiveProvider, model);
+  const modelOptions = modelOptionsFromCatalog(providerCatalog, effectiveProvider, model, modelSelectorVisibility);
   const hasCustomModel = Boolean(model && !curatedModels.includes(model));
-  const preferredChildModelOptions = modelOptionsFromCatalog(providerCatalog, effectiveProvider, preferredChildModel);
+  const preferredChildModelOptions = modelOptionsFromCatalog(
+    providerCatalog,
+    effectiveProvider,
+    preferredChildModel,
+    modelSelectorVisibility,
+  );
   const hasCustomChildModel = Boolean(preferredChildModel && !curatedModels.includes(preferredChildModel));
   const visibleAllowedChildModelRefs = useMemo(
     () =>
@@ -1116,7 +1137,11 @@ export function WorkspacesPage() {
                             if (!ws) return;
                             const nextProvider = value as ProviderName;
                             if (UI_DISABLED_PROVIDERS.has(nextProvider)) return;
-                            const nextDefault = providerDefaultModelByProvider[nextProvider] ?? defaultModelForProvider(nextProvider);
+                            const nextDefault =
+                              providerDefaultModelByProvider[nextProvider]?.trim()
+                              || modelChoices[nextProvider]?.[0]
+                              || defaultModelForProvider(nextProvider);
+                            if (!nextDefault) return;
                             void updateWorkspaceDefaults(ws.id, {
                               defaultProvider: nextProvider,
                               defaultModel: nextDefault,

--- a/apps/desktop/test/modelChoices.test.ts
+++ b/apps/desktop/test/modelChoices.test.ts
@@ -4,6 +4,7 @@ import {
   availableProvidersFromCatalog,
   MODEL_CHOICES,
   modelChoicesFromCatalog,
+  modelOptionsFromCatalog,
   modelOptionsForProvider,
 } from "../src/lib/modelChoices";
 
@@ -99,6 +100,23 @@ describe("modelOptionsForProvider", () => {
     expect(providers).toEqual(["google", "openai"]);
   });
 
+  test("preserves the current provider even when it disappears from the live catalog", () => {
+    const providers = availableProvidersFromCatalog(
+      [
+        {
+          id: "google",
+          name: "Google",
+          models: [{ id: "gemini-3-pro", displayName: "Gemini 3 Pro", knowledgeCutoff: "Unknown", supportsImageInput: true }],
+          defaultModel: "gemini-3-pro",
+        },
+      ],
+      ["google"],
+      "lmstudio",
+    );
+
+    expect(providers).toEqual(["google", "lmstudio"]);
+  });
+
   test("preserves disabled current provider for existing workspaces", () => {
     const providers = availableProvidersFromCatalog(
       [
@@ -120,5 +138,83 @@ describe("modelOptionsForProvider", () => {
     );
 
     expect(providers).toEqual(["openai", "baseten"]);
+  });
+
+  test("filters hidden LM Studio models from live catalog choices", () => {
+    const choices = modelChoicesFromCatalog(
+      [
+        {
+          id: "lmstudio",
+          name: "LM Studio",
+          models: [
+            { id: "model-a", displayName: "Model A", knowledgeCutoff: "Unknown", supportsImageInput: false },
+            { id: "model-b", displayName: "Model B", knowledgeCutoff: "Unknown", supportsImageInput: false },
+          ],
+          defaultModel: "model-a",
+        },
+      ],
+      {
+        hiddenModelsByProvider: {
+          lmstudio: ["model-b"],
+        },
+      },
+    );
+
+    expect(choices.lmstudio).toEqual(["model-a"]);
+  });
+
+  test("preserves the current hidden LM Studio model in model options", () => {
+    const options = modelOptionsFromCatalog(
+      [
+        {
+          id: "lmstudio",
+          name: "LM Studio",
+          models: [
+            { id: "model-a", displayName: "Model A", knowledgeCutoff: "Unknown", supportsImageInput: false },
+            { id: "model-b", displayName: "Model B", knowledgeCutoff: "Unknown", supportsImageInput: false },
+          ],
+          defaultModel: "model-a",
+        },
+      ],
+      "lmstudio",
+      "model-b",
+      {
+        hiddenModelsByProvider: {
+          lmstudio: ["model-b"],
+        },
+      },
+    );
+
+    expect(options).toEqual(["model-b", "model-a"]);
+  });
+
+  test("hides LM Studio from provider choices when the local provider is disabled", () => {
+    const providers = availableProvidersFromCatalog(
+      [
+        {
+          id: "lmstudio",
+          name: "LM Studio",
+          models: [{ id: "model-a", displayName: "Model A", knowledgeCutoff: "Unknown", supportsImageInput: false }],
+          defaultModel: "model-a",
+        },
+        {
+          id: "openai",
+          name: "OpenAI",
+          models: [{ id: "gpt-5.4", displayName: "GPT-5.4", knowledgeCutoff: "Unknown", supportsImageInput: true }],
+          defaultModel: "gpt-5.4",
+        },
+      ],
+      ["lmstudio", "openai"],
+      undefined,
+      {
+        hiddenProviders: ["lmstudio"],
+        visibleModelsByProvider: {
+          lmstudio: [],
+          openai: ["gpt-5.4"],
+        },
+      },
+    );
+
+    expect(providers).toEqual(["openai"]);
   });
 });

--- a/apps/desktop/test/onboarding-ui.test.tsx
+++ b/apps/desktop/test/onboarding-ui.test.tsx
@@ -229,6 +229,91 @@ describe("DeveloperPage rerun onboarding button", () => {
     }
   });
 
+  test("provider step shows LM Studio local connect controls instead of an API key field", async () => {
+    const harness = setupJsdom();
+    const setLmStudioEnabled = mock(async () => {});
+    const refreshProviderStatus = mock(async () => {});
+
+    try {
+      const container = harness.dom.window.document.getElementById("root");
+      if (!container) throw new Error("missing root");
+      const root = createRoot(container);
+
+      await act(async () => {
+        useAppStore.setState({
+          onboardingVisible: true,
+          onboardingStep: "provider",
+          providerCatalog: [
+            {
+              id: "lmstudio",
+              name: "LM Studio",
+              state: "unreachable",
+              message: "LM Studio unavailable.",
+              models: [
+                { id: "qwen/qwen3-30b-a3b", displayName: "Qwen 3 30B", knowledgeCutoff: "Unknown", supportsImageInput: false },
+              ],
+              defaultModel: "qwen/qwen3-30b-a3b",
+            },
+          ] as any,
+          providerStatusByName: {
+            lmstudio: {
+              provider: "lmstudio",
+              authorized: false,
+              verified: false,
+              mode: "local",
+              account: null,
+              message: "LM Studio unavailable.",
+              checkedAt: "2026-03-18T00:00:00.000Z",
+            },
+          } as any,
+          providerConnected: [],
+          providerUiState: {
+            lmstudio: {
+              enabled: false,
+              hiddenModels: [],
+            },
+          },
+          setLmStudioEnabled,
+          ...defaultProviderActions,
+          refreshProviderStatus,
+        });
+      });
+
+      await act(async () => {
+        root.render(createElement(DesktopOnboarding));
+      });
+
+      const lmStudioButton = [...container.querySelectorAll("button")].find((button) =>
+        button.textContent?.includes("LM Studio"),
+      );
+      if (!lmStudioButton) throw new Error("missing LM Studio onboarding card");
+
+      await act(async () => {
+        lmStudioButton.dispatchEvent(new harness.dom.window.MouseEvent("click", { bubbles: true }));
+      });
+
+      expect(container.textContent).toContain("LM Studio runs on a local server.");
+      expect(container.textContent).toContain("Connect");
+      expect(container.textContent).toContain("Refresh");
+      expect(container.textContent).not.toContain("Paste your API key");
+      expect(container.textContent).not.toContain("API token");
+
+      const connectButton = [...container.querySelectorAll("button")].find((button) => button.textContent?.trim() === "Connect");
+      if (!connectButton) throw new Error("missing LM Studio connect button");
+      await act(async () => {
+        connectButton.dispatchEvent(new harness.dom.window.MouseEvent("click", { bubbles: true }));
+      });
+
+      expect(setLmStudioEnabled).toHaveBeenCalledWith(true);
+
+      await act(async () => {
+        root.unmount();
+      });
+    } finally {
+      harness.restore();
+    }
+  });
+
   test("clicking 'Run onboarding again' calls startOnboarding", async () => {
     const startOnboarding = mock(() => {});
     const harness = setupJsdom();

--- a/apps/desktop/test/persistence-state-sanitization.test.ts
+++ b/apps/desktop/test/persistence-state-sanitization.test.ts
@@ -142,6 +142,88 @@ describe("desktop persistence state validation", () => {
     expect(loaded.providerState?.statusByName?.["codex-cli"]?.account?.email).toBe("max@example.com");
   });
 
+  test("saveState preserves LM Studio UI visibility preferences", async () => {
+    const persistence = new PersistenceService();
+    const validWorkspace = path.join(userDataDir, "workspace-lmstudio-ui");
+    await fs.mkdir(validWorkspace, { recursive: true });
+
+    await persistence.saveState({
+      version: 2,
+      workspaces: [
+        {
+          id: "ws_lmstudio_ui",
+          name: "LM Studio workspace",
+          path: validWorkspace,
+          createdAt: TS,
+          lastOpenedAt: TS,
+          defaultEnableMcp: true,
+          defaultBackupsEnabled: true,
+          yolo: false,
+        },
+      ],
+      threads: [],
+      developerMode: false,
+      showHiddenFiles: false,
+      providerUiState: {
+        lmstudio: {
+          enabled: true,
+          hiddenModels: ["llama-3.2-vision"],
+        },
+      },
+    });
+
+    const loaded = await persistence.loadState();
+    expect(loaded.providerUiState).toEqual({
+      lmstudio: {
+        enabled: true,
+        hiddenModels: ["llama-3.2-vision"],
+      },
+    });
+  });
+
+  test("loadState enables LM Studio UI by default when the saved provider status is already connected", async () => {
+    const persistence = new PersistenceService();
+    const validWorkspace = path.join(userDataDir, "workspace-lmstudio-default");
+    await fs.mkdir(validWorkspace, { recursive: true });
+
+    await persistence.saveState({
+      version: 2,
+      workspaces: [
+        {
+          id: "ws_lmstudio_default",
+          name: "LM Studio workspace",
+          path: validWorkspace,
+          createdAt: TS,
+          lastOpenedAt: TS,
+          defaultEnableMcp: true,
+          defaultBackupsEnabled: true,
+          yolo: false,
+        },
+      ],
+      threads: [],
+      developerMode: false,
+      showHiddenFiles: false,
+      providerState: {
+        statusByName: {
+          lmstudio: {
+            provider: "lmstudio",
+            authorized: true,
+            verified: true,
+            mode: "local",
+            account: null,
+            message: "LM Studio reachable.",
+            checkedAt: TS,
+          },
+        },
+        statusLastUpdatedAt: TS,
+      },
+    });
+
+    const loaded = await persistence.loadState();
+    expect(loaded.providerUiState?.lmstudio.enabled).toBe(true);
+    expect(loaded.providerUiState?.lmstudio.hiddenModels).toEqual([]);
+  });
+
   test("saveState preserves workspace tool output overflow defaults", async () => {
     const persistence = new PersistenceService();
     const customWorkspace = path.join(userDataDir, "workspace-overflow-custom");
@@ -426,6 +508,12 @@ describe("desktop persistence state validation", () => {
       threads: [],
       developerMode: false,
       showHiddenFiles: false,
+      providerUiState: {
+        lmstudio: {
+          enabled: false,
+          hiddenModels: [],
+        },
+      },
     });
   });
 

--- a/apps/desktop/test/protocol-v2-events.test.ts
+++ b/apps/desktop/test/protocol-v2-events.test.ts
@@ -1374,6 +1374,30 @@ describe("desktop protocol v2 mapping", () => {
     expect(useAppStore.getState().providerConnected).toEqual([]);
   });
 
+  test("verified-only local providers stay in providerConnected", async () => {
+    await useAppStore.getState().newThread({ workspaceId });
+    const controlSocket = socketByClient("desktop-control");
+
+    emitServerHello(controlSocket, "control-session");
+    controlSocket.emit({
+      type: "provider_status",
+      sessionId: "control-session",
+      providers: [
+        {
+          provider: "lmstudio",
+          authorized: false,
+          verified: true,
+          mode: "local",
+          account: null,
+          message: "LM Studio reachable",
+          checkedAt: new Date().toISOString(),
+        },
+      ],
+    } as any);
+
+    expect(useAppStore.getState().providerConnected).toEqual(["lmstudio"]);
+  });
+
   test("legacy log events still map to log feed items when no model stream exists", async () => {
     await useAppStore.getState().newThread({ workspaceId });
     const threadId = useAppStore.getState().selectedThreadId;

--- a/apps/desktop/test/providers-page.test.ts
+++ b/apps/desktop/test/providers-page.test.ts
@@ -168,6 +168,13 @@ describe("desktop providers page", () => {
       } as any,
       providerLastAuthChallenge: null,
       providerLastAuthResult: null,
+      providerConnected: [],
+      providerUiState: {
+        lmstudio: {
+          enabled: false,
+          hiddenModels: [],
+        },
+      },
       ...defaultProviderActions,
     });
   });
@@ -719,5 +726,144 @@ describe("desktop providers page", () => {
 
     expect(html).toContain("OpenCode Zen");
     expect(html).not.toContain("Use OpenCode Go key");
+  });
+
+  test("renders LM Studio as a local provider card without API token controls", () => {
+    useAppStore.setState({
+      ...useAppStore.getState(),
+      providerStatusByName: {
+        ...useAppStore.getState().providerStatusByName,
+        lmstudio: {
+          provider: "lmstudio",
+          authorized: true,
+          verified: true,
+          mode: "local",
+          account: null,
+          message: "LM Studio reachable.",
+          checkedAt: "2026-03-18T00:00:00.000Z",
+        },
+      } as any,
+      providerCatalog: [
+        {
+          id: "lmstudio",
+          name: "LM Studio",
+          state: "ready",
+          message: "LM Studio reachable.",
+          models: [
+            { id: "qwen/qwen3-30b-a3b", displayName: "Qwen 3 30B", knowledgeCutoff: "Unknown", supportsImageInput: false },
+            { id: "llama/llama-3.2-vision", displayName: "Llama 3.2 Vision", knowledgeCutoff: "Unknown", supportsImageInput: true },
+          ],
+          defaultModel: "qwen/qwen3-30b-a3b",
+        },
+      ] as any,
+      providerUiState: {
+        lmstudio: {
+          enabled: true,
+          hiddenModels: ["llama/llama-3.2-vision"],
+        },
+      },
+    });
+
+    const html = renderToStaticMarkup(
+      createElement(ProvidersPage, {
+        initialExpandedSectionId: "provider:lmstudio",
+      }),
+    );
+
+    expect(html).toContain("LM Studio runs on a local server.");
+    expect(html).toContain("Disable");
+    expect(html).toContain("Refresh");
+    expect(html).toContain("Models shown in chat");
+    expect(html).toContain("Show all");
+    expect(html).toContain("Qwen 3 30B");
+    expect(html).toContain("Llama 3.2 Vision");
+    expect(html).not.toContain("API TOKEN");
+    expect(html).not.toContain("Paste your API key");
+    expect(html).not.toContain("Reveal");
+  });
+
+  test("LM Studio card actions call local enable and model visibility handlers", async () => {
+    const harness = setupJsdom();
+    const setLmStudioEnabled = mock(async () => {});
+    const setLmStudioModelVisible = mock(async () => {});
+    const refreshProviderStatus = mock(async () => {});
+
+    try {
+      const container = harness.dom.window.document.getElementById("root");
+      if (!container) throw new Error("missing root");
+      const root = createRoot(container);
+
+      await act(async () => {
+        useAppStore.setState({
+          ...useAppStore.getState(),
+          providerStatusByName: {
+            ...useAppStore.getState().providerStatusByName,
+            lmstudio: {
+              provider: "lmstudio",
+              authorized: false,
+              verified: false,
+              mode: "local",
+              account: null,
+              message: "LM Studio unavailable.",
+              checkedAt: "2026-03-18T00:00:00.000Z",
+            },
+          } as any,
+          providerCatalog: [
+            {
+              id: "lmstudio",
+              name: "LM Studio",
+              state: "unreachable",
+              message: "LM Studio unavailable.",
+              models: [
+                { id: "qwen/qwen3-30b-a3b", displayName: "Qwen 3 30B", knowledgeCutoff: "Unknown", supportsImageInput: false },
+              ],
+              defaultModel: "qwen/qwen3-30b-a3b",
+            },
+          ] as any,
+          providerUiState: {
+            lmstudio: {
+              enabled: false,
+              hiddenModels: [],
+            },
+          },
+          setLmStudioEnabled,
+          setLmStudioModelVisible,
+          refreshProviderStatus,
+        });
+      });
+
+      await act(async () => {
+        root.render(createElement(ProvidersPage, { initialExpandedSectionId: "provider:lmstudio" }));
+      });
+
+      const connectButton = [...container.querySelectorAll("button")].find((button) => button.textContent?.trim() === "Connect");
+      if (!connectButton) throw new Error("missing LM Studio connect button");
+      await act(async () => {
+        connectButton.dispatchEvent(new harness.dom.window.MouseEvent("click", { bubbles: true }));
+      });
+      expect(setLmStudioEnabled).toHaveBeenCalledWith(true);
+
+      const refreshButton = [...container.querySelectorAll("button")].find((button) => button.textContent?.trim() === "Refresh");
+      if (!refreshButton) throw new Error("missing LM Studio refresh button");
+      await act(async () => {
+        refreshButton.dispatchEvent(new harness.dom.window.MouseEvent("click", { bubbles: true }));
+      });
+      expect(refreshProviderStatus).toHaveBeenCalled();
+
+      const modelCheckbox = container.querySelector('[aria-label="Show LM Studio model qwen/qwen3-30b-a3b in chat"]');
+      if (!(modelCheckbox instanceof harness.dom.window.HTMLElement)) {
+        throw new Error("missing LM Studio model checkbox");
+      }
+      await act(async () => {
+        modelCheckbox.dispatchEvent(new harness.dom.window.MouseEvent("click", { bubbles: true }));
+      });
+      expect(setLmStudioModelVisible).toHaveBeenCalledWith("qwen/qwen3-30b-a3b", false);
+
+      await act(async () => {
+        root.unmount();
+      });
+    } finally {
+      harness.restore();
+    }
   });
 });

--- a/docs/websocket-protocol.md
+++ b/docs/websocket-protocol.md
@@ -6,7 +6,7 @@ Canonical protocol contract for `agent-coworker` WebSocket clients.
 
 - URL: `ws://127.0.0.1:{port}/ws`
 - Session resume: `?resumeSessionId=<sessionId>`
-- Current protocol version: `7.21`
+- Current protocol version: `7.22`
 
 ## Table of Contents
 
@@ -48,6 +48,12 @@ Canonical protocol contract for `agent-coworker` WebSocket clients.
   - Error & Keepalive: [error](#error) | [pong](#pong)
 
 ## Protocol v7 Notes
+
+Changes in `7.22`:
+
+- Added `lmstudio` as a first-class dynamic local provider.
+- `provider_catalog` entries may now include optional provider-level `state` (`"ready" | "empty" | "unreachable"`) and `message` fields for dynamic providers such as LM Studio.
+- `set_config.config.providerOptions.lmstudio` and `session_config.config.providerOptions.lmstudio` now support `baseUrl`, `contextLength`, `autoLoad`, and `reloadOnContextMismatch`.
 
 Changes in `7.21`:
 
@@ -161,7 +167,7 @@ Changes in `7.2`:
 
 Changes in `7.1`:
 
-- `set_config.config` now accepts editable OpenAI-compatible `providerOptions` for `openai` and `codex-cli` only.
+- `set_config.config` now accepts editable OpenAI-compatible `providerOptions` for `openai`, `codex-cli`, and `lmstudio`.
 - `session_config.config` now includes the same normalized OpenAI-compatible `providerOptions` subset when configured.
 - OpenAI API and Codex CLI provider defaults now use `gpt-5.4`.
 
@@ -244,7 +250,7 @@ Types referenced across multiple messages.
 ### ProviderName
 
 ```
-"google" | "openai" | "anthropic" | "opencode-go" | "opencode-zen" | "codex-cli"
+"google" | "openai" | "anthropic" | "baseten" | "together" | "nvidia" | "lmstudio" | "opencode-go" | "opencode-zen" | "codex-cli"
 ```
 
 ### PublicConfig
@@ -265,10 +271,19 @@ Returned in `server_hello` and `config_updated`:
 
 ```json
 {
-  "id": "opencode-zen",
-  "name": "OpenCode Zen",
-  "models": ["glm-5", "kimi-k2.5", "nemotron-3-super-free", "mimo-v2-flash-free", "big-pickle", "minimax-m2.5-free", "minimax-m2.5"],
-  "defaultModel": "glm-5"
+  "id": "lmstudio",
+  "name": "LM Studio",
+  "models": [
+    {
+      "id": "local/qwen-2.5",
+      "displayName": "Qwen 2.5 Local",
+      "knowledgeCutoff": "Unknown",
+      "supportsImageInput": false
+    }
+  ],
+  "defaultModel": "local/qwen-2.5",
+  "state": "ready",
+  "message": "LM Studio server reachable at http://localhost:1234."
 }
 ```
 
@@ -343,9 +358,9 @@ Returned in `server_hello` and `config_updated`:
 | Field | Type | Description |
 |-------|------|-------------|
 | `provider` | `ProviderName` | Provider identifier |
-| `authorized` | `boolean` | Whether auth credentials exist |
+| `authorized` | `boolean` | Whether the provider is immediately usable. For local providers like LM Studio this can be `true` based on reachability rather than stored auth |
 | `verified` | `boolean` | Whether credentials have been verified working |
-| `mode` | `"missing" \| "error" \| "api_key" \| "oauth" \| "oauth_pending"` | Current auth mode |
+| `mode` | `"missing" \| "error" \| "api_key" \| "oauth" \| "oauth_pending" \| "local"` | Current auth/connection mode |
 | `account` | `{ email?: string, name?: string } \| null` | Account info if available |
 | `message` | `string` | Human-readable status message |
 | `checkedAt` | `string` | ISO 8601 timestamp of last check |
@@ -1908,6 +1923,12 @@ Update runtime configuration values.
             "timezone": "America/New_York"
           }
         }
+      },
+      "lmstudio": {
+        "baseUrl": "http://127.0.0.1:1234",
+        "contextLength": 16384,
+        "autoLoad": true,
+        "reloadOnContextMismatch": true
       }
     }
   }
@@ -1929,7 +1950,7 @@ Update runtime configuration values.
 | `config.preferredChildModelRef` | `string` | No | Preferred child target ref. Accepts either a plain same-provider model id or a canonical `provider:modelId` ref |
 | `config.allowedChildModelRefs` | `string[]` | No | Exact cross-provider child target refs allowed for this workspace |
 | `config.maxSteps` | `number` | No | Max steps per turn (1-1000) |
-| `config.providerOptions` | `object` | No | Editable OpenAI-compatible provider option patch. Only `openai` and `codex-cli` are allowed |
+| `config.providerOptions` | `object` | No | Editable provider option patch. Only `openai`, `codex-cli`, and `lmstudio` are allowed |
 | `config.providerOptions.openai.reasoningEffort` | `"none" \| "low" \| "medium" \| "high" \| "xhigh"` | No | OpenAI reasoning effort |
 | `config.providerOptions.openai.reasoningSummary` | `"auto" \| "concise" \| "detailed"` | No | OpenAI reasoning summary |
 | `config.providerOptions.openai.textVerbosity` | `"low" \| "medium" \| "high"` | No | OpenAI verbosity |
@@ -1944,6 +1965,10 @@ Update runtime configuration values.
 | `config.providerOptions.codex-cli.webSearch.location.region` | `string` | No | Approximate region/state hint for Codex native web search |
 | `config.providerOptions.codex-cli.webSearch.location.city` | `string` | No | Approximate city hint for Codex native web search |
 | `config.providerOptions.codex-cli.webSearch.location.timezone` | `string` | No | Approximate timezone hint for Codex native web search |
+| `config.providerOptions.lmstudio.baseUrl` | `string` | No | Override the LM Studio server base URL. Defaults to `http://localhost:1234` |
+| `config.providerOptions.lmstudio.contextLength` | `number` | No | Preferred LM Studio load context length |
+| `config.providerOptions.lmstudio.autoLoad` | `boolean` | No | Whether the harness proactively loads the LM Studio model before inference when needed |
+| `config.providerOptions.lmstudio.reloadOnContextMismatch` | `boolean` | No | Whether the harness reloads an already-loaded LM Studio model when the requested context length differs |
 | `config.userProfile` | `object` | No | User profile patch merged into persisted workspace config. Empty-string fields clear the corresponding prompt context |
 | `config.userName` | `string` | No | User name used for prompt injection. An empty string clears it |
 | `config.userProfile.instructions` | `string` | No | Custom behavioral instructions the agent should follow. An empty string clears it |
@@ -1954,7 +1979,7 @@ Update runtime configuration values.
 
 Notes:
 - `providerOptions` is a deep-merged patch against the workspace config. Unrelated provider settings outside this editable subset are preserved.
-- Only `openai` and `codex-cli` are editable through this message. Other provider option trees remain internal.
+- `lmstudio` provider options affect harness-side discovery/load behavior; inference still runs through the normal runtime path.
 - `toolOutputOverflowChars: null` disables spill files explicitly. `clearToolOutputOverflowChars: true` removes the persisted override so future sessions inherit the default again.
 
 ---
@@ -2296,12 +2321,26 @@ Provider catalog metadata. Sent on connection and after model changes.
   "type": "provider_catalog",
   "sessionId": "...",
   "all": [
-    { "id": "openai", "name": "OpenAI", "models": ["gpt-5.4", "gpt-5.4-mini", "gpt-5.2", "gpt-5.2-codex"], "defaultModel": "gpt-5.4" },
-    { "id": "opencode-go", "name": "OpenCode Go", "models": ["glm-5", "kimi-k2.5"], "defaultModel": "glm-5" },
-    { "id": "opencode-zen", "name": "OpenCode Zen", "models": ["glm-5", "kimi-k2.5", "nemotron-3-super-free", "mimo-v2-flash-free", "big-pickle", "minimax-m2.5-free", "minimax-m2.5"], "defaultModel": "glm-5" }
+    {
+      "id": "openai",
+      "name": "OpenAI",
+      "models": [
+        { "id": "gpt-5.4", "displayName": "GPT-5.4", "knowledgeCutoff": "August 2025", "supportsImageInput": true }
+      ],
+      "defaultModel": "gpt-5.4"
+    },
+    {
+      "id": "lmstudio",
+      "name": "LM Studio",
+      "models": [
+        { "id": "local/qwen-2.5", "displayName": "Qwen 2.5 Local", "knowledgeCutoff": "Unknown", "supportsImageInput": false }
+      ],
+      "defaultModel": "local/qwen-2.5",
+      "state": "ready"
+    }
   ],
-  "default": { "openai": "gpt-5.4", "opencode-go": "glm-5", "opencode-zen": "glm-5", "google": "gemini-3.1-pro-preview-customtools" },
-  "connected": ["openai", "opencode-go", "opencode-zen"]
+  "default": { "openai": "gpt-5.4", "lmstudio": "local/qwen-2.5", "opencode-go": "glm-5", "opencode-zen": "glm-5", "google": "gemini-3-pro-preview" },
+  "connected": ["openai", "lmstudio", "opencode-go", "opencode-zen"]
 }
 ```
 
@@ -2311,7 +2350,7 @@ Provider catalog metadata. Sent on connection and after model changes.
 | `sessionId` | `string` | Session identifier |
 | `all` | `ProviderCatalogEntry[]` | All available providers with their models |
 | `default` | `Record<string, string>` | Default model per provider (includes current session's selection) |
-| `connected` | `string[]` | Provider IDs that have active auth |
+| `connected` | `string[]` | Provider IDs that are currently usable. For local providers like LM Studio this can be based on reachability rather than stored auth |
 
 ---
 
@@ -3430,6 +3469,12 @@ Current runtime config. Sent on connection and after `set_config`.
             "timezone": "America/New_York"
           }
         }
+      },
+      "lmstudio": {
+        "baseUrl": "http://127.0.0.1:1234",
+        "contextLength": 16384,
+        "autoLoad": true,
+        "reloadOnContextMismatch": true
       }
     }
   }
@@ -3451,7 +3496,7 @@ Current runtime config. Sent on connection and after `set_config`.
 | `config.preferredChildModelRef` | `string` | Canonical preferred child target ref shown in workspace/UI suggestions |
 | `config.allowedChildModelRefs` | `string[]` | Exact cross-provider child target refs allowed for this workspace |
 | `config.maxSteps` | `number` | Maximum steps per turn |
-| `config.providerOptions` | `object?` | Editable OpenAI-compatible provider options when configured |
+| `config.providerOptions` | `object?` | Editable provider options when configured |
 | `config.userName` | `string` | Effective user name |
 | `config.userProfile` | `object` | Effective user profile metadata used for prompt injection |
 | `config.userProfile.instructions` | `string` | Effective profile instructions |
@@ -3471,6 +3516,10 @@ Current runtime config. Sent on connection and after `set_config`.
 | `config.providerOptions.codex-cli.webSearch.location.region` | `string` | Current editable Codex native web-search region/state |
 | `config.providerOptions.codex-cli.webSearch.location.city` | `string` | Current editable Codex native web-search city |
 | `config.providerOptions.codex-cli.webSearch.location.timezone` | `string` | Current editable Codex native web-search timezone |
+| `config.providerOptions.lmstudio.baseUrl` | `string` | Current LM Studio base URL override |
+| `config.providerOptions.lmstudio.contextLength` | `number` | Current requested LM Studio context length override |
+| `config.providerOptions.lmstudio.autoLoad` | `boolean` | Current LM Studio eager-load toggle |
+| `config.providerOptions.lmstudio.reloadOnContextMismatch` | `boolean` | Current LM Studio reload-on-context-mismatch toggle |
 
 ---
 

--- a/src/cli/repl.ts
+++ b/src/cli/repl.ts
@@ -159,6 +159,7 @@ export async function runCliRepl(
   let activeApproval: ApprovalPrompt | null = null;
   let busy = false;
   let providerList: string[] = [...UI_PROVIDER_NAMES];
+  let providerDefaultModels: Record<string, string> = {};
   let providerAuthMethods: Record<string, ProviderAuthMethod[]> = {};
   let providerStatuses: ProviderStatus[] = [];
   let lastStreamedAssistantTurnId: string | null = null;
@@ -269,6 +270,7 @@ export async function runCliRepl(
     selectedProvider = null;
     busy = false;
     providerList = [...UI_PROVIDER_NAMES];
+    providerDefaultModels = {};
     providerAuthMethods = {};
     providerStatuses = [];
     resetModelStreamState();
@@ -324,6 +326,12 @@ export async function runCliRepl(
     },
     set providerList(value) {
       providerList = value;
+    },
+    get providerDefaultModels() {
+      return providerDefaultModels;
+    },
+    set providerDefaultModels(value) {
+      providerDefaultModels = value;
     },
     get providerAuthMethods() {
       return providerAuthMethods;
@@ -540,6 +548,10 @@ export async function runCliRepl(
             selectedProvider = provider;
           },
           getProviderList: () => providerList,
+          getProviderDefaultModel: (provider) => {
+            const value = providerDefaultModels[provider];
+            return typeof value === "string" && value.trim().length > 0 ? value : null;
+          },
           getProviderAuthMethods: () => providerAuthMethods,
           trySend: (msg) => {
             const ok = send(msg);

--- a/src/cli/repl/commandRouter.ts
+++ b/src/cli/repl/commandRouter.ts
@@ -26,6 +26,7 @@ export type ReplCommandContext = {
   getSelectedProvider: () => string | null;
   setSelectedProvider: (provider: string | null) => void;
   getProviderList: () => string[];
+  getProviderDefaultModel: (provider: string) => string | null;
   getProviderAuthMethods: () => Record<string, ProviderAuthMethod[]>;
   trySend: (msg: ClientMessage) => boolean;
   activateNextPrompt: () => void;
@@ -118,7 +119,16 @@ export async function handleSlashCommand(input: string, ctx: ReplCommandContext)
       ctx.activateNextPrompt();
       return true;
     }
-    const nextModel = defaultModelForProvider(name);
+    const nextModel = ctx.getProviderDefaultModel(name) ?? defaultModelForProvider(name);
+    if (!nextModel) {
+      console.log(
+        name === "lmstudio"
+          ? "LM Studio has no default LLM right now. Make sure the LM Studio server is reachable and exposes at least one LLM, then retry /provider lmstudio or set a model explicitly with /model <key>."
+          : `provider ${name} has no selectable default model right now`,
+      );
+      ctx.activateNextPrompt();
+      return true;
+    }
     if (sessionId()) {
       const ok = ctx.trySend({ type: "set_model", sessionId: sessionId()!, provider: name, model: nextModel });
       if (!ok) return true;

--- a/src/cli/repl/serverEventHandler.ts
+++ b/src/cli/repl/serverEventHandler.ts
@@ -21,6 +21,7 @@ export type ReplServerEventState = {
   selectedProvider: string | null;
   busy: boolean;
   providerList: string[];
+  providerDefaultModels: Record<string, string>;
   providerAuthMethods: Record<string, ProviderAuthMethod[]>;
   providerStatuses: ProviderStatus[];
   pendingAsk: AskPrompt[];
@@ -226,6 +227,7 @@ export function createServerEventHandler(ctx: ReplServerEventContext) {
         break;
       case "provider_catalog":
         ctx.state.providerList = evt.all.map((entry) => entry.id);
+        ctx.state.providerDefaultModels = evt.default;
         break;
       case "provider_auth_methods":
         ctx.state.providerAuthMethods = evt.methods;

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,7 +7,7 @@ import { z } from "zod";
 
 import { getAiCoworkerPaths } from "./connect";
 import { parseConnectionStoreJson } from "./store/connections";
-import { defaultModelForProvider, getModelForProvider, getProviderKeyCandidates } from "./providers";
+import { getModelForProvider, getProviderKeyCandidates } from "./providers";
 import { DEFAULT_TOOL_OUTPUT_OVERFLOW_CHARS } from "./shared/toolOutputOverflow";
 import {
   normalizeRuntimeNameForProvider,
@@ -17,8 +17,14 @@ import {
 } from "./types";
 import type { AgentConfig, CommandTemplateConfig, ProviderName, RuntimeName } from "./types";
 import { resolveAuthHomeDir } from "./utils/authHome";
-import { assertSupportedModel, defaultSupportedModel, getSupportedModel } from "./models/registry";
+import { defaultSupportedModel, getSupportedModel } from "./models/registry";
 import { normalizeChildRoutingConfig } from "./models/childModelRouting";
+import {
+  getResolvedModelMetadataSync,
+  normalizeModelIdForProvider,
+  resolveDefaultModelMetadata,
+  resolveModelMetadata,
+} from "./models/metadata";
 
 export { defaultModelForProvider } from "./providers";
 
@@ -84,7 +90,7 @@ function mergeProviderOptionDefaults(
   modelId: string,
   providerOptions: Record<string, any> | undefined,
 ): Record<string, any> | undefined {
-  const defaults = assertSupportedModel(provider, modelId, "model").providerOptionsDefaults;
+  const defaults = getResolvedModelMetadataSync(provider, modelId, "model").providerOptionsDefaults;
   const current = isPlainObject(providerOptions) ? deepMerge({}, providerOptions) as Record<string, any> : undefined;
   const currentProviderOptions =
     current && isPlainObject(current[provider]) ? current[provider] as Record<string, unknown> : undefined;
@@ -104,7 +110,22 @@ function mergeProviderOptionDefaults(
   };
 }
 
-function resolveSupportedConfiguredModel(provider: ProviderName, modelId: string, source: string) {
+async function resolveConfiguredModelMetadata(
+  provider: ProviderName,
+  modelId: string,
+  source: string,
+  providerOptions: Record<string, unknown> | undefined,
+  env: Record<string, string | undefined>,
+) {
+  if (provider === "lmstudio") {
+    return await resolveModelMetadata(provider, modelId, {
+      allowPlaceholder: true,
+      providerOptions,
+      env,
+      source,
+      log: (line) => console.warn(`[config] ${line}`),
+    });
+  }
   const supported = getSupportedModel(provider, modelId);
   if (supported) return supported;
   const fallback = defaultSupportedModel(provider);
@@ -316,13 +337,18 @@ export async function loadConfig(options: LoadConfigOptions = {}): Promise<Agent
 
   const workingDirectory = env.AGENT_WORKING_DIR || cwd;
 
-  const model =
+  const providerOptions = isPlainObject((merged as Record<string, unknown>).providerOptions)
+    ? (deepMerge({}, (merged as Record<string, unknown>).providerOptions as Record<string, unknown>) as Record<string, unknown>)
+    : undefined;
+
+  const configuredModel =
     asNonEmptyString(env.AGENT_MODEL) ||
     asNonEmptyString(projectConfig.model) ||
     asNonEmptyString(userConfig.model) ||
-    (asProviderName(builtInDefaults.provider) === provider && asNonEmptyString(builtInDefaults.model)) ||
-    defaultModelForProvider(provider);
-  const supportedModel = resolveSupportedConfiguredModel(provider, model, "model");
+    (asProviderName(builtInDefaults.provider) === provider && asNonEmptyString(builtInDefaults.model));
+  const supportedModel = configuredModel
+    ? await resolveConfiguredModelMetadata(provider, configuredModel, "model", providerOptions, env)
+    : await resolveDefaultModelMetadata(provider, { providerOptions, env });
 
   const childModelRoutingMode =
     resolveChildModelRoutingMode(projectConfig.childModelRoutingMode) ||
@@ -486,12 +512,13 @@ export async function loadConfig(options: LoadConfigOptions = {}): Promise<Agent
   };
 
   const command = parseCommandConfig((merged as Record<string, unknown>).command);
-  const providerOptions = isPlainObject((merged as Record<string, unknown>).providerOptions)
-    ? (deepMerge({}, (merged as Record<string, unknown>).providerOptions as Record<string, unknown>) as Record<string, any>)
-    : undefined;
   const disableBuiltInSkills = asBoolean(env.COWORK_DISABLE_BUILTIN_SKILLS) ?? false;
 
-  const normalizedProviderOptions = mergeProviderOptionDefaults(provider, supportedModel.id, providerOptions);
+  const normalizedProviderOptions = mergeProviderOptionDefaults(
+    provider,
+    supportedModel.id,
+    providerOptions as Record<string, any> | undefined,
+  );
 
   const mergedModelSettings = parseLayer(modelSettingsLayerSchema, (merged as Record<string, unknown>).modelSettings, {});
   const maxRetries = normalizeNonNegativeInt(env.AGENT_MODEL_MAX_RETRIES) ?? mergedModelSettings.maxRetries;
@@ -552,7 +579,7 @@ export async function loadConfig(options: LoadConfigOptions = {}): Promise<Agent
 
 export function getModel(config: AgentConfig, id?: string) {
   const modelId = id || config.model;
-  assertSupportedModel(config.provider, modelId, id ? "model override" : "model");
+  const normalizedModelId = normalizeModelIdForProvider(config.provider, modelId, id ? "model override" : "model");
   const savedKey = getSavedProviderApiKey(config, config.provider);
-  return getModelForProvider(config, modelId, savedKey);
+  return getModelForProvider(config, normalizedModelId, savedKey);
 }

--- a/src/models/childModelRouting.ts
+++ b/src/models/childModelRouting.ts
@@ -1,4 +1,4 @@
-import { assertSupportedModel } from "./registry";
+import { normalizeModelIdForProvider } from "./metadata";
 import {
   type ChildModelRoutingMode,
   isChildModelRoutingMode,
@@ -28,7 +28,7 @@ export function parseChildModelRef(raw: string, defaultProvider?: ProviderName, 
     if (!defaultProvider) {
       throw new Error(`Unsupported ${source} "${trimmed}". Expected provider:modelId.`);
     }
-    const modelId = assertSupportedModel(defaultProvider, trimmed, source).id;
+    const modelId = normalizeModelIdForProvider(defaultProvider, trimmed, source);
     return {
       provider: defaultProvider,
       modelId,
@@ -43,7 +43,7 @@ export function parseChildModelRef(raw: string, defaultProvider?: ProviderName, 
     throw new Error(`Unsupported ${source} "${trimmed}". Expected provider:modelId.`);
   }
 
-  const modelId = assertSupportedModel(providerRaw, modelRaw, source).id;
+  const modelId = normalizeModelIdForProvider(providerRaw, modelRaw, source);
   return {
     provider: providerRaw,
     modelId,
@@ -100,7 +100,8 @@ export function normalizeChildRoutingConfig(opts: {
   const mode = isChildModelRoutingMode(opts.childModelRoutingMode)
     ? opts.childModelRoutingMode
     : "same-provider";
-  const fallbackRef = childModelRef(opts.provider, assertSupportedModel(opts.provider, opts.model, "model").id);
+  const fallbackModelId = normalizeModelIdForProvider(opts.provider, opts.model, "model");
+  const fallbackRef = childModelRef(opts.provider, fallbackModelId);
   const allowedChildModelRefs = normalizeAllowedChildModelRefs(
     opts.allowedChildModelRefs ?? undefined,
     opts.provider,

--- a/src/models/metadata.ts
+++ b/src/models/metadata.ts
@@ -1,0 +1,136 @@
+import {
+  buildLmStudioPlaceholderMetadata,
+  resolveDefaultLmStudioModelMetadata,
+  resolveLmStudioDiscoveredModelMetadata,
+} from "../providers/lmstudio/catalog";
+import type { ProviderName } from "../types";
+import {
+  assertSupportedModel,
+  defaultSupportedModel,
+  getSupportedModel,
+} from "./registry";
+import type { ResolvedModelMetadata } from "./metadataTypes";
+
+function toResolvedStaticModel(provider: ProviderName, modelId: string, source = "model"): ResolvedModelMetadata {
+  const model = assertSupportedModel(provider, modelId, source);
+  return {
+    id: model.id,
+    provider: model.provider,
+    displayName: model.displayName,
+    knowledgeCutoff: model.knowledgeCutoff,
+    supportsImageInput: model.supportsImageInput,
+    promptTemplate: model.promptTemplate,
+    providerOptionsDefaults: { ...model.providerOptionsDefaults },
+    source: "static",
+  };
+}
+
+export function isDynamicModelProvider(provider: ProviderName): provider is "lmstudio" {
+  return provider === "lmstudio";
+}
+
+export function normalizeModelIdForProvider(
+  provider: ProviderName,
+  modelId: string,
+  source = "model",
+): string {
+  const trimmed = modelId.trim();
+  if (!trimmed) {
+    throw new Error(`${source} is required.`);
+  }
+  if (provider === "lmstudio") {
+    return trimmed;
+  }
+  return assertSupportedModel(provider, trimmed, source).id;
+}
+
+export function getResolvedModelMetadataSync(
+  provider: ProviderName,
+  modelId: string,
+  source = "model",
+): ResolvedModelMetadata {
+  if (provider === "lmstudio") {
+    return buildLmStudioPlaceholderMetadata(normalizeModelIdForProvider(provider, modelId, source));
+  }
+  return toResolvedStaticModel(provider, modelId, source);
+}
+
+export async function resolveModelMetadata(
+  provider: ProviderName,
+  modelId: string,
+  opts: {
+    allowPlaceholder?: boolean;
+    providerOptions?: unknown;
+    env?: NodeJS.ProcessEnv;
+    fetchImpl?: typeof fetch;
+    source?: string;
+    log?: (line: string) => void;
+  } = {},
+): Promise<ResolvedModelMetadata> {
+  if (provider !== "lmstudio") {
+    return toResolvedStaticModel(provider, modelId, opts.source);
+  }
+
+  const normalizedModelId = normalizeModelIdForProvider(provider, modelId, opts.source);
+  try {
+    return await resolveLmStudioDiscoveredModelMetadata({
+      modelId: normalizedModelId,
+      providerOptions: opts.providerOptions,
+      env: opts.env,
+      fetchImpl: opts.fetchImpl,
+    });
+  } catch (error) {
+    if (opts.allowPlaceholder) {
+      opts.log?.(
+        `[lmstudio] using conservative placeholder metadata for ${normalizedModelId}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return buildLmStudioPlaceholderMetadata(normalizedModelId);
+    }
+    throw error;
+  }
+}
+
+export async function resolveDefaultModelMetadata(
+  provider: ProviderName,
+  opts: {
+    providerOptions?: unknown;
+    env?: NodeJS.ProcessEnv;
+    fetchImpl?: typeof fetch;
+  } = {},
+): Promise<ResolvedModelMetadata> {
+  if (provider === "lmstudio") {
+    return await resolveDefaultLmStudioModelMetadata(opts);
+  }
+  const model = defaultSupportedModel(provider);
+  return {
+    id: model.id,
+    provider: model.provider,
+    displayName: model.displayName,
+    knowledgeCutoff: model.knowledgeCutoff,
+    supportsImageInput: model.supportsImageInput,
+    promptTemplate: model.promptTemplate,
+    providerOptionsDefaults: { ...model.providerOptionsDefaults },
+    source: "static",
+  };
+}
+
+export function getKnownResolvedModelMetadata(
+  provider: ProviderName,
+  modelId: string,
+): ResolvedModelMetadata | null {
+  if (provider === "lmstudio") {
+    return buildLmStudioPlaceholderMetadata(modelId);
+  }
+  const model = getSupportedModel(provider, modelId);
+  if (!model) return null;
+  return {
+    id: model.id,
+    provider: model.provider,
+    displayName: model.displayName,
+    knowledgeCutoff: model.knowledgeCutoff,
+    supportsImageInput: model.supportsImageInput,
+    promptTemplate: model.promptTemplate,
+    providerOptionsDefaults: { ...model.providerOptionsDefaults },
+    source: "static",
+  };
+}

--- a/src/models/metadataTypes.ts
+++ b/src/models/metadataTypes.ts
@@ -1,0 +1,20 @@
+import type { ProviderName } from "../types";
+
+export type ModelMetadataSource = "static" | "dynamic";
+
+export type ResolvedModelMetadata = {
+  id: string;
+  provider: ProviderName;
+  displayName: string;
+  knowledgeCutoff: string;
+  supportsImageInput: boolean;
+  promptTemplate: string;
+  providerOptionsDefaults: Record<string, unknown>;
+  source: ModelMetadataSource;
+  maxContextLength?: number;
+  effectiveContextLength?: number;
+  trainedForToolUse?: boolean;
+  architecture?: string;
+  format?: string;
+  loaded?: boolean;
+};

--- a/src/models/registry.ts
+++ b/src/models/registry.ts
@@ -39,7 +39,7 @@ import togetherQwenQwen35397bA17b from "../../config/models/together/qwen-qwen3.
 import togetherZaiOrgGlm5 from "../../config/models/together/zai-org-glm-5.json";
 import type { ProviderName } from "../types";
 
-const providerNameSchema = z.enum([
+export const STATIC_MODEL_PROVIDER_NAMES = [
   "google",
   "openai",
   "anthropic",
@@ -49,7 +49,11 @@ const providerNameSchema = z.enum([
   "opencode-go",
   "opencode-zen",
   "codex-cli",
-]);
+ ] as const satisfies readonly ProviderName[];
+
+export type StaticModelProviderName = (typeof STATIC_MODEL_PROVIDER_NAMES)[number];
+
+const providerNameSchema = z.enum(STATIC_MODEL_PROVIDER_NAMES);
 
 const supportedModelSchema = z.object({
   id: z.string().trim().min(1),
@@ -108,7 +112,7 @@ const RAW_MODEL_REGISTRY_ENTRIES = [
 // supplying the JSON file and including it in this array so buildRegistry actually sees it.
 
 function buildRegistry(entries: SupportedModel[]) {
-  const byProvider: Record<ProviderName, SupportedModel[]> = {
+  const byProvider: Record<StaticModelProviderName, SupportedModel[]> = {
     google: [],
     openai: [],
     anthropic: [],
@@ -120,7 +124,7 @@ function buildRegistry(entries: SupportedModel[]) {
     "codex-cli": [],
   };
   const byKey = new Map<string, SupportedModel>();
-  const defaults = new Map<ProviderName, SupportedModel>();
+  const defaults = new Map<StaticModelProviderName, SupportedModel>();
 
   for (const entry of entries) {
     byProvider[entry.provider].push(entry);
@@ -137,7 +141,7 @@ function buildRegistry(entries: SupportedModel[]) {
     }
   }
 
-  for (const provider of Object.keys(byProvider) as ProviderName[]) {
+  for (const provider of STATIC_MODEL_PROVIDER_NAMES) {
     if (byProvider[provider].length === 0) {
       throw new Error(`No supported models configured for provider ${provider}.`);
     }
@@ -157,15 +161,23 @@ const MODEL_REGISTRY = buildRegistry(MODEL_REGISTRY_ENTRIES);
 
 export { MODEL_REGISTRY_ENTRIES };
 
+export function isStaticRegistryProvider(provider: ProviderName): provider is StaticModelProviderName {
+  return (STATIC_MODEL_PROVIDER_NAMES as readonly string[]).includes(provider);
+}
+
 export function listSupportedModels(provider: ProviderName): readonly SupportedModel[] {
-  return MODEL_REGISTRY.byProvider[provider];
+  return isStaticRegistryProvider(provider) ? MODEL_REGISTRY.byProvider[provider] : [];
 }
 
 export function getSupportedModel(provider: ProviderName, modelId: string): SupportedModel | null {
+  if (!isStaticRegistryProvider(provider)) return null;
   return MODEL_REGISTRY.byKey.get(`${provider}:${modelId.trim()}`) ?? null;
 }
 
 export function defaultSupportedModel(provider: ProviderName): SupportedModel {
+  if (!isStaticRegistryProvider(provider)) {
+    throw new Error(`Provider ${provider} uses dynamic model discovery and has no static default model.`);
+  }
   const entry = MODEL_REGISTRY.defaults.get(provider);
   if (!entry) throw new Error(`Missing default model for provider ${provider}.`);
   return entry;

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -3,7 +3,8 @@ import path from "node:path";
 
 import type { AgentConfig } from "./types";
 import { discoverSkills } from "./skills";
-import { assertSupportedModel, type SupportedModel } from "./models/registry";
+import { getResolvedModelMetadataSync, resolveModelMetadata } from "./models/metadata";
+import type { ResolvedModelMetadata } from "./models/metadataTypes";
 import { getChildAgentModelInfo, listChildAgentModelsWithInfo } from "./models/childAgentModelInfo";
 import { parseChildModelRef } from "./models/childModelRouting";
 import { MemoryStore } from "./memoryStore";
@@ -17,8 +18,13 @@ import { isUserFacingProviderEnabled } from "./providers/catalog";
 import type { ProviderName } from "./types";
 
 async function resolveSystemTemplatePath(config: AgentConfig): Promise<string> {
-  const supportedModel = assertSupportedModel(config.provider, config.model, "model");
-  const modelSystemPath = path.join(config.builtInDir, "prompts", supportedModel.promptTemplate);
+  const modelMetadata = await resolveModelMetadata(config.provider, config.model, {
+    allowPlaceholder: true,
+    providerOptions: config.providerOptions,
+    source: "model",
+    log: (line) => console.warn(line),
+  });
+  const modelSystemPath = path.join(config.builtInDir, "prompts", modelMetadata.promptTemplate);
   try {
     await fs.access(modelSystemPath);
     return modelSystemPath;
@@ -50,8 +56,8 @@ function renderTemplateVariables(prompt: string, vars: Record<string, string>): 
   return out.replace(/\{\{([A-Za-z0-9_]+)\}\}/g, (match, key: string) => vars[key] ?? match);
 }
 
-function renderCapabilitySpecificPrompt(prompt: string, supportedModel: SupportedModel): string {
-  if (supportedModel.supportsImageInput) return prompt;
+function renderCapabilitySpecificPrompt(prompt: string, modelMetadata: ResolvedModelMetadata): string {
+  if (modelMetadata.supportsImageInput) return prompt;
 
   let out = prompt;
   const replacements: Array<[RegExp, string]> = [
@@ -141,6 +147,7 @@ const PROVIDER_DISPLAY_NAMES: Record<ProviderName, string> = {
   baseten: "Baseten",
   together: "Together AI",
   nvidia: "NVIDIA",
+  lmstudio: "LM Studio",
   "opencode-go": "OpenCode Go",
   "opencode-zen": "OpenCode Zen",
   "codex-cli": "Codex CLI",
@@ -148,7 +155,7 @@ const PROVIDER_DISPLAY_NAMES: Record<ProviderName, string> = {
 
 function buildSpawnAgentPromptBody(config: AgentConfig): string {
   const providerLabel = PROVIDER_DISPLAY_NAMES[config.provider] ?? config.provider;
-  const currentModel = assertSupportedModel(config.provider, config.model, "model");
+  const currentModel = getResolvedModelMetadataSync(config.provider, config.model, "model");
 
   const roleLines = Object.values(AGENT_ROLE_DEFINITIONS)
     .map((role) => `- **${role.id}**: ${role.description}`)
@@ -158,7 +165,7 @@ function buildSpawnAgentPromptBody(config: AgentConfig): string {
     .map((ref) => {
       try {
         const parsed = parseChildModelRef(ref, config.provider, "child target");
-        const supported = assertSupportedModel(parsed.provider, parsed.modelId, "child target");
+        const supported = getResolvedModelMetadataSync(parsed.provider, parsed.modelId, "child target");
         const bestFor = getChildAgentModelInfo(parsed.provider, parsed.modelId)?.bestFor ?? "general-purpose work on this provider";
         const displayProvider = PROVIDER_DISPLAY_NAMES[parsed.provider] ?? parsed.provider;
         return `- **${displayProvider} / ${supported.displayName}** (\`${parsed.ref}\`): ${bestFor}.`;
@@ -170,6 +177,8 @@ function buildSpawnAgentPromptBody(config: AgentConfig): string {
   const providerSupportsUserFacingModels = isUserFacingProviderEnabled(config.provider);
   const modelLines = config.childModelRoutingMode === "cross-provider-allowlist" && crossProviderRefs.length > 0
     ? crossProviderRefs.join("\n")
+    : config.provider === "lmstudio"
+      ? "- Any LM Studio LLM key discovered at runtime is allowed. Use either the bare key or `lmstudio:<modelKey>`."
     : !providerSupportsUserFacingModels
       ? "- No user-facing child model overrides are available for this provider."
       : listChildAgentModelsWithInfo(config.provider)
@@ -284,7 +293,12 @@ export interface SystemPromptResult {
  * Use this when you need the skill metadata (e.g. for dynamic tool descriptions).
  */
 export async function loadSystemPromptWithSkills(config: AgentConfig): Promise<SystemPromptResult> {
-  const supportedModel = assertSupportedModel(config.provider, config.model, "model");
+  const supportedModel = await resolveModelMetadata(config.provider, config.model, {
+    allowPlaceholder: true,
+    providerOptions: config.providerOptions,
+    source: "model",
+    log: (line) => console.warn(line),
+  });
   const systemPath = await resolveSystemTemplatePath(config);
   let prompt = await fs.readFile(systemPath, "utf-8");
 

--- a/src/providerStatus.ts
+++ b/src/providerStatus.ts
@@ -2,10 +2,12 @@ import { z } from "zod";
 
 import { getAiCoworkerPaths, maskApiKey, readConnectionStore, type AiCoworkerPaths, type ConnectionStore } from "./connect";
 import { CODEX_BACKEND_BASE_URL, decodeJwtPayload, isTokenExpiring, readCodexAuthMaterial, refreshCodexAuthMaterial } from "./providers/codex-auth";
+import { listLmStudioLlms } from "./providers/lmstudio/catalog";
+import { isLmStudioError, listLmStudioModels, resolveLmStudioProviderOptions } from "./providers/lmstudio/client";
 import { PROVIDER_NAMES, type ProviderName } from "./types";
 import { resolveAuthHomeDir } from "./utils/authHome";
 
-export type ProviderStatusMode = "missing" | "error" | "api_key" | "oauth" | "oauth_pending";
+export type ProviderStatusMode = "missing" | "error" | "api_key" | "oauth" | "oauth_pending" | "local";
 
 export type ProviderAccount = {
   email?: string;
@@ -58,7 +60,7 @@ export type ProviderStatus = {
 
 const nonEmptyTrimmedStringSchema = z.string().trim().min(1);
 const finiteNumberSchema = z.number().finite();
-const providerStatusModeSchema = z.enum(["api_key", "oauth", "oauth_pending"]);
+const providerStatusModeSchema = z.enum(["api_key", "oauth", "oauth_pending", "local"]);
 
 function normalizeProviderStatusMode(mode: unknown): ProviderStatusMode {
   const parsed = providerStatusModeSchema.safeParse(mode);
@@ -88,6 +90,12 @@ function buildSavedApiKeyMasks(opts: {
   }
 
   return Object.keys(out).length > 0 ? out : undefined;
+}
+
+function storedProviderApiKey(store: ConnectionStore, provider: ProviderName): string | undefined {
+  const entry = store.services[provider];
+  const apiKey = entry?.mode === "api_key" ? entry.apiKey?.trim() : "";
+  return apiKey || undefined;
 }
 
 function statusFromConnectionStore(opts: {
@@ -441,11 +449,59 @@ async function getCodexCliStatus(opts: {
   };
 }
 
+async function getLmStudioStatus(opts: {
+  store: ConnectionStore;
+  checkedAt: string;
+  providerOptions?: unknown;
+  env?: NodeJS.ProcessEnv;
+  fetchImpl: typeof fetch;
+}): Promise<ProviderStatus> {
+  const providerConfig = resolveLmStudioProviderOptions(opts.providerOptions, opts.env);
+  const savedApiKeyMasks = buildSavedApiKeyMasks({ provider: "lmstudio", store: opts.store });
+
+  try {
+    const models = (await listLmStudioModels({
+      baseUrl: providerConfig.baseUrl,
+      apiKey: providerConfig.apiKey ?? storedProviderApiKey(opts.store, "lmstudio"),
+      fetchImpl: opts.fetchImpl,
+    })).models;
+    const llmCount = listLmStudioLlms(models).length;
+    return {
+      provider: "lmstudio",
+      authorized: true,
+      verified: true,
+      mode: "local",
+      account: null,
+      message: llmCount > 0
+        ? `LM Studio server reachable at ${providerConfig.baseUrl}.`
+        : `LM Studio server reachable at ${providerConfig.baseUrl}, but no LLMs are available.`,
+      checkedAt: opts.checkedAt,
+      ...(savedApiKeyMasks ? { savedApiKeyMasks } : {}),
+    };
+  } catch (error) {
+    const message = isLmStudioError(error)
+      ? error.message
+      : `Failed to query LM Studio at ${providerConfig.baseUrl}: ${String(error)}`;
+    return {
+      provider: "lmstudio",
+      authorized: false,
+      verified: false,
+      mode: "error",
+      account: null,
+      message,
+      checkedAt: opts.checkedAt,
+      ...(savedApiKeyMasks ? { savedApiKeyMasks } : {}),
+    };
+  }
+}
+
 export async function getProviderStatuses(opts: {
   homedir?: string;
   paths?: AiCoworkerPaths;
   fetchImpl?: typeof fetch;
   now?: () => Date;
+  providerOptions?: unknown;
+  env?: NodeJS.ProcessEnv;
 } = {}): Promise<ProviderStatus[]> {
   const paths = opts.paths ?? getAiCoworkerPaths({ homedir: opts.homedir ?? resolveAuthHomeDir() });
   const fetchImpl = opts.fetchImpl ?? fetch;
@@ -458,6 +514,16 @@ export async function getProviderStatuses(opts: {
   for (const provider of PROVIDER_NAMES) {
     if (provider === "codex-cli") {
       out.push(await getCodexCliStatus({ paths, store, checkedAt, fetchImpl }));
+      continue;
+    }
+    if (provider === "lmstudio") {
+      out.push(await getLmStudioStatus({
+        store,
+        checkedAt,
+        providerOptions: opts.providerOptions,
+        env: opts.env,
+        fetchImpl,
+      }));
       continue;
     }
     out.push(statusFromConnectionStore({ provider, store, checkedAt }));

--- a/src/providers/authRegistry.ts
+++ b/src/providers/authRegistry.ts
@@ -53,6 +53,7 @@ const PROVIDER_AUTH_METHODS: Record<ProviderName, ProviderAuthMethod[]> = {
   baseten: [{ id: "api_key", type: "api", label: "API key" }],
   together: [{ id: "api_key", type: "api", label: "API key" }],
   nvidia: [{ id: "api_key", type: "api", label: "API key" }],
+  lmstudio: [{ id: "api_key", type: "api", label: "API token (optional)" }],
   "opencode-go": [{ id: "api_key", type: "api", label: "API key" }],
   "opencode-zen": [{ id: "api_key", type: "api", label: "API key" }],
   "codex-cli": [

--- a/src/providers/catalog.ts
+++ b/src/providers/catalog.ts
@@ -13,7 +13,7 @@ export function isUserFacingProviderEnabled(provider: ProviderName): boolean {
   return !USER_FACING_DISABLED_PROVIDER_SET.has(provider);
 }
 
-export const PROVIDER_MODEL_CATALOG = {
+const STATIC_PROVIDER_MODEL_CATALOG = {
   anthropic: {
     defaultModel: defaultModelIdForProvider("anthropic"),
     availableModels: listSupportedModelIds("anthropic"),
@@ -50,7 +50,15 @@ export const PROVIDER_MODEL_CATALOG = {
     defaultModel: defaultModelIdForProvider("openai"),
     availableModels: listSupportedModelIds("openai"),
   },
-} as const satisfies Record<ProviderName, ProviderModelDefinition>;
+} as const satisfies Record<Exclude<ProviderName, "lmstudio">, ProviderModelDefinition>;
+
+export const PROVIDER_MODEL_CATALOG: Record<ProviderName, ProviderModelDefinition> = {
+  ...STATIC_PROVIDER_MODEL_CATALOG,
+  lmstudio: {
+    defaultModel: "",
+    availableModels: [],
+  },
+};
 
 export function defaultModelForProvider(provider: ProviderName): string {
   return PROVIDER_MODEL_CATALOG[provider].defaultModel;
@@ -69,6 +77,7 @@ export const PROVIDER_MODEL_CHOICES: Record<ProviderName, readonly string[]> = {
   baseten: PROVIDER_MODEL_CATALOG.baseten.availableModels,
   together: PROVIDER_MODEL_CATALOG.together.availableModels,
   nvidia: PROVIDER_MODEL_CATALOG.nvidia.availableModels,
+  lmstudio: PROVIDER_MODEL_CATALOG.lmstudio.availableModels,
   "opencode-go": PROVIDER_MODEL_CATALOG["opencode-go"].availableModels,
   "opencode-zen": PROVIDER_MODEL_CATALOG["opencode-zen"].availableModels,
   "codex-cli": PROVIDER_MODEL_CATALOG["codex-cli"].availableModels,
@@ -81,5 +90,6 @@ export function modelChoicesByProvider(): Record<ProviderName, readonly string[]
 }
 
 export function userFacingProviders(): ProviderName[] {
-  return (Object.keys(PROVIDER_MODEL_CATALOG) as ProviderName[]).filter((provider) => isUserFacingProviderEnabled(provider));
+  return (Object.keys(PROVIDER_MODEL_CATALOG) as ProviderName[])
+    .filter((provider) => isUserFacingProviderEnabled(provider));
 }

--- a/src/providers/connectionCatalog.ts
+++ b/src/providers/connectionCatalog.ts
@@ -2,8 +2,21 @@ import { getAiCoworkerPaths, readConnectionStore, type AiCoworkerPaths } from ".
 import { PROVIDER_NAMES, type ProviderName } from "../types";
 import { defaultSupportedModel, listSupportedModels, type SupportedModel } from "../models/registry";
 import { readCodexAuthMaterial } from "./codex-auth";
+import {
+  listLmStudioLlms,
+  lmStudioCatalogStateMessage,
+  mapLmStudioModelToResolvedMetadata,
+  selectDefaultLmStudioModel,
+} from "./lmstudio/catalog";
+import { isLmStudioError, listLmStudioModels, resolveLmStudioProviderOptions } from "./lmstudio/client";
 import { getOpenCodeDisplayName } from "./opencodeShared";
 import { resolveAuthHomeDir } from "../utils/authHome";
+
+function storedProviderApiKey(store: Awaited<ReturnType<typeof readConnectionStore>>, provider: ProviderName): string | undefined {
+  const entry = store.services[provider];
+  const apiKey = entry?.mode === "api_key" ? entry.apiKey?.trim() : "";
+  return apiKey || undefined;
+}
 
 export type ProviderCatalogModelEntry = Pick<
   SupportedModel,
@@ -15,6 +28,8 @@ export type ProviderCatalogEntry = {
   name: string;
   models: ProviderCatalogModelEntry[];
   defaultModel: string;
+  state?: "ready" | "empty" | "unreachable";
+  message?: string;
 };
 
 export type ProviderCatalogPayload = {
@@ -30,13 +45,14 @@ const PROVIDER_LABELS: Record<ProviderName, string> = {
   baseten: "Baseten",
   together: "Together AI",
   nvidia: "NVIDIA",
+  lmstudio: "LM Studio",
   "opencode-go": getOpenCodeDisplayName("opencode-go"),
   "opencode-zen": getOpenCodeDisplayName("opencode-zen"),
   "codex-cli": "Codex CLI",
 };
 
-export function listProviderCatalogEntries(): ProviderCatalogEntry[] {
-  return PROVIDER_NAMES.map((provider) => ({
+function staticCatalogEntry(provider: Exclude<ProviderName, "lmstudio">): ProviderCatalogEntry {
+  return {
     id: provider,
     name: PROVIDER_LABELS[provider],
     models: listSupportedModels(provider).map((model) => ({
@@ -46,7 +62,84 @@ export function listProviderCatalogEntries(): ProviderCatalogEntry[] {
       supportsImageInput: model.supportsImageInput,
     })),
     defaultModel: defaultSupportedModel(provider).id,
-  }));
+  };
+}
+
+async function lmStudioCatalogEntry(opts: {
+  store?: Awaited<ReturnType<typeof readConnectionStore>>;
+  providerOptions?: unknown;
+  env?: NodeJS.ProcessEnv;
+  lmstudioFetchImpl?: typeof fetch;
+}): Promise<{ entry: ProviderCatalogEntry; connected: boolean }> {
+  const provider = resolveLmStudioProviderOptions(opts.providerOptions, opts.env);
+  try {
+    const models = (await listLmStudioModels({
+      baseUrl: provider.baseUrl,
+      apiKey: provider.apiKey ?? (opts.store ? storedProviderApiKey(opts.store, "lmstudio") : undefined),
+      fetchImpl: opts.lmstudioFetchImpl,
+    })).models;
+    const llms = listLmStudioLlms(models);
+    const defaultModel = llms.length > 0 ? selectDefaultLmStudioModel(models, provider.baseUrl).key : "";
+    return {
+      entry: {
+        id: "lmstudio",
+        name: PROVIDER_LABELS.lmstudio,
+        models: llms.map((model) => {
+          const metadata = mapLmStudioModelToResolvedMetadata(model);
+          return {
+            id: metadata.id,
+            displayName: metadata.displayName,
+            knowledgeCutoff: metadata.knowledgeCutoff,
+            supportsImageInput: metadata.supportsImageInput,
+          };
+        }),
+        defaultModel,
+        state: "ready",
+      },
+      connected: true,
+    };
+  } catch (error) {
+    if (isLmStudioError(error) && error.code === "no_llms") {
+      return {
+        entry: {
+          id: "lmstudio",
+          name: PROVIDER_LABELS.lmstudio,
+          models: [],
+          defaultModel: "",
+          state: "empty",
+          message: error.message,
+        },
+        connected: true,
+      };
+    }
+    return {
+      entry: {
+        id: "lmstudio",
+        name: PROVIDER_LABELS.lmstudio,
+        models: [],
+        defaultModel: "",
+        state: "unreachable",
+        message: lmStudioCatalogStateMessage({
+          error,
+          baseUrl: provider.baseUrl,
+        }),
+      },
+      connected: false,
+    };
+  }
+}
+
+export async function listProviderCatalogEntries(opts: {
+  store?: Awaited<ReturnType<typeof readConnectionStore>>;
+  providerOptions?: unknown;
+  env?: NodeJS.ProcessEnv;
+  lmstudioFetchImpl?: typeof fetch;
+} = {}): Promise<ProviderCatalogEntry[]> {
+  const lmstudio = await lmStudioCatalogEntry(opts);
+  return PROVIDER_NAMES.map((provider) => {
+    if (provider === "lmstudio") return lmstudio.entry;
+    return staticCatalogEntry(provider);
+  });
 }
 
 export async function getProviderCatalog(opts: {
@@ -54,16 +147,31 @@ export async function getProviderCatalog(opts: {
   paths?: AiCoworkerPaths;
   readStore?: typeof readConnectionStore;
   readCodexAuthMaterialImpl?: typeof readCodexAuthMaterial;
+  providerOptions?: unknown;
+  env?: NodeJS.ProcessEnv;
+  lmstudioFetchImpl?: typeof fetch;
 } = {}): Promise<ProviderCatalogPayload> {
   const paths = opts.paths ?? getAiCoworkerPaths({ homedir: opts.homedir ?? resolveAuthHomeDir() });
   const readStore = opts.readStore ?? readConnectionStore;
   const readCodexAuthMaterialImpl = opts.readCodexAuthMaterialImpl ?? readCodexAuthMaterial;
   const store = await readStore(paths);
-  const all = listProviderCatalogEntries();
+  const lmstudio = await lmStudioCatalogEntry({
+    store,
+    providerOptions: opts.providerOptions,
+    env: opts.env,
+    lmstudioFetchImpl: opts.lmstudioFetchImpl,
+  });
+  const all = PROVIDER_NAMES.map((provider) => {
+    if (provider === "lmstudio") return lmstudio.entry;
+    return staticCatalogEntry(provider);
+  });
   const defaults: Record<string, string> = {};
   for (const entry of all) defaults[entry.id] = entry.defaultModel;
   const hasCodexOauth = Boolean((await readCodexAuthMaterialImpl(paths))?.accessToken);
   const connected = PROVIDER_NAMES.filter((provider) => {
+    if (provider === "lmstudio") {
+      return lmstudio.connected;
+    }
     const entry = store.services[provider];
     if (entry?.mode === "api_key" || entry?.mode === "oauth") return true;
     return provider === "codex-cli" && hasCodexOauth;

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,11 +1,12 @@
 import type { AgentConfig, ProviderName } from "../types";
-import { assertSupportedModel } from "../models/registry";
+import { normalizeModelIdForProvider } from "../models/metadata";
 
 import { anthropicProvider } from "./anthropic";
 import { basetenProvider } from "./baseten";
 import { PROVIDER_MODEL_CATALOG } from "./catalog";
 import { codexCliProvider } from "./codex-cli";
 import { googleProvider } from "./google";
+import { lmstudioProvider } from "./lmstudio";
 import { nvidiaProvider } from "./nvidia";
 import { opencodeGoProvider } from "./opencode-go";
 import { opencodeZenProvider } from "./opencode-zen";
@@ -50,6 +51,7 @@ const PROVIDER_RUNTIMES: Record<ProviderName, ProviderRuntimeDefinition> = {
   baseten: basetenProvider,
   together: togetherProvider,
   nvidia: nvidiaProvider,
+  lmstudio: lmstudioProvider,
   "opencode-go": opencodeGoProvider,
   "opencode-zen": opencodeZenProvider,
   "codex-cli": codexCliProvider,
@@ -62,6 +64,7 @@ export const PROVIDERS: Record<ProviderName, ProviderDefinition> = {
   baseten: { ...PROVIDER_RUNTIMES.baseten, ...PROVIDER_MODEL_CATALOG.baseten },
   together: { ...PROVIDER_RUNTIMES.together, ...PROVIDER_MODEL_CATALOG.together },
   nvidia: { ...PROVIDER_RUNTIMES.nvidia, ...PROVIDER_MODEL_CATALOG.nvidia },
+  lmstudio: { ...PROVIDER_RUNTIMES.lmstudio, ...PROVIDER_MODEL_CATALOG.lmstudio },
   "opencode-go": { ...PROVIDER_RUNTIMES["opencode-go"], ...PROVIDER_MODEL_CATALOG["opencode-go"] },
   "opencode-zen": { ...PROVIDER_RUNTIMES["opencode-zen"], ...PROVIDER_MODEL_CATALOG["opencode-zen"] },
   "codex-cli": { ...PROVIDER_RUNTIMES["codex-cli"], ...PROVIDER_MODEL_CATALOG["codex-cli"] },
@@ -70,8 +73,8 @@ export const PROVIDERS: Record<ProviderName, ProviderDefinition> = {
 };
 
 export function getModelForProvider(config: AgentConfig, modelId: string, savedKey?: string) {
-  const supported = assertSupportedModel(config.provider, modelId);
-  return PROVIDERS[config.provider].createModel({ config, modelId: supported.id, savedKey });
+  const normalizedModelId = normalizeModelIdForProvider(config.provider, modelId);
+  return PROVIDERS[config.provider].createModel({ config, modelId: normalizedModelId, savedKey });
 }
 
 export function getProviderKeyCandidates(provider: ProviderName): readonly ProviderName[] {

--- a/src/providers/lmstudio.ts
+++ b/src/providers/lmstudio.ts
@@ -1,0 +1,8 @@
+import type { AgentConfig } from "../types";
+import { createLmStudioModelAdapter } from "./modelAdapter";
+
+export const lmstudioProvider = {
+  keyCandidates: ["lmstudio"] as const,
+  createModel: ({ config, modelId, savedKey }: { config: AgentConfig; modelId: string; savedKey?: string }) =>
+    createLmStudioModelAdapter(config, modelId, savedKey),
+};

--- a/src/providers/lmstudio/catalog.ts
+++ b/src/providers/lmstudio/catalog.ts
@@ -1,0 +1,324 @@
+import type { ResolvedModelMetadata } from "../../models/metadataTypes";
+import {
+  createLmStudioError,
+  isLmStudioError,
+  listLmStudioModels,
+  loadLmStudioModel,
+  resolveLmStudioProviderOptions,
+  unloadLmStudioModel,
+  type ResolvedLmStudioProviderOptions,
+} from "./client";
+import type {
+  LmStudioLoadedInstance,
+  LmStudioLoadResponse,
+  LmStudioModel,
+} from "./types";
+
+type FetchLike = typeof fetch;
+
+function compareModelKeys(a: { key: string }, b: { key: string }): number {
+  return a.key.localeCompare(b.key);
+}
+
+function normalizeModelKey(modelId: string, source = "model"): string {
+  const trimmed = modelId.trim();
+  if (!trimmed) {
+    throw new Error(`${source} is required.`);
+  }
+  return trimmed;
+}
+
+export function listLmStudioLlms(models: readonly LmStudioModel[]): LmStudioModel[] {
+  return models
+    .filter((model) => model.type === "llm")
+    .sort(compareModelKeys);
+}
+
+export function pickLmStudioLoadedInstance(
+  instances: readonly LmStudioLoadedInstance[],
+): LmStudioLoadedInstance | null {
+  if (instances.length === 0) return null;
+  return [...instances].sort((a, b) => a.id.localeCompare(b.id))[0] ?? null;
+}
+
+function loadConfigContextLength(load: LmStudioLoadResponse | undefined): number | undefined {
+  return typeof load?.load_config?.context_length === "number" && Number.isFinite(load.load_config.context_length)
+    ? load.load_config.context_length
+    : undefined;
+}
+
+export function buildLmStudioPlaceholderMetadata(modelId: string): ResolvedModelMetadata {
+  const id = normalizeModelKey(modelId);
+  return {
+    id,
+    provider: "lmstudio",
+    displayName: id,
+    knowledgeCutoff: "Unknown",
+    supportsImageInput: false,
+    promptTemplate: "system.md",
+    providerOptionsDefaults: {},
+    source: "dynamic",
+    loaded: false,
+  };
+}
+
+function metadataFromLoadResult(model: LmStudioModel, loadResult?: LmStudioLoadResponse): ResolvedModelMetadata {
+  const effectiveContextLength =
+    loadConfigContextLength(loadResult)
+    ?? pickLmStudioLoadedInstance(model.loaded_instances)?.config.context_length
+    ?? model.max_context_length;
+  return {
+    ...mapLmStudioModelToResolvedMetadata(model),
+    effectiveContextLength,
+    loaded: true,
+  };
+}
+
+export function mapLmStudioModelToResolvedMetadata(model: LmStudioModel): ResolvedModelMetadata {
+  const loadedInstance = pickLmStudioLoadedInstance(model.loaded_instances);
+  return {
+    id: model.key,
+    provider: "lmstudio",
+    displayName: model.display_name?.trim() || model.key,
+    knowledgeCutoff: "Unknown",
+    supportsImageInput: model.capabilities?.vision === true,
+    promptTemplate: "system.md",
+    providerOptionsDefaults: {},
+    source: "dynamic",
+    maxContextLength: model.max_context_length,
+    effectiveContextLength: loadedInstance?.config.context_length ?? model.max_context_length,
+    trainedForToolUse: model.capabilities?.trained_for_tool_use === true,
+    ...(model.architecture ? { architecture: model.architecture } : {}),
+    ...(model.format ? { format: model.format } : {}),
+    loaded: loadedInstance !== null,
+  };
+}
+
+export function selectDefaultLmStudioModel(models: readonly LmStudioModel[], baseUrl: string): LmStudioModel {
+  const llms = listLmStudioLlms(models);
+  const loaded = llms.filter((model) => model.loaded_instances.length > 0);
+  if (loaded.length > 0) {
+    return [...loaded].sort(compareModelKeys)[0]!;
+  }
+  if (llms.length > 0) {
+    return llms[0]!;
+  }
+  throw createLmStudioError(
+    "no_llms",
+    `LM Studio server at ${baseUrl} is reachable, but no LLMs are available.`,
+    baseUrl,
+  );
+}
+
+export async function resolveLmStudioDiscoveredModelMetadata(opts: {
+  modelId: string;
+  providerOptions?: unknown;
+  env?: NodeJS.ProcessEnv;
+  fetchImpl?: FetchLike;
+}): Promise<ResolvedModelMetadata> {
+  const provider = resolveLmStudioProviderOptions(opts.providerOptions, opts.env);
+  const models = (await listLmStudioModels({
+    baseUrl: provider.baseUrl,
+    apiKey: provider.apiKey,
+    fetchImpl: opts.fetchImpl,
+  })).models;
+  const model = models.find((entry) => entry.key === normalizeModelKey(opts.modelId));
+  if (!model) {
+    throw createLmStudioError(
+      "missing_model",
+      `LM Studio model "${opts.modelId}" is not available at ${provider.baseUrl}.`,
+      provider.baseUrl,
+    );
+  }
+  if (model.type !== "llm") {
+    throw createLmStudioError(
+      "missing_model",
+      `LM Studio model "${opts.modelId}" is not an LLM and cannot be used for chat inference.`,
+      provider.baseUrl,
+    );
+  }
+  return mapLmStudioModelToResolvedMetadata(model);
+}
+
+export async function resolveDefaultLmStudioModelMetadata(opts: {
+  providerOptions?: unknown;
+  env?: NodeJS.ProcessEnv;
+  fetchImpl?: FetchLike;
+}): Promise<ResolvedModelMetadata> {
+  const provider = resolveLmStudioProviderOptions(opts.providerOptions, opts.env);
+  const models = (await listLmStudioModels({
+    baseUrl: provider.baseUrl,
+    apiKey: provider.apiKey,
+    fetchImpl: opts.fetchImpl,
+  })).models;
+  return mapLmStudioModelToResolvedMetadata(selectDefaultLmStudioModel(models, provider.baseUrl));
+}
+
+function metadataAfterLoad(model: LmStudioModel, loadResult: LmStudioLoadResponse): ResolvedModelMetadata {
+  const loadedInstance: LmStudioLoadedInstance = {
+    id: loadResult.instance_id,
+    config: {
+      context_length: loadConfigContextLength(loadResult) ?? model.max_context_length,
+      ...(typeof loadResult.load_config?.eval_batch_size === "number"
+        ? { eval_batch_size: loadResult.load_config.eval_batch_size }
+        : {}),
+      ...(typeof loadResult.load_config?.flash_attention === "boolean"
+        ? { flash_attention: loadResult.load_config.flash_attention }
+        : {}),
+      ...(typeof loadResult.load_config?.num_experts === "number"
+        ? { num_experts: loadResult.load_config.num_experts }
+        : {}),
+      ...(typeof loadResult.load_config?.offload_kv_cache_to_gpu === "boolean"
+        ? { offload_kv_cache_to_gpu: loadResult.load_config.offload_kv_cache_to_gpu }
+        : {}),
+    },
+  };
+  return metadataFromLoadResult({
+    ...model,
+    loaded_instances: [loadedInstance],
+  }, loadResult);
+}
+
+async function unloadLoadedInstances(opts: {
+  provider: ResolvedLmStudioProviderOptions;
+  instances: readonly LmStudioLoadedInstance[];
+  fetchImpl?: FetchLike;
+}): Promise<void> {
+  for (const instance of opts.instances) {
+    await unloadLmStudioModel({
+      baseUrl: opts.provider.baseUrl,
+      apiKey: opts.provider.apiKey,
+      fetchImpl: opts.fetchImpl,
+      instanceId: instance.id,
+    });
+  }
+}
+
+export async function prepareLmStudioModelMetadataForInference(opts: {
+  modelId: string;
+  providerOptions?: unknown;
+  env?: NodeJS.ProcessEnv;
+  fetchImpl?: FetchLike;
+  log?: (line: string) => void;
+}): Promise<{
+  metadata: ResolvedModelMetadata;
+  provider: ResolvedLmStudioProviderOptions;
+}> {
+  const provider = resolveLmStudioProviderOptions(opts.providerOptions, opts.env);
+  const requestedModelId = normalizeModelKey(opts.modelId);
+  const response = await listLmStudioModels({
+    baseUrl: provider.baseUrl,
+    apiKey: provider.apiKey,
+    fetchImpl: opts.fetchImpl,
+  });
+  const model = response.models.find((entry) => entry.key === requestedModelId);
+  if (!model) {
+    throw createLmStudioError(
+      "missing_model",
+      `LM Studio model "${requestedModelId}" is not available at ${provider.baseUrl}.`,
+      provider.baseUrl,
+    );
+  }
+  if (model.type !== "llm") {
+    throw createLmStudioError(
+      "missing_model",
+      `LM Studio model "${requestedModelId}" is not an LLM and cannot be used for chat inference.`,
+      provider.baseUrl,
+    );
+  }
+
+  const loadedInstance = pickLmStudioLoadedInstance(model.loaded_instances);
+  const currentContextLength = loadedInstance?.config.context_length;
+  const requestedContextLength = provider.contextLength;
+
+  if (loadedInstance && requestedContextLength === undefined) {
+    return {
+      metadata: mapLmStudioModelToResolvedMetadata(model),
+      provider,
+    };
+  }
+
+  if (loadedInstance && requestedContextLength !== undefined && requestedContextLength !== currentContextLength) {
+    if (provider.reloadOnContextMismatch === false) {
+      opts.log?.(
+        `[lmstudio] requested context length ${requestedContextLength} differs from loaded ${currentContextLength} for ${requestedModelId}; reusing the existing load because reloadOnContextMismatch=false.`,
+      );
+      return {
+        metadata: mapLmStudioModelToResolvedMetadata(model),
+        provider,
+      };
+    }
+    opts.log?.(
+      `[lmstudio] requested context length ${requestedContextLength} differs from loaded ${currentContextLength} for ${requestedModelId}; unloading ${model.loaded_instances.length} instance(s) and reloading.`,
+    );
+    await unloadLoadedInstances({
+      provider,
+      instances: model.loaded_instances,
+      fetchImpl: opts.fetchImpl,
+    });
+    const loadResult = await loadLmStudioModel({
+      baseUrl: provider.baseUrl,
+      apiKey: provider.apiKey,
+      fetchImpl: opts.fetchImpl,
+      modelKey: requestedModelId,
+      contextLength: requestedContextLength,
+    });
+    return {
+      metadata: metadataAfterLoad(model, loadResult),
+      provider,
+    };
+  }
+
+  if (!loadedInstance && requestedContextLength !== undefined) {
+    opts.log?.(
+      `[lmstudio] loading ${requestedModelId} with explicit context length ${requestedContextLength}.`,
+    );
+    const loadResult = await loadLmStudioModel({
+      baseUrl: provider.baseUrl,
+      apiKey: provider.apiKey,
+      fetchImpl: opts.fetchImpl,
+      modelKey: requestedModelId,
+      contextLength: requestedContextLength,
+    });
+    return {
+      metadata: metadataAfterLoad(model, loadResult),
+      provider,
+    };
+  }
+
+  if (!loadedInstance && provider.autoLoad) {
+    opts.log?.(`[lmstudio] loading ${requestedModelId} before inference to capture the active context window.`);
+    const loadResult = await loadLmStudioModel({
+      baseUrl: provider.baseUrl,
+      apiKey: provider.apiKey,
+      fetchImpl: opts.fetchImpl,
+      modelKey: requestedModelId,
+    });
+    return {
+      metadata: metadataAfterLoad(model, loadResult),
+      provider,
+    };
+  }
+
+  if (!loadedInstance) {
+    opts.log?.(
+      `[lmstudio] ${requestedModelId} is not loaded and autoLoad=false; inference will rely on LM Studio JIT loading.`,
+    );
+  }
+
+  return {
+    metadata: mapLmStudioModelToResolvedMetadata(model),
+    provider,
+  };
+}
+
+export function lmStudioCatalogStateMessage(opts: {
+  error?: unknown;
+  baseUrl: string;
+}): string {
+  if (!opts.error) return "";
+  if (isLmStudioError(opts.error)) {
+    return opts.error.message;
+  }
+  return `Failed to query LM Studio at ${opts.baseUrl}: ${String(opts.error)}`;
+}

--- a/src/providers/lmstudio/client.ts
+++ b/src/providers/lmstudio/client.ts
@@ -1,0 +1,299 @@
+import type {
+  LmStudioListModelsResponse,
+  LmStudioLoadResponse,
+  LmStudioProviderOptions,
+  LmStudioUnloadResponse,
+} from "./types";
+
+export const DEFAULT_LM_STUDIO_BASE_URL = "http://localhost:1234";
+
+export type LmStudioErrorCode =
+  | "unreachable"
+  | "http_error"
+  | "invalid_response"
+  | "missing_model"
+  | "no_llms"
+  | "load_failed"
+  | "unload_failed";
+
+export class LmStudioError extends Error {
+  readonly code: LmStudioErrorCode;
+  readonly baseUrl: string;
+  readonly status?: number;
+
+  constructor(opts: {
+    code: LmStudioErrorCode;
+    message: string;
+    baseUrl: string;
+    status?: number;
+    cause?: unknown;
+  }) {
+    super(opts.message, "cause" in Error.prototype ? { cause: opts.cause } : undefined);
+    this.name = "LmStudioError";
+    this.code = opts.code;
+    this.baseUrl = opts.baseUrl;
+    this.status = opts.status;
+  }
+}
+
+export function isLmStudioError(error: unknown): error is LmStudioError {
+  return error instanceof LmStudioError;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function asNonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function asBoolean(value: unknown): boolean | undefined {
+  if (typeof value === "boolean") return value;
+  if (typeof value !== "string") return undefined;
+  const normalized = value.trim().toLowerCase();
+  if (["1", "true", "yes", "y", "on"].includes(normalized)) return true;
+  if (["0", "false", "no", "n", "off"].includes(normalized)) return false;
+  return undefined;
+}
+
+function asPositiveInteger(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    const normalized = Math.floor(value);
+    return normalized > 0 ? normalized : undefined;
+  }
+  if (typeof value !== "string") return undefined;
+  const parsed = Number(value.trim());
+  if (!Number.isFinite(parsed)) return undefined;
+  const normalized = Math.floor(parsed);
+  return normalized > 0 ? normalized : undefined;
+}
+
+function normalizeLmStudioBaseUrl(raw?: string): string {
+  const trimmed = raw?.trim() || DEFAULT_LM_STUDIO_BASE_URL;
+  let normalized = trimmed.replace(/\/+$/, "");
+  if (normalized.endsWith("/api/v1")) {
+    normalized = normalized.slice(0, -"/api/v1".length);
+  } else if (normalized.endsWith("/v1")) {
+    normalized = normalized.slice(0, -"/v1".length);
+  }
+  return normalized || DEFAULT_LM_STUDIO_BASE_URL;
+}
+
+export type ResolvedLmStudioProviderOptions = {
+  baseUrl: string;
+  apiKey?: string;
+  contextLength?: number;
+  autoLoad: boolean;
+  reloadOnContextMismatch: boolean;
+};
+
+export function resolveLmStudioProviderOptions(
+  providerOptions: unknown,
+  env: NodeJS.ProcessEnv = process.env,
+): ResolvedLmStudioProviderOptions {
+  const root = asRecord(providerOptions);
+  const section = asRecord(root?.lmstudio);
+  const rawSection = (section ?? {}) as LmStudioProviderOptions;
+  const baseUrl = normalizeLmStudioBaseUrl(
+    asNonEmptyString(env.LM_STUDIO_BASE_URL)
+    ?? asNonEmptyString(rawSection.baseUrl),
+  );
+  const apiKey =
+    asNonEmptyString(env.LM_STUDIO_API_KEY)
+    ?? asNonEmptyString(env.LM_STUDIO_API_TOKEN)
+    ?? undefined;
+  const contextLength =
+    asPositiveInteger(env.LM_STUDIO_CONTEXT_LENGTH)
+    ?? asPositiveInteger(rawSection.contextLength);
+  const autoLoad =
+    asBoolean(env.LM_STUDIO_AUTO_LOAD)
+    ?? asBoolean(rawSection.autoLoad)
+    ?? true;
+  const reloadOnContextMismatch =
+    asBoolean(env.LM_STUDIO_RELOAD_ON_CONTEXT_MISMATCH)
+    ?? asBoolean(rawSection.reloadOnContextMismatch)
+    ?? true;
+
+  return {
+    baseUrl,
+    ...(apiKey ? { apiKey } : {}),
+    ...(contextLength ? { contextLength } : {}),
+    autoLoad,
+    reloadOnContextMismatch,
+  };
+}
+
+export function lmStudioOpenAiBaseUrl(baseUrl: string): string {
+  return `${normalizeLmStudioBaseUrl(baseUrl)}/v1`;
+}
+
+function nativeEndpoint(baseUrl: string, pathname: string): string {
+  return `${normalizeLmStudioBaseUrl(baseUrl)}/api/v1${pathname}`;
+}
+
+function requestHeaders(baseUrl: string, apiKey?: string, json = true): HeadersInit {
+  const headers: Record<string, string> = {};
+  if (json) {
+    headers.accept = "application/json";
+    headers["content-type"] = "application/json";
+  }
+  const token = apiKey?.trim();
+  if (token) {
+    headers.authorization = `Bearer ${token}`;
+  }
+  return headers;
+}
+
+async function readErrorBody(response: Response): Promise<string> {
+  try {
+    const text = (await response.text()).trim();
+    return text ? text.slice(0, 400) : "";
+  } catch {
+    return "";
+  }
+}
+
+async function requestJson<T>(opts: {
+  baseUrl: string;
+  apiKey?: string;
+  fetchImpl?: typeof fetch;
+  pathname: string;
+  method?: "GET" | "POST";
+  body?: Record<string, unknown>;
+}): Promise<T> {
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const baseUrl = normalizeLmStudioBaseUrl(opts.baseUrl);
+  const url = nativeEndpoint(baseUrl, opts.pathname);
+
+  let response: Response;
+  try {
+    response = await fetchImpl(url, {
+      method: opts.method ?? "GET",
+      headers: requestHeaders(baseUrl, opts.apiKey, true),
+      ...(opts.body ? { body: JSON.stringify(opts.body) } : {}),
+    });
+  } catch (error) {
+    throw new LmStudioError({
+      code: "unreachable",
+      baseUrl,
+      message: `LM Studio server is unreachable at ${baseUrl}.`,
+      cause: error,
+    });
+  }
+
+  if (!response.ok) {
+    const body = await readErrorBody(response);
+    throw new LmStudioError({
+      code: "http_error",
+      baseUrl,
+      status: response.status,
+      message: body
+        ? `LM Studio request failed at ${url} (${response.status}): ${body}`
+        : `LM Studio request failed at ${url} (${response.status}).`,
+    });
+  }
+
+  let json: unknown;
+  try {
+    json = await response.json();
+  } catch (error) {
+    throw new LmStudioError({
+      code: "invalid_response",
+      baseUrl,
+      message: `LM Studio returned invalid JSON from ${url}.`,
+      cause: error,
+    });
+  }
+
+  return json as T;
+}
+
+export async function listLmStudioModels(opts: {
+  baseUrl: string;
+  apiKey?: string;
+  fetchImpl?: typeof fetch;
+}): Promise<LmStudioListModelsResponse> {
+  return await requestJson<LmStudioListModelsResponse>({
+    baseUrl: opts.baseUrl,
+    apiKey: opts.apiKey,
+    fetchImpl: opts.fetchImpl,
+    pathname: "/models",
+  });
+}
+
+export async function loadLmStudioModel(opts: {
+  baseUrl: string;
+  apiKey?: string;
+  fetchImpl?: typeof fetch;
+  modelKey: string;
+  contextLength?: number;
+}): Promise<LmStudioLoadResponse> {
+  try {
+    return await requestJson<LmStudioLoadResponse>({
+      baseUrl: opts.baseUrl,
+      apiKey: opts.apiKey,
+      fetchImpl: opts.fetchImpl,
+      pathname: "/models/load",
+      method: "POST",
+      body: {
+        model: opts.modelKey,
+        ...(typeof opts.contextLength === "number" ? { context_length: opts.contextLength } : {}),
+        echo_load_config: true,
+      },
+    });
+  } catch (error) {
+    if (isLmStudioError(error)) {
+      throw new LmStudioError({
+        code: error.code === "http_error" ? "load_failed" : error.code,
+        baseUrl: error.baseUrl,
+        status: error.status,
+        message: error.message,
+        cause: error,
+      });
+    }
+    throw error;
+  }
+}
+
+export async function unloadLmStudioModel(opts: {
+  baseUrl: string;
+  apiKey?: string;
+  fetchImpl?: typeof fetch;
+  instanceId: string;
+}): Promise<LmStudioUnloadResponse> {
+  try {
+    return await requestJson<LmStudioUnloadResponse>({
+      baseUrl: opts.baseUrl,
+      apiKey: opts.apiKey,
+      fetchImpl: opts.fetchImpl,
+      pathname: "/models/unload",
+      method: "POST",
+      body: {
+        instance_id: opts.instanceId,
+      },
+    });
+  } catch (error) {
+    if (isLmStudioError(error)) {
+      throw new LmStudioError({
+        code: error.code === "http_error" ? "unload_failed" : error.code,
+        baseUrl: error.baseUrl,
+        status: error.status,
+        message: error.message,
+        cause: error,
+      });
+    }
+    throw error;
+  }
+}
+
+export function createLmStudioError(
+  code: LmStudioErrorCode,
+  message: string,
+  baseUrl: string,
+): LmStudioError {
+  return new LmStudioError({ code, message, baseUrl: normalizeLmStudioBaseUrl(baseUrl) });
+}

--- a/src/providers/lmstudio/types.ts
+++ b/src/providers/lmstudio/types.ts
@@ -1,0 +1,61 @@
+export type LmStudioLoadedInstance = {
+  id: string;
+  config: {
+    context_length: number;
+    eval_batch_size?: number;
+    flash_attention?: boolean;
+    num_experts?: number;
+    offload_kv_cache_to_gpu?: boolean;
+  };
+};
+
+export type LmStudioModel = {
+  type: "llm" | "embedding";
+  publisher: string;
+  key: string;
+  display_name?: string | null;
+  architecture?: string | null;
+  quantization?: {
+    name?: string | null;
+    bits_per_weight?: number | null;
+  } | null;
+  size_bytes: number;
+  params_string?: string | null;
+  loaded_instances: LmStudioLoadedInstance[];
+  max_context_length: number;
+  format?: "gguf" | "mlx" | null;
+  capabilities?: {
+    vision?: boolean;
+    trained_for_tool_use?: boolean;
+  } | null;
+  description?: string | null;
+};
+
+export type LmStudioListModelsResponse = {
+  models: LmStudioModel[];
+};
+
+export type LmStudioLoadResponse = {
+  type: "llm" | "embedding";
+  instance_id: string;
+  load_time_seconds: number;
+  status: "loaded";
+  load_config?: {
+    context_length: number;
+    eval_batch_size?: number;
+    flash_attention?: boolean;
+    num_experts?: number;
+    offload_kv_cache_to_gpu?: boolean;
+  };
+};
+
+export type LmStudioUnloadResponse = {
+  status?: string;
+};
+
+export type LmStudioProviderOptions = {
+  baseUrl?: string;
+  contextLength?: number;
+  autoLoad?: boolean;
+  reloadOnContextMismatch?: boolean;
+};

--- a/src/providers/modelAdapter.ts
+++ b/src/providers/modelAdapter.ts
@@ -22,6 +22,7 @@ export type ProviderModelAdapter = {
   specificationVersion: "v3";
   config: {
     headers: HeaderResolver;
+    baseUrl?: string;
   };
 };
 
@@ -41,13 +42,19 @@ function envKey(...candidates: string[]): string | undefined {
   return undefined;
 }
 
-function createModelAdapter(modelId: string, provider: string, headers: HeaderResolver): ProviderModelAdapter {
+function createModelAdapter(
+  modelId: string,
+  provider: string,
+  headers: HeaderResolver,
+  baseUrl?: string,
+): ProviderModelAdapter {
   return {
     modelId,
     provider,
     specificationVersion: "v3",
     config: {
       headers,
+      ...(baseUrl ? { baseUrl } : {}),
     },
   };
 }
@@ -185,4 +192,33 @@ export function createCodexCliModelAdapter(
     if (key) return { authorization: `Bearer ${key}` };
     return await resolveCodexAuthHeaders(config);
   });
+}
+
+export function createLmStudioModelAdapter(
+  config: AgentConfig,
+  modelId: string,
+  savedKey?: string,
+): ProviderModelAdapter {
+  const root = typeof config.providerOptions === "object" && config.providerOptions !== null
+    ? (config.providerOptions as Record<string, unknown>)
+    : {};
+  const section = typeof root.lmstudio === "object" && root.lmstudio !== null
+    ? root.lmstudio as Record<string, unknown>
+    : {};
+  const baseUrl =
+    (typeof process.env.LM_STUDIO_BASE_URL === "string" && process.env.LM_STUDIO_BASE_URL.trim())
+    || (typeof section.baseUrl === "string" && section.baseUrl.trim())
+    || "http://localhost:1234";
+  return createModelAdapter(modelId, "lmstudio.openai-compat", async () => {
+    const key = firstNonEmpty(
+      savedKey,
+      process.env.LM_STUDIO_API_KEY,
+      process.env.LM_STUDIO_API_TOKEN,
+    );
+    const headers: HeaderMap = {};
+    if (key) {
+      headers.authorization = `Bearer ${key}`;
+    }
+    return headers;
+  }, baseUrl);
 }

--- a/src/runtime/piRuntime.ts
+++ b/src/runtime/piRuntime.ts
@@ -17,6 +17,8 @@ import { mapPiEventToRawParts } from "./piStreamParts";
 
 import { getSavedProviderApiKey } from "../config";
 import { getBasetenModelSpec, resolveBasetenApiKey } from "../providers/basetenShared";
+import { prepareLmStudioModelMetadataForInference } from "../providers/lmstudio/catalog";
+import { lmStudioOpenAiBaseUrl } from "../providers/lmstudio/client";
 import { getNvidiaModelSpec, resolveNvidiaApiKey } from "../providers/nvidiaShared";
 import {
   getOpenCodeModelPricing,
@@ -29,7 +31,7 @@ import {
 } from "../providers/opencodeShared";
 import { getTogetherModelSpec, resolveTogetherApiKey } from "../providers/togetherShared";
 import type { ModelMessage, ProviderName } from "../types";
-import { assertSupportedModel } from "../models/registry";
+import { getResolvedModelMetadataSync } from "../models/metadata";
 import type { TelemetrySettings } from "../observability/runtime";
 import {
   continuationMatchesTarget,
@@ -48,6 +50,8 @@ import {
 } from "./piMessageBridge";
 import { maybeSpillToolOutputToWorkspace } from "./toolOutputOverflow";
 import type { LlmRuntime, RuntimeRunTurnParams, RuntimeRunTurnResult, RuntimeStepOverride, RuntimeToolDefinition } from "./types";
+
+const LM_STUDIO_LOCAL_SENTINEL_API_KEY = "lmstudio-local";
 
 function safeJsonStringify(value: unknown): string {
   try {
@@ -190,13 +194,42 @@ function stripPlaceholderCostFromAssistantRecord(
 }
 
 function applySupportedModelMetadata(model: PiModel, provider: ProviderName, modelId: string): PiModel {
-  const supported = assertSupportedModel(provider, modelId, "model");
+  const supported = getResolvedModelMetadataSync(provider, modelId, "model");
   const input: Array<"text" | "image"> = supported.supportsImageInput ? ["text", "image"] : ["text"];
   return {
     ...model,
     id: supported.id,
     name: supported.displayName,
     input,
+  };
+}
+
+function safeLmStudioMaxTokens(contextWindow: number): number {
+  return Math.max(1, Math.floor(contextWindow / 4));
+}
+
+function buildLmStudioPiModel(opts: {
+  metadata: ReturnType<typeof getResolvedModelMetadataSync>;
+  baseUrl: string;
+}): PiModel {
+  const contextWindow = opts.metadata.effectiveContextLength ?? opts.metadata.maxContextLength ?? 8192;
+  return {
+    id: opts.metadata.id,
+    name: opts.metadata.displayName,
+    api: "openai-completions",
+    provider: "lmstudio",
+    baseUrl: lmStudioOpenAiBaseUrl(opts.baseUrl),
+    reasoning: false,
+    input: opts.metadata.supportsImageInput ? ["text", "image"] : ["text"],
+    contextWindow,
+    maxTokens: safeLmStudioMaxTokens(contextWindow),
+    compat: {
+      supportsStore: false,
+      supportsDeveloperRole: false,
+      supportsReasoningEffort: false,
+      maxTokensField: "max_tokens",
+      thinkingFormat: "openai",
+    },
   };
 }
 
@@ -498,6 +531,31 @@ export async function resolvePiModel(params: RuntimeRunTurnParams): Promise<Reso
       apiKey: resolveNvidiaApiKey({
         savedKey: getSavedProviderApiKey(params.config, "nvidia"),
       }),
+    };
+  }
+
+  if (provider === "lmstudio") {
+    const prepared = await prepareLmStudioModelMetadataForInference({
+      modelId,
+      providerOptions: params.providerOptions ?? params.config.providerOptions,
+      log: params.log,
+    });
+    const configuredApiKey = prepared.provider.apiKey ?? getSavedProviderApiKey(params.config, "lmstudio");
+    return {
+      model: buildLmStudioPiModel({
+        metadata: prepared.metadata,
+        baseUrl: prepared.provider.baseUrl,
+      }),
+      // pi-ai's OpenAI-compatible client refuses to initialize without a truthy apiKey,
+      // even for local endpoints that do not require authentication.
+      apiKey: configuredApiKey ?? LM_STUDIO_LOCAL_SENTINEL_API_KEY,
+      ...(configuredApiKey
+        ? {
+            headers: {
+              authorization: `Bearer ${configuredApiKey}`,
+            },
+          }
+        : {}),
     };
   }
 

--- a/src/server/agents/modelRouter.ts
+++ b/src/server/agents/modelRouter.ts
@@ -1,4 +1,4 @@
-import { assertSupportedModel, providerOptionsDefaultsForModel } from "../../models/registry";
+import { getResolvedModelMetadataSync, normalizeModelIdForProvider } from "../../models/metadata";
 import {
   childModelRef,
   normalizeChildRoutingConfig,
@@ -32,7 +32,7 @@ function currentReasoningEffort(config: AgentConfig): AgentReasoningEffort | und
 }
 
 function modelDefaultReasoningEffort(provider: ProviderName, model: string): AgentReasoningEffort | undefined {
-  const defaults = providerOptionsDefaultsForModel(provider, model);
+  const defaults = getResolvedModelMetadataSync(provider, model, "child model").providerOptionsDefaults;
   const section = isPlainObject(defaults) ? defaults : {};
   return isOpenAiReasoningEffort(section.reasoningEffort) ? section.reasoningEffort : undefined;
 }
@@ -43,7 +43,7 @@ function applyReasoningEffort(
   effectiveReasoningEffort: AgentReasoningEffort | undefined,
 ): AgentConfig["providerOptions"] {
   const nextProviderOptions = isPlainObject(config.providerOptions) ? { ...config.providerOptions } : {};
-  const modelDefaults = providerOptionsDefaultsForModel(provider, config.model);
+  const modelDefaults = getResolvedModelMetadataSync(provider, config.model, "child model").providerOptionsDefaults;
   if (Object.keys(modelDefaults).length > 0) {
     const nextSection = isPlainObject(nextProviderOptions[provider])
       ? { ...(nextProviderOptions[provider] as Record<string, unknown>) }
@@ -89,11 +89,21 @@ export function routeAgentConfig(
   let fallbackLine: string | undefined;
 
   if (opts.role.modelPolicy?.fixedModel) {
-    effectiveModel = assertSupportedModel(parentConfig.provider, opts.role.modelPolicy.fixedModel, "child role model").id;
+    effectiveModel = normalizeModelIdForProvider(parentConfig.provider, opts.role.modelPolicy.fixedModel, "child role model");
   } else if (requestedModel) {
     const requestedTarget = parseChildModelRef(requestedModel, parentConfig.provider, "child model");
     if (requestedTarget.provider === parentConfig.provider) {
-      effectiveModel = requestedTarget.modelId;
+      if (
+        requestedTarget.provider === "lmstudio"
+        && requestedTarget.modelId !== parentConfig.model
+        && connectedProviders.size > 0
+        && !connectedProviders.has("lmstudio")
+      ) {
+        fallbackLine =
+          `[agent] Requested child target ${requestedTarget.ref} could not be used because LM Studio is not connected; falling back to ${childModelRef(parentConfig.provider, parentConfig.model)}.`;
+      } else {
+        effectiveModel = requestedTarget.modelId;
+      }
     } else {
       const allowedRefs = new Set(parentConfig.allowedChildModelRefs ?? []);
       const crossProviderEnabled = (parentConfig.childModelRoutingMode ?? "same-provider") === "cross-provider-allowlist";
@@ -121,10 +131,10 @@ export function routeAgentConfig(
       : undefined)
     ?? currentReasoningEffort(parentConfig);
 
-  const supportedEffectiveModel = assertSupportedModel(effectiveProvider, effectiveModel, "child model");
+  const resolvedEffectiveModel = getResolvedModelMetadataSync(effectiveProvider, effectiveModel, "child model");
   const normalizedChildRouting = normalizeChildRoutingConfig({
     provider: effectiveProvider,
-    model: supportedEffectiveModel.id,
+    model: resolvedEffectiveModel.id,
     childModelRoutingMode: parentConfig.childModelRoutingMode,
     preferredChildModelRef: parentConfig.preferredChildModelRef,
     allowedChildModelRefs: parentConfig.allowedChildModelRefs,
@@ -137,21 +147,21 @@ export function routeAgentConfig(
       ...parentConfig,
       provider: effectiveProvider,
       runtime: defaultRuntimeNameForProvider(effectiveProvider),
-      model: supportedEffectiveModel.id,
+      model: resolvedEffectiveModel.id,
       preferredChildModel: normalizedChildRouting.preferredChildModel,
       childModelRoutingMode: normalizedChildRouting.childModelRoutingMode,
       preferredChildModelRef: normalizedChildRouting.preferredChildModelRef,
       allowedChildModelRefs: normalizedChildRouting.allowedChildModelRefs,
-      knowledgeCutoff: supportedEffectiveModel.knowledgeCutoff,
+      knowledgeCutoff: resolvedEffectiveModel.knowledgeCutoff,
       providerOptions: applyReasoningEffort(
-        { ...parentConfig, provider: effectiveProvider, model: supportedEffectiveModel.id },
+        { ...parentConfig, provider: effectiveProvider, model: resolvedEffectiveModel.id },
         effectiveProvider,
         effectiveReasoningEffort,
       ),
     },
     ...(requestedModel ? { requestedModel } : {}),
     effectiveProvider,
-    effectiveModel: supportedEffectiveModel.id,
+    effectiveModel: resolvedEffectiveModel.id,
     ...(requestedReasoningEffort ? { requestedReasoningEffort } : {}),
     ...(effectiveReasoningEffort ? { effectiveReasoningEffort } : {}),
     ...(fallbackLine ? { fallbackLine } : {}),

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -474,7 +474,7 @@ export type ServerEvent =
   | { type: "error"; sessionId: string; message: string; code: ServerErrorCode; source: ServerErrorSource }
   | { type: "pong"; sessionId: string };
 
-export const WEBSOCKET_PROTOCOL_VERSION = "7.21";
+export const WEBSOCKET_PROTOCOL_VERSION = "7.22";
 
 export const CLIENT_MESSAGE_TYPES = [
   "client_hello",

--- a/src/server/protocolParser.ts
+++ b/src/server/protocolParser.ts
@@ -109,9 +109,17 @@ const codexCliProviderOptionsSchema = openAiCompatibleProviderOptionsSchema.exte
   webSearch: codexWebSearchSchema.optional(),
 }).strict();
 
+const lmStudioProviderOptionsSchema = z.object({
+  baseUrl: z.string().trim().min(1).optional(),
+  contextLength: z.number().int().positive().optional(),
+  autoLoad: z.boolean().optional(),
+  reloadOnContextMismatch: z.boolean().optional(),
+}).strict();
+
 const editableOpenAiProviderOptionsByProviderSchema = z.object({
   openai: openAiCompatibleProviderOptionsSchema.optional(),
   "codex-cli": codexCliProviderOptionsSchema.optional(),
+  lmstudio: lmStudioProviderOptionsSchema.optional(),
 }).strict();
 
 const setConfigPayloadSchema = z.object({
@@ -211,7 +219,7 @@ function setConfigIssueMessage(issue: z.ZodIssue): string {
   if (field === "providerOptions") {
     if (issue.code === "unrecognized_keys") {
       if (provider === undefined) {
-        return "set_config config.providerOptions only supports openai and codex-cli";
+        return "set_config config.providerOptions only supports openai, codex-cli, and lmstudio";
       }
       if (provider === "codex-cli" && option === "webSearch" && nestedOption === "location") {
         return "set_config config.providerOptions.codex-cli.webSearch.location only supports country, region, city, and timezone";
@@ -221,6 +229,9 @@ function setConfigIssueMessage(issue: z.ZodIssue): string {
       }
       if (provider === "codex-cli") {
         return "set_config config.providerOptions.codex-cli only supports reasoningEffort, reasoningSummary, textVerbosity, webSearchBackend, webSearchMode, and webSearch";
+      }
+      if (provider === "lmstudio") {
+        return "set_config config.providerOptions.lmstudio only supports baseUrl, contextLength, autoLoad, and reloadOnContextMismatch";
       }
       return `set_config config.providerOptions.${provider} only supports reasoningEffort, reasoningSummary, and textVerbosity`;
     }
@@ -270,6 +281,18 @@ function setConfigIssueMessage(issue: z.ZodIssue): string {
 
     if (option === "reasoningSummary") {
       return `set_config config.providerOptions.${provider}.reasoningSummary must be one of ${OPENAI_REASONING_SUMMARY_VALUES.join(", ")}`;
+    }
+
+    if (provider === "lmstudio" && option === "baseUrl") {
+      return "set_config config.providerOptions.lmstudio.baseUrl must be a non-empty string";
+    }
+
+    if (provider === "lmstudio" && option === "contextLength") {
+      return "set_config config.providerOptions.lmstudio.contextLength must be a positive integer";
+    }
+
+    if (provider === "lmstudio" && (option === "autoLoad" || option === "reloadOnContextMismatch")) {
+      return `set_config config.providerOptions.lmstudio.${option} must be boolean`;
     }
 
     return "set_config missing/invalid config";

--- a/src/server/session/AgentSession.ts
+++ b/src/server/session/AgentSession.ts
@@ -7,6 +7,7 @@ import type { MCPRegistryServer } from "../../mcp/configRegistry";
 import { getProviderCatalog } from "../../providers/connectionCatalog";
 import { getProviderStatuses } from "../../providerStatus";
 import { defaultSupportedModel, getSupportedModel } from "../../models/registry";
+import { getKnownResolvedModelMetadata, isDynamicModelProvider } from "../../models/metadata";
 import { MemoryStore, type MemoryScope } from "../../memoryStore";
 import type {
   AgentConfig,
@@ -499,9 +500,9 @@ export class AgentSession {
     getWorkspaceBackupDeltaImpl?: SessionDependencies["getWorkspaceBackupDeltaImpl"];
   }): AgentSession {
     const { persisted } = opts;
-    const supportedPersistedModel = getSupportedModel(persisted.provider, persisted.model);
-    const resumedModel = supportedPersistedModel ?? defaultSupportedModel(persisted.provider);
-    const migratedLegacyModel = supportedPersistedModel === null;
+    const resolvedPersistedModel = getKnownResolvedModelMetadata(persisted.provider, persisted.model);
+    const resumedModel = resolvedPersistedModel ?? defaultSupportedModel(persisted.provider);
+    const migratedLegacyModel = resolvedPersistedModel === null && !isDynamicModelProvider(persisted.provider);
     const clearedContinuationState = migratedLegacyModel && persisted.providerState !== null;
     const config: AgentConfig = {
       ...opts.baseConfig,

--- a/src/server/session/ProviderAuthManager.ts
+++ b/src/server/session/ProviderAuthManager.ts
@@ -13,7 +13,7 @@ import { supportsOpenAiContinuation } from "../../shared/openaiContinuation";
 import { defaultRuntimeNameForProvider, isProviderName } from "../../types";
 import type { AgentConfig, ServerErrorCode, ServerErrorSource } from "../../types";
 import type { ServerEvent } from "../protocol";
-import { assertSupportedModel } from "../../models/registry";
+import { resolveModelMetadata } from "../../models/metadata";
 import { normalizeChildRoutingConfig } from "../../models/childModelRouting";
 
 export class ProviderAuthManager {
@@ -72,19 +72,23 @@ export class ProviderAuthManager {
 
     const currentConfig = this.opts.getConfig();
     const nextProvider = providerRaw ?? currentConfig.provider;
+    let resolvedModel;
     try {
-      assertSupportedModel(nextProvider, modelId, "model");
+      resolvedModel = await resolveModelMetadata(nextProvider, modelId, {
+        providerOptions: currentConfig.providerOptions,
+        source: "model",
+      });
     } catch (error) {
       this.opts.emitError("validation_failed", "provider", error instanceof Error ? error.message : String(error));
       return;
     }
     const normalizedChildRouting = normalizeChildRoutingConfig({
       provider: nextProvider,
-      model: modelId,
+      model: resolvedModel.id,
       childModelRoutingMode: currentConfig.childModelRoutingMode,
       preferredChildModelRef:
         currentConfig.provider !== nextProvider || currentConfig.preferredChildModel === currentConfig.model
-          ? `${nextProvider}:${modelId}`
+          ? `${nextProvider}:${resolvedModel.id}`
           : currentConfig.preferredChildModelRef ?? currentConfig.preferredChildModel,
       allowedChildModelRefs: currentConfig.allowedChildModelRefs,
       source: "model selection",
@@ -93,17 +97,18 @@ export class ProviderAuthManager {
       ? currentConfig.runtime
       : defaultRuntimeNameForProvider(nextProvider);
     const shouldClearProviderState =
-      currentConfig.provider !== nextProvider || currentConfig.model !== modelId;
+      currentConfig.provider !== nextProvider || currentConfig.model !== resolvedModel.id;
 
     this.opts.setConfig({
       ...currentConfig,
       provider: nextProvider,
       ...(nextRuntime !== undefined ? { runtime: nextRuntime } : {}),
-      model: modelId,
+      model: resolvedModel.id,
       preferredChildModel: normalizedChildRouting.preferredChildModel,
       childModelRoutingMode: normalizedChildRouting.childModelRoutingMode,
       preferredChildModelRef: normalizedChildRouting.preferredChildModelRef,
       allowedChildModelRefs: normalizedChildRouting.allowedChildModelRefs,
+      knowledgeCutoff: resolvedModel.knowledgeCutoff,
     });
     if (shouldClearProviderState) {
       this.opts.clearProviderState();
@@ -114,7 +119,7 @@ export class ProviderAuthManager {
       try {
         await this.opts.persistModelSelection({
           provider: nextProvider,
-          model: modelId,
+          model: resolvedModel.id,
           preferredChildModel: normalizedChildRouting.preferredChildModel,
           childModelRoutingMode: normalizedChildRouting.childModelRoutingMode,
           preferredChildModelRef: normalizedChildRouting.preferredChildModelRef,
@@ -128,7 +133,7 @@ export class ProviderAuthManager {
     this.opts.emitConfigUpdated();
     this.opts.updateSessionInfo({
       provider: nextProvider,
-      model: modelId,
+      model: resolvedModel.id,
     });
 
     this.opts.queuePersistSessionSnapshot("session.model_updated");

--- a/src/server/session/ProviderCatalogManager.ts
+++ b/src/server/session/ProviderCatalogManager.ts
@@ -2,7 +2,7 @@ import { listProviderAuthMethods } from "../../providers/authRegistry";
 import type { getAiCoworkerPaths } from "../../connect";
 import type { getProviderCatalog } from "../../providers/connectionCatalog";
 import type { getProviderStatuses } from "../../providerStatus";
-import type { ServerErrorCode, ServerErrorSource } from "../../types";
+import type { AgentConfig, ServerErrorCode, ServerErrorSource } from "../../types";
 import type { ServerEvent } from "../protocol";
 
 export class ProviderCatalogManager {
@@ -11,7 +11,7 @@ export class ProviderCatalogManager {
   constructor(
     private readonly opts: {
       sessionId: string;
-      getConfig: () => { provider: string; model: string };
+      getConfig: () => AgentConfig;
       getGlobalAuthPaths: () => ReturnType<typeof getAiCoworkerPaths>;
       getProviderCatalog: typeof getProviderCatalog;
       getProviderStatuses: typeof getProviderStatuses;
@@ -31,6 +31,7 @@ export class ProviderCatalogManager {
     try {
       const payload = await this.opts.getProviderCatalog({
         paths: this.opts.getGlobalAuthPaths(),
+        providerOptions: this.opts.getConfig().providerOptions,
       });
       const cfg = this.opts.getConfig();
       const defaults = { ...payload.default, [cfg.provider]: cfg.model };
@@ -65,6 +66,7 @@ export class ProviderCatalogManager {
     try {
       const providers = await this.opts.getProviderStatuses({
         paths: this.opts.getGlobalAuthPaths(),
+        providerOptions: this.opts.getConfig().providerOptions,
       });
       this.opts.emit({ type: "provider_status", sessionId: this.opts.sessionId, providers });
       this.opts.emitTelemetry(

--- a/src/server/sessionTitleService.ts
+++ b/src/server/sessionTitleService.ts
@@ -2,7 +2,7 @@ import { defaultModelForProvider } from "../config";
 import { createRuntime } from "../runtime";
 import type { AgentConfig } from "../types";
 
-const TITLE_MODEL_BY_PROVIDER = {
+const TITLE_MODEL_BY_PROVIDER: Partial<Record<AgentConfig["provider"], string>> = {
   anthropic: "claude-haiku-4-5",
   baseten: "moonshotai/Kimi-K2.5",
   "codex-cli": "gpt-5.2-codex",
@@ -12,7 +12,7 @@ const TITLE_MODEL_BY_PROVIDER = {
   together: "moonshotai/Kimi-K2.5",
   "opencode-go": "glm-5",
   "opencode-zen": "glm-5",
-} as const satisfies Record<AgentConfig["provider"], string>;
+};
 
 const TITLE_MAX_TOKENS = 150;
 const TITLE_MAX_CHARS = 50;
@@ -96,10 +96,12 @@ export function heuristicTitleFromQuery(query: string): string {
 
 function modelCandidatesForProvider(
   provider: AgentConfig["provider"],
+  currentModel: string,
   defaultModelForProviderImpl: typeof defaultModelForProvider
 ): string[] {
   const candidates = [
     TITLE_MODEL_BY_PROVIDER[provider],
+    currentModel,
     defaultModelForProviderImpl(provider),
   ];
 
@@ -148,7 +150,11 @@ export function createSessionTitleGenerator(overrides: Partial<SessionTitleDeps>
       };
     }
 
-    const candidates = modelCandidatesForProvider(opts.config.provider, deps.defaultModelForProvider);
+    const candidates = modelCandidatesForProvider(
+      opts.config.provider,
+      opts.config.model,
+      deps.defaultModelForProvider,
+    );
 
     for (const modelId of candidates) {
       try {

--- a/src/shared/openaiCompatibleOptions.ts
+++ b/src/shared/openaiCompatibleOptions.ts
@@ -49,10 +49,18 @@ export type CodexCliProviderOptions = OpenAiCompatibleProviderOptions & {
   webSearch?: CodexWebSearchOptions;
 };
 
+export type LmStudioProviderOptions = {
+  baseUrl?: string;
+  contextLength?: number;
+  autoLoad?: boolean;
+  reloadOnContextMismatch?: boolean;
+};
+
 export type OpenAiCompatibleProviderOptionsByProvider = Partial<
   {
     openai: OpenAiProviderOptions;
     "codex-cli": CodexCliProviderOptions;
+    lmstudio: LmStudioProviderOptions;
   }
 >;
 
@@ -100,6 +108,27 @@ function pickStringArray(value: unknown): string[] | undefined {
     .map((entry) => pickTrimmedString(entry))
     .filter((entry): entry is string => !!entry);
   return next;
+}
+
+function pickPositiveInteger(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    const normalized = Math.floor(value);
+    return normalized > 0 ? normalized : undefined;
+  }
+  if (typeof value !== "string") return undefined;
+  const parsed = Number(value.trim());
+  if (!Number.isFinite(parsed)) return undefined;
+  const normalized = Math.floor(parsed);
+  return normalized > 0 ? normalized : undefined;
+}
+
+function pickBoolean(value: unknown): boolean | undefined {
+  if (typeof value === "boolean") return value;
+  if (typeof value !== "string") return undefined;
+  const normalized = value.trim().toLowerCase();
+  if (["1", "true", "yes", "y", "on"].includes(normalized)) return true;
+  if (["0", "false", "no", "n", "off"].includes(normalized)) return false;
+  return undefined;
 }
 
 function pickCodexWebSearchLocation(value: unknown): CodexWebSearchLocation | undefined {
@@ -174,6 +203,30 @@ function pickCodexCliProviderOptionsSection(value: unknown): CodexCliProviderOpt
   return Object.keys(next).length > 0 ? next : undefined;
 }
 
+function pickLmStudioProviderOptionsSection(value: unknown): LmStudioProviderOptions | undefined {
+  if (!isPlainObject(value)) return undefined;
+
+  const next: LmStudioProviderOptions = {};
+  const baseUrl = pickTrimmedString(value.baseUrl);
+  if (baseUrl) {
+    next.baseUrl = baseUrl;
+  }
+  const contextLength = pickPositiveInteger(value.contextLength);
+  if (contextLength !== undefined) {
+    next.contextLength = contextLength;
+  }
+  const autoLoad = pickBoolean(value.autoLoad);
+  if (autoLoad !== undefined) {
+    next.autoLoad = autoLoad;
+  }
+  const reloadOnContextMismatch = pickBoolean(value.reloadOnContextMismatch);
+  if (reloadOnContextMismatch !== undefined) {
+    next.reloadOnContextMismatch = reloadOnContextMismatch;
+  }
+
+  return Object.keys(next).length > 0 ? next : undefined;
+}
+
 export function pickEditableOpenAiCompatibleProviderOptions(
   providerOptions: unknown,
 ): OpenAiCompatibleProviderOptionsByProvider | undefined {
@@ -187,6 +240,10 @@ export function pickEditableOpenAiCompatibleProviderOptions(
   const codex = pickCodexCliProviderOptionsSection(providerOptions["codex-cli"]);
   if (codex) {
     out["codex-cli"] = codex;
+  }
+  const lmstudio = pickLmStudioProviderOptionsSection(providerOptions.lmstudio);
+  if (lmstudio) {
+    out.lmstudio = lmstudio;
   }
 
   return Object.keys(out).length > 0 ? out : undefined;
@@ -262,6 +319,15 @@ export function mergeEditableOpenAiCompatibleProviderOptions(
     current[provider] = {
       ...currentSection,
       ...cleanedPatch,
+    };
+  }
+
+  const lmstudioPatch = pickLmStudioProviderOptionsSection(patch.lmstudio);
+  if (lmstudioPatch) {
+    const currentSection = isPlainObject(current.lmstudio) ? { ...current.lmstudio } : {};
+    current.lmstudio = {
+      ...currentSection,
+      ...lmstudioPatch,
     };
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@ export const PROVIDER_NAMES = [
   "baseten",
   "together",
   "nvidia",
+  "lmstudio",
   "opencode-go",
   "opencode-zen",
   "codex-cli",

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,6 @@
 # Lessons
 
+- For local model providers in the desktop app, do not force them through the generic auth/API-key card; give them local connect/refresh controls and persist model-visibility preferences in dedicated desktop UI state so chat selectors can hide or show them cleanly.
 - When the user explicitly asks for PR triage via subagents, spawn the requested reviewers before local implementation so the final fix plan is grounded in the current branch state instead of only your own read.
 - For provider auth and saved-key lookups in this repo, treat `~/.cowork` as the only auth home; never derive auth storage from a workspace `.agent` path, and pin `HOME` in tests that fabricate auth state so they cannot accidentally read real machine credentials.
 - For desktop admin pages that auto-fetch data, do not assume store-level success/error handling is enough; add a UI-level fallback so an orphaned request cannot leave the page stuck on a perpetual loading message when the correct end state is simply empty.
@@ -135,3 +136,4 @@
 - For Electron desktop shutdown in this repo, keep `ipcMain.handle(...)` registrations alive until async shutdown actually finishes; unregistering IPC at `before-quit` entry can leave the renderer open long enough to hit `No handler registered for 'desktop:...'` recovery failures.
 - When the user asks to fix release automation for the next build only, land the workflow update as a separate follow-up commit and do not conflate it with the in-flight tagged release state.
 - For Bun-compiled desktop sidecars in this repo, never read `package.json` via runtime filesystem paths like `resolve(__dirname, "../package.json")`; compiled binaries run from `/$bunfs` and must get version data from bundled imports or explicit build-time/env injection.
+- For local OpenAI-compatible providers like LM Studio, do not treat a transport library's required `apiKey` parameter as a user-facing auth requirement; satisfy that client internally when necessary, but never surface `OPENAI_API_KEY` or API-key UI as mandatory for local inference.

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -43,6 +43,19 @@ async function withEnv<T>(
   }
 }
 
+async function withMockedFetch<T>(
+  fetchImpl: typeof fetch,
+  run: () => Promise<T>,
+): Promise<T> {
+  const previous = globalThis.fetch;
+  globalThis.fetch = fetchImpl;
+  try {
+    return await run();
+  } finally {
+    globalThis.fetch = previous;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // loadConfig
 // ---------------------------------------------------------------------------
@@ -107,6 +120,94 @@ describe("loadConfig", () => {
 
     expect(cfg.provider).toBe("openai");
     expect(cfg.model).toBe("gpt-5.4");
+  });
+
+  test("accepts arbitrary LM Studio model ids discovered at runtime", async () => {
+    const { cwd, home } = await makeTmpDirs();
+
+    await withMockedFetch(
+      (async () => new Response(JSON.stringify({
+        models: [
+          {
+            type: "llm",
+            publisher: "local",
+            key: "local/qwen-2.5",
+            display_name: "Qwen 2.5 Local",
+            loaded_instances: [],
+            max_context_length: 32768,
+            capabilities: { vision: false, trained_for_tool_use: false },
+            size_bytes: 1,
+          },
+        ],
+      }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })) as typeof fetch,
+      async () => {
+        const cfg = await loadConfig({
+          cwd,
+          homedir: home,
+          builtInDir: repoRoot(),
+          env: {
+            AGENT_PROVIDER: "lmstudio",
+            AGENT_MODEL: "local/qwen-2.5",
+          },
+        });
+
+        expect(cfg.provider).toBe("lmstudio");
+        expect(cfg.model).toBe("local/qwen-2.5");
+        expect(cfg.preferredChildModel).toBe("local/qwen-2.5");
+        expect(cfg.knowledgeCutoff).toBe("Unknown");
+      },
+    );
+  });
+
+  test("uses the live LM Studio default selection policy when no model is configured", async () => {
+    const { cwd, home } = await makeTmpDirs();
+
+    await withMockedFetch(
+      (async () => new Response(JSON.stringify({
+        models: [
+          {
+            type: "llm",
+            publisher: "local",
+            key: "local/beta",
+            display_name: "Beta",
+            loaded_instances: [],
+            max_context_length: 32768,
+            capabilities: { vision: false, trained_for_tool_use: false },
+            size_bytes: 1,
+          },
+          {
+            type: "llm",
+            publisher: "local",
+            key: "local/alpha",
+            display_name: "Alpha",
+            loaded_instances: [{ id: "inst-1", config: { context_length: 8192 } }],
+            max_context_length: 32768,
+            capabilities: { vision: false, trained_for_tool_use: false },
+            size_bytes: 1,
+          },
+        ],
+      }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })) as typeof fetch,
+      async () => {
+        const cfg = await loadConfig({
+          cwd,
+          homedir: home,
+          builtInDir: repoRoot(),
+          env: {
+            AGENT_PROVIDER: "lmstudio",
+          },
+        });
+
+        expect(cfg.provider).toBe("lmstudio");
+        expect(cfg.model).toBe("local/alpha");
+        expect(cfg.preferredChildModel).toBe("local/alpha");
+      },
+    );
   });
 
   test("runtime defaults follow the resolved provider and ignore unsupported AGENT_RUNTIME values", async () => {

--- a/test/prompt.test.ts
+++ b/test/prompt.test.ts
@@ -55,6 +55,19 @@ async function writeFile(p: string, content: string) {
   await fs.writeFile(p, content, "utf-8");
 }
 
+async function withMockedFetch<T>(
+  fetchImpl: typeof fetch,
+  run: () => Promise<T>,
+): Promise<T> {
+  const previous = globalThis.fetch;
+  globalThis.fetch = fetchImpl;
+  try {
+    return await run();
+  } finally {
+    globalThis.fetch = previous;
+  }
+}
+
 function skillDoc(name: string, description: string, body = "# Skill Body\n"): string {
   return ["---", `name: \"${name}\"`, `description: \"${description}\"`, "---", "", body].join("\n");
 }
@@ -154,6 +167,26 @@ describe("loadSystemPrompt", () => {
     const prompt = await loadSystemPrompt(config);
     expect(prompt).toContain("GPT-5.4");
     expect(prompt).not.toContain("{{modelName}}");
+  });
+
+  test("falls back to the generic system prompt for dynamic LM Studio models", async () => {
+    const config = makeConfig({
+      provider: "lmstudio",
+      model: "local/qwen-2.5",
+      preferredChildModel: "local/qwen-2.5",
+      knowledgeCutoff: "Unknown",
+    });
+
+    const prompt = await withMockedFetch(
+      (async () => {
+        throw new Error("connect ECONNREFUSED");
+      }) as typeof fetch,
+      async () => await loadSystemPrompt(config),
+    );
+
+    expect(prompt).toContain("local/qwen-2.5");
+    expect(prompt).toContain("Available model overrides for the current provider (LM Studio):");
+    expect(prompt).toContain("Any LM Studio LLM key discovered at runtime is allowed.");
   });
 
   test("renders dynamic spawnAgent roles and current-provider model guidance", async () => {

--- a/test/protocol.test.ts
+++ b/test/protocol.test.ts
@@ -1243,6 +1243,35 @@ describe("safeParseClientMessage", () => {
       }
     });
 
+    test("valid set_config accepts lmstudio provider options", () => {
+      const msg = expectOk(
+        JSON.stringify({
+          type: "set_config",
+          sessionId: "s1",
+          config: {
+            providerOptions: {
+              lmstudio: {
+                baseUrl: "http://127.0.0.1:1234",
+                contextLength: 16384,
+                autoLoad: false,
+                reloadOnContextMismatch: true,
+              },
+            },
+          },
+        }),
+      );
+
+      expect(msg.type).toBe("set_config");
+      if (msg.type === "set_config") {
+        expect(msg.config.providerOptions?.lmstudio).toEqual({
+          baseUrl: "http://127.0.0.1:1234",
+          contextLength: 16384,
+          autoLoad: false,
+          reloadOnContextMismatch: true,
+        });
+      }
+    });
+
     test("valid set_config accepts clearToolOutputOverflowChars", () => {
       const msg = expectOk(
         JSON.stringify({
@@ -1334,7 +1363,7 @@ describe("safeParseClientMessage", () => {
             config: { providerOptions: { anthropic: { reasoningEffort: "high" } } },
           }),
         ),
-      ).toBe("set_config config.providerOptions only supports openai and codex-cli");
+      ).toBe("set_config config.providerOptions only supports openai, codex-cli, and lmstudio");
       expect(
         expectErr(
           JSON.stringify({
@@ -1407,6 +1436,33 @@ describe("safeParseClientMessage", () => {
           }),
         ),
       ).toBe("set_config config.providerOptions.codex-cli.webSearch.location.country must be a non-empty string");
+      expect(
+        expectErr(
+          JSON.stringify({
+            type: "set_config",
+            sessionId: "s1",
+            config: { providerOptions: { lmstudio: { unsupported: true } } },
+          }),
+        ),
+      ).toBe("set_config config.providerOptions.lmstudio only supports baseUrl, contextLength, autoLoad, and reloadOnContextMismatch");
+      expect(
+        expectErr(
+          JSON.stringify({
+            type: "set_config",
+            sessionId: "s1",
+            config: { providerOptions: { lmstudio: { contextLength: 0 } } },
+          }),
+        ),
+      ).toBe("set_config config.providerOptions.lmstudio.contextLength must be a positive integer");
+      expect(
+        expectErr(
+          JSON.stringify({
+            type: "set_config",
+            sessionId: "s1",
+            config: { providerOptions: { lmstudio: { autoLoad: "yes" } } },
+          }),
+        ),
+      ).toBe("set_config config.providerOptions.lmstudio.autoLoad must be boolean");
     });
 
     test("set_config accepts userName with non-empty string", () => {

--- a/test/providers/connection-catalog.test.ts
+++ b/test/providers/connection-catalog.test.ts
@@ -19,7 +19,7 @@ describe("providers/connectionCatalog", () => {
 
     const entryIds = payload.all.map((entry) => entry.id);
     expect(entryIds).toEqual(PROVIDER_NAMES);
-    expect(payload.all).toEqual(listProviderCatalogEntries());
+    expect(payload.all).toEqual(await listProviderCatalogEntries());
     expect(Object.keys(payload.default)).toEqual(PROVIDER_NAMES);
     for (const entry of payload.all) {
       expect(payload.default[entry.id]).toBe(entry.defaultModel);

--- a/test/providers/cross-provider.test.ts
+++ b/test/providers/cross-provider.test.ts
@@ -52,10 +52,18 @@ describe("Cross-provider model creation", () => {
 describe("Provider model catalog invariants", () => {
   for (const provider of PROVIDER_NAMES) {
     test(`${provider}: available model list is non-empty`, () => {
+      if (provider === "lmstudio") {
+        expect(PROVIDER_MODEL_CATALOG[provider].availableModels).toEqual([]);
+        return;
+      }
       expect(PROVIDER_MODEL_CATALOG[provider].availableModels.length).toBeGreaterThan(0);
     });
 
     test(`${provider}: default model exists in available models`, () => {
+      if (provider === "lmstudio") {
+        expect(PROVIDER_MODEL_CATALOG[provider].defaultModel).toBe("");
+        return;
+      }
       expect(PROVIDER_MODEL_CATALOG[provider].availableModels).toContain(PROVIDER_MODEL_CATALOG[provider].defaultModel);
     });
   }

--- a/test/providers/index.test.ts
+++ b/test/providers/index.test.ts
@@ -114,6 +114,25 @@ describe("src/providers/index.ts", () => {
       expect(model.provider).toBe("codex-cli.responses");
       expect(headers.authorization).toBe("Bearer openai-fallback-key");
     });
+
+    test("creates LM Studio model adapters for arbitrary discovered model ids", async () => {
+      const config = makeConfig({
+        provider: "lmstudio",
+        model: "local/qwen-2.5",
+        preferredChildModel: "local/qwen-2.5",
+        providerOptions: {
+          lmstudio: {
+            baseUrl: "http://127.0.0.1:1234",
+          },
+        },
+      });
+      const model = getModelForProvider(config, "local/qwen-2.5", "lmstudio-token") as any;
+      const headers = await model.config.headers();
+      expect(model.modelId).toBe("local/qwen-2.5");
+      expect(model.provider).toBe("lmstudio.openai-compat");
+      expect(model.config.baseUrl).toBe("http://127.0.0.1:1234");
+      expect(headers.authorization).toBe("Bearer lmstudio-token");
+    });
   });
 
   describe("defaultModelForProvider", () => {
@@ -165,6 +184,10 @@ describe("src/providers/index.ts", () => {
 
     test("returns key candidates for codex-cli", () => {
       expect(getProviderKeyCandidates("codex-cli")).toBe(PROVIDERS["codex-cli"].keyCandidates);
+    });
+
+    test("returns key candidates for lmstudio", () => {
+      expect(getProviderKeyCandidates("lmstudio")).toBe(PROVIDERS.lmstudio.keyCandidates);
     });
   });
 });

--- a/test/providers/lmstudio.test.ts
+++ b/test/providers/lmstudio.test.ts
@@ -1,0 +1,342 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import { parseChildModelRef } from "../../src/models/childModelRouting";
+import { getProviderCatalog } from "../../src/providers/connectionCatalog";
+import {
+  prepareLmStudioModelMetadataForInference,
+  selectDefaultLmStudioModel,
+} from "../../src/providers/lmstudio/catalog";
+import {
+  DEFAULT_LM_STUDIO_BASE_URL,
+  listLmStudioModels,
+} from "../../src/providers/lmstudio/client";
+import type { LmStudioModel } from "../../src/providers/lmstudio/types";
+import { AGENT_ROLE_DEFINITIONS } from "../../src/server/agents/roles";
+import { routeAgentConfig } from "../../src/server/agents/modelRouter";
+import type { ConnectionStore } from "../../src/store/connections";
+
+import { makeConfig } from "./helpers";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function makeStore(overrides: Partial<ConnectionStore["services"]> = {}): ConnectionStore {
+  return {
+    version: 1,
+    updatedAt: new Date().toISOString(),
+    services: {
+      ...overrides,
+    },
+  };
+}
+
+function lmModel(overrides: Partial<LmStudioModel> & Pick<LmStudioModel, "key">): LmStudioModel {
+  return {
+    type: "llm",
+    publisher: "local",
+    key: overrides.key,
+    display_name: overrides.display_name ?? `${overrides.key} Display`,
+    loaded_instances: overrides.loaded_instances ?? [],
+    max_context_length: overrides.max_context_length ?? 32768,
+    capabilities: overrides.capabilities ?? {
+      vision: false,
+      trained_for_tool_use: false,
+    },
+    size_bytes: overrides.size_bytes ?? 1,
+    architecture: overrides.architecture ?? "llama",
+    format: overrides.format ?? "gguf",
+    params_string: overrides.params_string ?? null,
+    quantization: overrides.quantization ?? null,
+    description: overrides.description ?? null,
+  };
+}
+
+describe("lmstudio provider", () => {
+  test("lists models through the native LM Studio /api/v1/models endpoint", async () => {
+    const fetchImpl = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+      expect(String(input)).toBe(`${DEFAULT_LM_STUDIO_BASE_URL}/api/v1/models`);
+      const headers = init?.headers as Record<string, string>;
+      expect(headers.authorization).toBe("Bearer lmstudio-token");
+      return jsonResponse({
+        models: [lmModel({ key: "local/qwen-2.5" })],
+      });
+    });
+
+    const result = await listLmStudioModels({
+      baseUrl: `${DEFAULT_LM_STUDIO_BASE_URL}/v1/`,
+      apiKey: "lmstudio-token",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    expect(result.models.map((model) => model.key)).toEqual(["local/qwen-2.5"]);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  test("selectDefaultLmStudioModel prefers already-loaded llms and ignores embeddings", () => {
+    const selected = selectDefaultLmStudioModel([
+      {
+        ...lmModel({ key: "local/embedder" }),
+        type: "embedding",
+      },
+      lmModel({ key: "local/zeta" }),
+      lmModel({
+        key: "local/alpha",
+        loaded_instances: [{ id: "inst-1", config: { context_length: 4096 } }],
+      }),
+    ], DEFAULT_LM_STUDIO_BASE_URL);
+
+    expect(selected.key).toBe("local/alpha");
+  });
+
+  test("getProviderCatalog returns live LM Studio llms and uses a stored optional token", async () => {
+    const fetchImpl = mock(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const headers = init?.headers as Record<string, string>;
+      expect(headers.authorization).toBe("Bearer stored-token");
+      return jsonResponse({
+        models: [
+          {
+            ...lmModel({ key: "local/embedder" }),
+            type: "embedding",
+          },
+          lmModel({ key: "local/beta" }),
+          lmModel({
+            key: "local/alpha",
+            loaded_instances: [{ id: "inst-1", config: { context_length: 8192 } }],
+            capabilities: { vision: true, trained_for_tool_use: true },
+          }),
+        ],
+      });
+    });
+
+    const catalog = await getProviderCatalog({
+      readStore: async () => makeStore({
+        lmstudio: {
+          service: "lmstudio",
+          mode: "api_key",
+          apiKey: "stored-token",
+          updatedAt: new Date().toISOString(),
+        },
+      }),
+      readCodexAuthMaterialImpl: async () => null,
+      lmstudioFetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    const entry = catalog.all.find((provider) => provider.id === "lmstudio");
+    expect(entry).toBeDefined();
+    expect(entry?.models.map((model) => model.id)).toEqual(["local/alpha", "local/beta"]);
+    expect(entry?.defaultModel).toBe("local/alpha");
+    expect(entry?.state).toBe("ready");
+    expect(catalog.connected).toContain("lmstudio");
+  });
+
+  test("getProviderCatalog surfaces unreachable LM Studio instances without crashing", async () => {
+    const catalog = await getProviderCatalog({
+      readStore: async () => makeStore(),
+      readCodexAuthMaterialImpl: async () => null,
+      lmstudioFetchImpl: mock(async () => {
+        throw new Error("connect ECONNREFUSED");
+      }) as unknown as typeof fetch,
+    });
+
+    const entry = catalog.all.find((provider) => provider.id === "lmstudio");
+    expect(entry?.models).toEqual([]);
+    expect(entry?.defaultModel).toBe("");
+    expect(entry?.state).toBe("unreachable");
+    expect(entry?.message).toContain("LM Studio");
+    expect(catalog.connected).not.toContain("lmstudio");
+  });
+
+  test("prepareLmStudioModelMetadataForInference reuses loaded context when no override is requested", async () => {
+    const fetchImpl = mock(async () => jsonResponse({
+      models: [
+        lmModel({
+          key: "local/qwen-2.5",
+          loaded_instances: [{ id: "inst-1", config: { context_length: 4096 } }],
+        }),
+      ],
+    }));
+
+    const prepared = await prepareLmStudioModelMetadataForInference({
+      modelId: "local/qwen-2.5",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    expect(prepared.metadata.effectiveContextLength).toBe(4096);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  test("prepareLmStudioModelMetadataForInference loads an unloaded model with an explicit context length", async () => {
+    const calls: string[] = [];
+    const fetchImpl = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const method = init?.method ?? "GET";
+      calls.push(`${method} ${String(input)}`);
+      if (String(input).endsWith("/api/v1/models")) {
+        return jsonResponse({ models: [lmModel({ key: "local/qwen-2.5" })] });
+      }
+      return jsonResponse({
+        type: "llm",
+        instance_id: "inst-2",
+        load_time_seconds: 0.5,
+        status: "loaded",
+        load_config: {
+          context_length: 8192,
+        },
+      });
+    });
+
+    const prepared = await prepareLmStudioModelMetadataForInference({
+      modelId: "local/qwen-2.5",
+      providerOptions: {
+        lmstudio: {
+          contextLength: 8192,
+        },
+      },
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    expect(prepared.metadata.loaded).toBe(true);
+    expect(prepared.metadata.effectiveContextLength).toBe(8192);
+    expect(calls).toEqual([
+      "GET http://localhost:1234/api/v1/models",
+      "POST http://localhost:1234/api/v1/models/load",
+    ]);
+  });
+
+  test("prepareLmStudioModelMetadataForInference reloads on context mismatch by default", async () => {
+    const logLines: string[] = [];
+    const calls: string[] = [];
+    const fetchImpl = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const method = init?.method ?? "GET";
+      calls.push(`${method} ${String(input)}`);
+      if (String(input).endsWith("/api/v1/models")) {
+        return jsonResponse({
+          models: [
+            lmModel({
+              key: "local/qwen-2.5",
+              loaded_instances: [{ id: "inst-1", config: { context_length: 4096 } }],
+            }),
+          ],
+        });
+      }
+      if (String(input).endsWith("/api/v1/models/unload")) {
+        return jsonResponse({ status: "ok" });
+      }
+      return jsonResponse({
+        type: "llm",
+        instance_id: "inst-2",
+        load_time_seconds: 0.5,
+        status: "loaded",
+        load_config: {
+          context_length: 8192,
+        },
+      });
+    });
+
+    const prepared = await prepareLmStudioModelMetadataForInference({
+      modelId: "local/qwen-2.5",
+      providerOptions: {
+        lmstudio: {
+          contextLength: 8192,
+        },
+      },
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      log: (line) => {
+        logLines.push(line);
+      },
+    });
+
+    expect(prepared.metadata.effectiveContextLength).toBe(8192);
+    expect(calls).toEqual([
+      "GET http://localhost:1234/api/v1/models",
+      "POST http://localhost:1234/api/v1/models/unload",
+      "POST http://localhost:1234/api/v1/models/load",
+    ]);
+    expect(logLines.some((line) => line.includes("requested context length 8192 differs from loaded 4096"))).toBe(true);
+  });
+
+  test("prepareLmStudioModelMetadataForInference errors when the requested model is missing", async () => {
+    const fetchImpl = mock(async () => jsonResponse({
+      models: [lmModel({ key: "local/other" })],
+    }));
+
+    await expect(
+      prepareLmStudioModelMetadataForInference({
+        modelId: "local/qwen-2.5",
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      }),
+    ).rejects.toThrow('LM Studio model "local/qwen-2.5" is not available');
+  });
+
+  test("parseChildModelRef accepts explicit lmstudio model refs", () => {
+    const parsed = parseChildModelRef("lmstudio:local/qwen-2.5", "google", "child model");
+    expect(parsed.provider).toBe("lmstudio");
+    expect(parsed.modelId).toBe("local/qwen-2.5");
+    expect(parsed.ref).toBe("lmstudio:local/qwen-2.5");
+  });
+
+  test("routeAgentConfig accepts arbitrary same-provider lmstudio child model keys", () => {
+    const parentConfig = makeConfig({
+      provider: "lmstudio",
+      model: "local/current",
+      preferredChildModel: "local/current",
+      childModelRoutingMode: "same-provider",
+      preferredChildModelRef: "lmstudio:local/current",
+      knowledgeCutoff: "Unknown",
+    });
+
+    const routed = routeAgentConfig(parentConfig, {
+      role: AGENT_ROLE_DEFINITIONS.worker,
+      model: "local/qwen-2.5",
+      connectedProviders: ["lmstudio"],
+    });
+
+    expect(routed.effectiveProvider).toBe("lmstudio");
+    expect(routed.effectiveModel).toBe("local/qwen-2.5");
+    expect(routed.config.model).toBe("local/qwen-2.5");
+  });
+
+  test("routeAgentConfig supports cross-provider LM Studio child targets", () => {
+    const parentConfig = makeConfig({
+      provider: "google",
+      model: "gemini-3-pro-preview",
+      preferredChildModel: "gemini-3-pro-preview",
+      childModelRoutingMode: "cross-provider-allowlist",
+      preferredChildModelRef: "google:gemini-3-pro-preview",
+      allowedChildModelRefs: ["lmstudio:local/qwen-2.5"],
+    });
+
+    const routed = routeAgentConfig(parentConfig, {
+      role: AGENT_ROLE_DEFINITIONS.worker,
+      model: "lmstudio:local/qwen-2.5",
+      connectedProviders: ["google", "lmstudio"],
+    });
+
+    expect(routed.effectiveProvider).toBe("lmstudio");
+    expect(routed.effectiveModel).toBe("local/qwen-2.5");
+  });
+
+  test("routeAgentConfig falls back cleanly when LM Studio is disconnected", () => {
+    const parentConfig = makeConfig({
+      provider: "lmstudio",
+      model: "local/current",
+      preferredChildModel: "local/current",
+      childModelRoutingMode: "same-provider",
+      preferredChildModelRef: "lmstudio:local/current",
+      knowledgeCutoff: "Unknown",
+    });
+
+    const routed = routeAgentConfig(parentConfig, {
+      role: AGENT_ROLE_DEFINITIONS.worker,
+      model: "local/qwen-2.5",
+      connectedProviders: ["openai"],
+    });
+
+    expect(routed.effectiveProvider).toBe("lmstudio");
+    expect(routed.effectiveModel).toBe("local/current");
+    expect(routed.fallbackLine).toContain("LM Studio is not connected");
+  });
+});

--- a/test/repl.test.ts
+++ b/test/repl.test.ts
@@ -374,6 +374,12 @@ describe("REPL slash command routing", () => {
         selectedProvider = provider;
       },
       getProviderList: () => ["openai", "codex-cli", "google"],
+      getProviderDefaultModel: (provider) => {
+        if (provider === "codex-cli") return "gpt-5.4";
+        if (provider === "openai") return "gpt-5.4";
+        if (provider === "google") return "gemini-3-pro-preview";
+        return null;
+      },
       getProviderAuthMethods: () => ({}),
       trySend: mock(() => true),
       activateNextPrompt: mock(() => {}),

--- a/test/runtime.pi-runtime.test.ts
+++ b/test/runtime.pi-runtime.test.ts
@@ -77,6 +77,19 @@ async function withEnv<T>(
   }
 }
 
+async function withMockedFetch<T>(
+  fetchImpl: typeof fetch,
+  run: () => Promise<T>,
+): Promise<T> {
+  const previous = globalThis.fetch;
+  globalThis.fetch = fetchImpl;
+  try {
+    return await run();
+  } finally {
+    globalThis.fetch = previous;
+  }
+}
+
 describe("pi runtime regressions", () => {
   test("calls onModelAbort exactly once when turn starts with an aborted signal", async () => {
     const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-runtime-abort-"));
@@ -238,6 +251,150 @@ describe("pi runtime regressions", () => {
     expect(resolved.model.api).toBe("openai-responses");
     expect(resolved.model.contextWindow).toBe(400000);
     expect(resolved.model.maxTokens).toBe(128000);
+  });
+
+  test("LM Studio PI model resolution builds a dynamic openai-completions model from live metadata", async () => {
+    const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-runtime-lmstudio-"));
+    const paths = getAiCoworkerPaths({ homedir: homeDir });
+    await fs.mkdir(path.dirname(paths.connectionsFile), { recursive: true });
+    await fs.writeFile(
+      paths.connectionsFile,
+      JSON.stringify({
+        version: 1,
+        updatedAt: new Date().toISOString(),
+        services: {
+          lmstudio: {
+            service: "lmstudio",
+            mode: "api_key",
+            apiKey: "lmstudio-token",
+            updatedAt: new Date().toISOString(),
+          },
+        },
+      }),
+      "utf-8",
+    );
+
+    const config = makeConfig(homeDir, {
+      provider: "lmstudio",
+      model: "local/qwen-2.5",
+      preferredChildModel: "local/qwen-2.5",
+      knowledgeCutoff: "Unknown",
+      providerOptions: {
+        lmstudio: {
+          baseUrl: "http://127.0.0.1:1234",
+          contextLength: 8192,
+        },
+      },
+    });
+
+    const resolved = await withMockedFetch(
+      (async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.endsWith("/api/v1/models")) {
+          return new Response(JSON.stringify({
+            models: [
+              {
+                type: "llm",
+                publisher: "local",
+                key: "local/qwen-2.5",
+                display_name: "Qwen 2.5 Local",
+                loaded_instances: [],
+                max_context_length: 32768,
+                capabilities: { vision: true, trained_for_tool_use: false },
+                size_bytes: 1,
+                architecture: "llama",
+                format: "gguf",
+              },
+            ],
+          }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        }
+
+        return new Response(JSON.stringify({
+          type: "llm",
+          instance_id: "inst-1",
+          load_time_seconds: 0.25,
+          status: "loaded",
+          load_config: {
+            context_length: 8192,
+          },
+        }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }) as typeof fetch,
+      async () => await piRuntimeInternal.resolvePiModel(makeParams(config, {
+        providerOptions: config.providerOptions,
+      })),
+    );
+
+    expect(resolved.model.id).toBe("local/qwen-2.5");
+    expect(resolved.model.name).toBe("Qwen 2.5 Local");
+    expect(resolved.model.api).toBe("openai-completions");
+    expect(resolved.model.provider).toBe("lmstudio");
+    expect(resolved.model.baseUrl).toBe("http://127.0.0.1:1234/v1");
+    expect(resolved.model.contextWindow).toBe(8192);
+    expect(resolved.model.maxTokens).toBe(2048);
+    expect(resolved.model.input).toEqual(["text", "image"]);
+    expect(resolved.headers).toEqual({ authorization: "Bearer lmstudio-token" });
+    expect(resolved.apiKey).toBe("lmstudio-token");
+  });
+
+  test("LM Studio PI model resolution does not require an API key for local inference", async () => {
+    const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-runtime-lmstudio-local-"));
+    const config = makeConfig(homeDir, {
+      provider: "lmstudio",
+      model: "local/qwen-2.5",
+      preferredChildModel: "local/qwen-2.5",
+      knowledgeCutoff: "Unknown",
+      providerOptions: {
+        lmstudio: {
+          baseUrl: "http://127.0.0.1:1234",
+          autoLoad: false,
+        },
+      },
+    });
+
+    const resolved = await withEnv("OPENAI_API_KEY", undefined, async () =>
+      await withMockedFetch(
+        (async (input: RequestInfo | URL) => {
+          const url = String(input);
+          if (url.endsWith("/api/v1/models")) {
+            return new Response(JSON.stringify({
+              models: [
+                {
+                  type: "llm",
+                  publisher: "local",
+                  key: "local/qwen-2.5",
+                  display_name: "Qwen 2.5 Local",
+                  loaded_instances: [],
+                  max_context_length: 32768,
+                  capabilities: { vision: false, trained_for_tool_use: false },
+                  size_bytes: 1,
+                  architecture: "llama",
+                  format: "gguf",
+                },
+              ],
+            }), {
+              status: 200,
+              headers: { "content-type": "application/json" },
+            });
+          }
+          throw new Error(`unexpected fetch url: ${url}`);
+        }) as typeof fetch,
+        async () => await piRuntimeInternal.resolvePiModel(makeParams(config, {
+          providerOptions: config.providerOptions,
+        })),
+      )
+    );
+
+    expect(resolved.model.id).toBe("local/qwen-2.5");
+    expect(resolved.model.provider).toBe("lmstudio");
+    expect(resolved.model.baseUrl).toBe("http://127.0.0.1:1234/v1");
+    expect(resolved.apiKey).toBe("lmstudio-local");
+    expect(resolved.headers).toBeUndefined();
   });
 
   test("codex openai-key runtime model resolution keeps supported token limits for gpt-5.4-mini", async () => {

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -5,8 +5,8 @@ import { isProviderName, PROVIDER_NAMES, resolveProviderName } from "../src/type
 // PROVIDER_NAMES
 // ---------------------------------------------------------------------------
 describe("PROVIDER_NAMES", () => {
-  test("contains exactly 9 providers", () => {
-    expect(PROVIDER_NAMES).toHaveLength(9);
+  test("contains exactly 10 providers", () => {
+    expect(PROVIDER_NAMES).toHaveLength(10);
   });
 
   test("contains expected provider names", () => {
@@ -16,6 +16,7 @@ describe("PROVIDER_NAMES", () => {
     expect(PROVIDER_NAMES).toContain("baseten");
     expect(PROVIDER_NAMES).toContain("together");
     expect(PROVIDER_NAMES).toContain("nvidia");
+    expect(PROVIDER_NAMES).toContain("lmstudio");
     expect(PROVIDER_NAMES).toContain("opencode-go");
     expect(PROVIDER_NAMES).toContain("opencode-zen");
     expect(PROVIDER_NAMES).toContain("codex-cli");
@@ -30,6 +31,7 @@ describe("resolveProviderName", () => {
     expect(resolveProviderName("baseten")).toBe("baseten");
     expect(resolveProviderName("together")).toBe("together");
     expect(resolveProviderName("nvidia")).toBe("nvidia");
+    expect(resolveProviderName("lmstudio")).toBe("lmstudio");
     expect(resolveProviderName("opencode-go")).toBe("opencode-go");
     expect(resolveProviderName("opencode-zen")).toBe("opencode-zen");
     expect(resolveProviderName("codex-cli")).toBe("codex-cli");
@@ -69,6 +71,10 @@ describe("isProviderName", () => {
 
     test("nvidia", () => {
       expect(isProviderName("nvidia")).toBe(true);
+    });
+
+    test("lmstudio", () => {
+      expect(isProviderName("lmstudio")).toBe(true);
     });
 
     test("codex-cli", () => {


### PR DESCRIPTION
**Summary**
- add `lmstudio` as a first-class dynamic provider with live model discovery instead of static registry entries
- introduce resolved model metadata so runtime-discovered LM Studio models work across config, prompts, routing, catalog generation, and PI runtime resolution
- implement LM Studio-specific discovery/load/context-window handling via native LM Studio APIs while keeping inference on the OpenAI-compatible chat completions path
- update desktop and TUI flows so LM Studio behaves like a local provider with connect/refresh controls, model visibility toggles, and no required API key UI
- fix LM Studio local inference so it does not require `OPENAI_API_KEY`, using an internal runtime sentinel only when the transport library requires a truthy key
- document websocket/config updates and add focused regression coverage for cataloging, routing, prompts, runtime behavior, and desktop state persistence

**Testing**
- `bun test`
- `bun run typecheck`
- `bun run build:server-binary`
- `bun run build:desktop-resources`
- `bun run desktop:build`