### PR TITLE
feat: add multimodal message attachments

### DIFF
--- a/apps/desktop/src/app/store.actions/thread.ts
+++ b/apps/desktop/src/app/store.actions/thread.ts
@@ -39,6 +39,7 @@ import {
 } from "../store.helpers";
 import { hydrateTranscriptSnapshot } from "../transcriptHydration";
 import type {
+  PendingThreadMessage,
   SessionSnapshot,
   SessionSnapshotFingerprint,
   ThreadBusyPolicy,
@@ -48,6 +49,25 @@ import type {
 } from "../types";
 
 export function createThreadActions(set: StoreSet, get: StoreGet): Pick<AppStoreActions, "removeThread" | "deleteThreadHistory" | "renameThread" | "newThread" | "selectThread" | "reconnectThread" | "sendMessage" | "cancelThread" | "clearThreadUsageHardCap" | "setThreadModel" | "setComposerText" | "setInjectContext" | "answerAsk" | "answerApproval" | "dismissPrompt" | "loadAllThreadUsage"> {
+  const normalizePendingThreadMessage = (
+    message?: string | PendingThreadMessage,
+  ): PendingThreadMessage | null => {
+    if (typeof message === "string") {
+      return message.trim() ? { text: message } : null;
+    }
+    if (!message) return null;
+    const text = message.text.trim();
+    const attachments = message.attachments?.length ? message.attachments : undefined;
+    if (!text && !attachments) return null;
+    return {
+      text,
+      ...(attachments ? { attachments } : {}),
+    };
+  };
+
+  const hasPendingThreadMessagePayload = (message?: string | PendingThreadMessage): boolean =>
+    normalizePendingThreadMessage(message) !== null;
+
   const waitForSelectionFrame = async () => {
     await new Promise<void>((resolve) => {
       if (typeof window === "undefined") {
@@ -375,7 +395,8 @@ export function createThreadActions(set: StoreSet, get: StoreGet): Pick<AppStore
         set({ selectedWorkspaceId: workspaceId });
       }
 
-      const createSessionImmediately = opts?.mode === "session" || Boolean(opts?.firstMessage?.trim());
+      const firstMessage = normalizePendingThreadMessage(opts?.firstMessage);
+      const createSessionImmediately = opts?.mode === "session" || Boolean(firstMessage);
       if (!createSessionImmediately) {
         const existingDraft = get().threads.find((thread) => thread.workspaceId === workspaceId && thread.draft === true);
         if (existingDraft) {
@@ -450,7 +471,7 @@ export function createThreadActions(set: StoreSet, get: StoreGet): Pick<AppStore
         return;
       }
 
-      ensureThreadSocket(get, set, threadId, url, opts?.firstMessage, false);
+      ensureThreadSocket(get, set, threadId, url, firstMessage ?? undefined, false);
     },
   
 
@@ -633,7 +654,7 @@ export function createThreadActions(set: StoreSet, get: StoreGet): Pick<AppStore
     },
   
 
-    reconnectThread: async (threadId: string, firstMessage?: string, opts?: { selectionRequestId?: number }) => {
+    reconnectThread: async (threadId: string, firstMessage?: string | PendingThreadMessage, opts?: { selectionRequestId?: number }) => {
       const isReconnectCurrent = () =>
         opts?.selectionRequestId === undefined
         || (get().selectedThreadId === threadId && isCurrentThreadSelectionRequest(threadId, opts.selectionRequestId));
@@ -642,8 +663,9 @@ export function createThreadActions(set: StoreSet, get: StoreGet): Pick<AppStore
   
       const thread = get().threads.find((t) => t.id === threadId);
       if (!thread) return;
+      const normalizedFirstMessage = normalizePendingThreadMessage(firstMessage);
 
-      if (thread.draft && !firstMessage?.trim()) {
+      if (thread.draft && !normalizedFirstMessage) {
         return;
       }
   
@@ -668,14 +690,18 @@ export function createThreadActions(set: StoreSet, get: StoreGet): Pick<AppStore
       }
       if (!isReconnectCurrent()) return;
   
-      if (firstMessage && firstMessage.trim()) {
-        queuePendingThreadMessage(threadId, firstMessage);
+      if (normalizedFirstMessage) {
+        queuePendingThreadMessage(threadId, firstMessage ?? normalizedFirstMessage);
       }
-      ensureThreadSocket(get, set, threadId, url, firstMessage, Boolean(firstMessage?.trim()));
+      ensureThreadSocket(get, set, threadId, url, normalizedFirstMessage ?? undefined, Boolean(normalizedFirstMessage));
     },
   
 
-    sendMessage: async (text: string, busyPolicy: ThreadBusyPolicy = "reject") => {
+    sendMessage: async (
+      text: string,
+      busyPolicy: ThreadBusyPolicy = "reject",
+      attachments?: PendingThreadMessage["attachments"],
+    ) => {
       const activeThreadId = get().selectedThreadId;
       if (!activeThreadId) return;
   
@@ -684,12 +710,24 @@ export function createThreadActions(set: StoreSet, get: StoreGet): Pick<AppStore
   
       const rt = get().threadRuntimeById[activeThreadId];
       const trimmed = text.trim();
-      if (!trimmed) return;
+      const hasAttachments = Boolean(attachments?.length);
+      if (!trimmed && !hasAttachments) return;
+      const withAttachments = (messageText: string): string | PendingThreadMessage =>
+        hasAttachments
+          ? {
+              text: messageText,
+              attachments,
+            }
+          : messageText;
   
       if (rt?.transcriptOnly) {
         const preamble = get().injectContext ? buildContextPreamble(rt?.feed ?? []) : "";
         const firstMessage = preamble ? `${preamble}${trimmed}` : trimmed;
-        await get().newThread({ workspaceId: thread.workspaceId, titleHint: thread.title, firstMessage });
+        await get().newThread({
+          workspaceId: thread.workspaceId,
+          titleHint: thread.title,
+          firstMessage: withAttachments(firstMessage),
+        });
         set({ composerText: "" });
         return;
       }
@@ -697,12 +735,12 @@ export function createThreadActions(set: StoreSet, get: StoreGet): Pick<AppStore
       if (thread.status !== "active" || !rt?.sessionId) {
         const preamble = get().injectContext ? buildContextPreamble(rt?.feed ?? []) : "";
         const firstMessage = preamble ? `${preamble}${trimmed}` : trimmed;
-        await get().reconnectThread(activeThreadId, firstMessage);
+        await get().reconnectThread(activeThreadId, withAttachments(firstMessage));
         set({ composerText: "" });
         return;
       }
   
-      const ok = sendUserMessageToThread(get, set, activeThreadId, trimmed, busyPolicy);
+      const ok = sendUserMessageToThread(get, set, activeThreadId, withAttachments(trimmed), busyPolicy);
       if (!ok) return;
       if (busyPolicy === "steer" && rt?.busy) return;
 

--- a/apps/desktop/src/app/store.feedMapping.ts
+++ b/apps/desktop/src/app/store.feedMapping.ts
@@ -834,6 +834,12 @@ const transcriptPayloadTypeSchema = z.object({
 const transcriptUserMessagePayloadSchema = z.object({
   type: z.literal("user_message"),
   text: z.unknown().optional(),
+  attachments: z.array(z.object({
+    filename: z.string().trim().min(1),
+    mimeType: z.string().trim().min(1),
+    kind: z.enum(["image", "audio", "video", "document"]),
+    path: z.string().optional(),
+  }).strict()).optional(),
   clientMessageId: z.string().optional(),
 }).passthrough();
 
@@ -1008,7 +1014,23 @@ export function mapTranscriptToFeed(events: TranscriptEvent[]): FeedItem[] {
     if (payload.type === "user_message") {
       clearThreadModelStreamRuntime(stream);
       const cmid = payload.clientMessageId ?? "";
-      if (cmid && seenUser.has(cmid)) continue;
+      if (cmid && seenUser.has(cmid)) {
+        if (payload.attachments && payload.attachments.length > 0) {
+          const existingIndex = out.findIndex(
+            (item) => item.kind === "message" && item.role === "user" && item.id === cmid,
+          );
+          if (existingIndex >= 0) {
+            const existing = out[existingIndex];
+            if (existing?.kind === "message" && existing.role === "user") {
+              out[existingIndex] = {
+                ...existing,
+                attachments: payload.attachments,
+              };
+            }
+          }
+        }
+        continue;
+      }
       if (cmid) seenUser.add(cmid);
       out.push({
         id: cmid || makeId(),
@@ -1016,6 +1038,7 @@ export function mapTranscriptToFeed(events: TranscriptEvent[]): FeedItem[] {
         role: "user",
         ts: evt.ts,
         text: String(payload.text ?? ""),
+        ...(payload.attachments && payload.attachments.length > 0 ? { attachments: payload.attachments } : {}),
       });
       continue;
     }

--- a/apps/desktop/src/app/store.helpers.ts
+++ b/apps/desktop/src/app/store.helpers.ts
@@ -7,6 +7,7 @@ import type {
   PersistedProviderUiState,
   Notification,
   OnboardingStep,
+  PendingThreadMessage,
   PersistedOnboardingState,
   PromptModalState,
   SettingsPageId,
@@ -199,14 +200,14 @@ export type AppStoreState = {
   selectWorkspace: (workspaceId: string) => Promise<void>;
   reorderWorkspaces: (sourceWorkspaceId: string, targetWorkspaceId: string) => Promise<void>;
 
-  newThread: (opts?: { workspaceId?: string; titleHint?: string; firstMessage?: string; mode?: "draft" | "session" }) => Promise<void>;
+  newThread: (opts?: { workspaceId?: string; titleHint?: string; firstMessage?: string | PendingThreadMessage; mode?: "draft" | "session" }) => Promise<void>;
   removeThread: (threadId: string) => Promise<void>;
   deleteThreadHistory: (threadId: string) => Promise<void>;
   selectThread: (threadId: string) => Promise<void>;
-  reconnectThread: (threadId: string, firstMessage?: string, opts?: { selectionRequestId?: number }) => Promise<void>;
+  reconnectThread: (threadId: string, firstMessage?: string | PendingThreadMessage, opts?: { selectionRequestId?: number }) => Promise<void>;
   renameThread: (threadId: string, newTitle: string) => void;
 
-  sendMessage: (text: string, busyPolicy?: ThreadBusyPolicy) => Promise<void>;
+  sendMessage: (text: string, busyPolicy?: ThreadBusyPolicy, attachments?: PendingThreadMessage["attachments"]) => Promise<void>;
   cancelThread: (threadId: string, opts?: { includeSubagents?: boolean }) => void;
   clearThreadUsageHardCap: (threadId: string) => void;
   setThreadModel: (threadId: string, provider: ProviderName, model: string) => void;

--- a/apps/desktop/src/app/store.helpers/runtimeState.ts
+++ b/apps/desktop/src/app/store.helpers/runtimeState.ts
@@ -5,7 +5,12 @@ import {
   type ThreadModelStreamRuntime,
 } from "../store.feedMapping";
 import type { AppStoreState } from "../store.helpers";
-import type { CachedSessionSnapshot, ThreadRuntime, WorkspaceRuntime } from "../types";
+import type {
+  CachedSessionSnapshot,
+  PendingThreadMessage,
+  ThreadRuntime,
+  WorkspaceRuntime,
+} from "../types";
 
 export type PendingThreadSteer = {
   clientMessageId: string;
@@ -28,7 +33,7 @@ export type RuntimeMaps = {
   skillInstallWaiters: Map<string, SkillInstallWaiter>;
   threadSockets: Map<string, AgentSocket>;
   optimisticUserMessageIds: Map<string, Set<string>>;
-  pendingThreadMessages: Map<string, string[]>;
+  pendingThreadMessages: Map<string, Array<string | PendingThreadMessage>>;
   pendingThreadSteers: Map<string, Map<string, PendingThreadSteer>>;
   threadSelectionRequests: Map<string, number>;
   nextThreadSelectionRequestId: number;
@@ -76,22 +81,29 @@ export function resetModelStreamRuntime(threadId: string) {
   RUNTIME.modelStreamByThread.set(threadId, createThreadModelStreamRuntime());
 }
 
-export function queuePendingThreadMessage(threadId: string, text: string) {
-  const trimmed = text.trim();
-  if (!trimmed) return;
+export function queuePendingThreadMessage(threadId: string, message: string | PendingThreadMessage) {
+  const normalized = typeof message === "string"
+    ? message.trim()
+    : {
+        text: message.text.trim(),
+        ...(message.attachments && message.attachments.length > 0 ? { attachments: message.attachments } : {}),
+      };
+  const text = typeof normalized === "string" ? normalized : normalized.text;
+  const hasAttachments = typeof normalized !== "string" && Boolean(normalized.attachments?.length);
+  if (!text && !hasAttachments) return;
   const existing = RUNTIME.pendingThreadMessages.get(threadId) ?? [];
-  existing.push(trimmed);
+  existing.push(normalized);
   RUNTIME.pendingThreadMessages.set(threadId, existing);
 }
 
-export function drainPendingThreadMessages(threadId: string): string[] {
+export function drainPendingThreadMessages(threadId: string): Array<string | PendingThreadMessage> {
   const existing = RUNTIME.pendingThreadMessages.get(threadId);
   if (!existing || existing.length === 0) return [];
   RUNTIME.pendingThreadMessages.delete(threadId);
   return existing;
 }
 
-export function shiftPendingThreadMessage(threadId: string): string | undefined {
+export function shiftPendingThreadMessage(threadId: string): string | PendingThreadMessage | undefined {
   const existing = RUNTIME.pendingThreadMessages.get(threadId);
   if (!existing || existing.length === 0) return undefined;
   const next = existing.shift();

--- a/apps/desktop/src/app/store.helpers/threadEventReducer.ts
+++ b/apps/desktop/src/app/store.helpers/threadEventReducer.ts
@@ -1,5 +1,6 @@
 import { AgentSocket } from "../../lib/agentSocket";
 import { VERSION } from "../../lib/version";
+import { classifyUserMessageAttachmentKind } from "../../../../../src/shared/messageAttachments";
 import type { ClientMessage, ServerEvent } from "../../lib/wsProtocol";
 import {
   mapModelStreamChunk,
@@ -23,8 +24,10 @@ import type {
   AskPrompt,
   FeedItem,
   Notification,
+  PendingThreadMessage,
   ThreadAgentSummary,
   ThreadBusyPolicy,
+  ThreadMessageAttachment,
   ThreadTitleSource,
 } from "../types";
 import {
@@ -42,6 +45,38 @@ import {
 } from "./runtimeState";
 
 const MAX_FEED_ITEMS = 2000;
+
+function normalizePendingThreadMessage(
+  message: string | PendingThreadMessage,
+): PendingThreadMessage {
+  if (typeof message === "string") {
+    return { text: message };
+  }
+  return {
+    text: message.text,
+    ...(message.attachments && message.attachments.length > 0 ? { attachments: message.attachments } : {}),
+  };
+}
+
+function messageHasPayload(message: PendingThreadMessage): boolean {
+  return message.text.trim().length > 0 || Boolean(message.attachments?.length);
+}
+
+function draftAttachmentsToFeedAttachments(
+  attachments: PendingThreadMessage["attachments"],
+): ThreadMessageAttachment[] | undefined {
+  if (!attachments || attachments.length === 0) return undefined;
+  const mapped = attachments.flatMap<ThreadMessageAttachment>((attachment) => {
+    const kind = classifyUserMessageAttachmentKind(attachment.mimeType);
+    if (!kind) return [];
+    return [{
+      filename: attachment.filename,
+      mimeType: attachment.mimeType,
+      kind,
+    }];
+  });
+  return mapped.length > 0 ? mapped : undefined;
+}
 
 function sortAgentSummaries(agents: ThreadAgentSummary[]): ThreadAgentSummary[] {
   return [...agents].sort((left, right) => {
@@ -213,11 +248,13 @@ export function createThreadEventReducer(deps: ThreadEventReducerDeps) {
     get: StoreGet,
     set: StoreSet,
     threadId: string,
-    text: string,
+    message: string | PendingThreadMessage,
     busyPolicy: ThreadBusyPolicy = "reject",
   ): boolean {
-    const trimmed = text.trim();
-    if (!trimmed) return false;
+    const normalizedMessage = normalizePendingThreadMessage(message);
+    const trimmed = normalizedMessage.text.trim();
+    const draftAttachments = draftAttachmentsToFeedAttachments(normalizedMessage.attachments);
+    if (!trimmed && !draftAttachments) return false;
 
     const thread = get().threads.find((t) => t.id === threadId);
     if (!thread) return false;
@@ -226,10 +263,13 @@ export function createThreadEventReducer(deps: ThreadEventReducerDeps) {
     if (!rt?.sessionId) return false;
 
     if (rt.busy) {
+      if (draftAttachments) {
+        return false;
+      }
       if (busyPolicy === "queue") {
         RUNTIME.pendingThreadMessages.set(threadId, [
           ...(RUNTIME.pendingThreadMessages.get(threadId) ?? []),
-          trimmed,
+          normalizedMessage,
         ]);
         return true;
       }
@@ -323,12 +363,14 @@ export function createThreadEventReducer(deps: ThreadEventReducerDeps) {
       role: "user",
       ts: deps.nowIso(),
       text: trimmed,
+      ...(draftAttachments ? { attachments: draftAttachments } : {}),
     });
 
     deps.appendThreadTranscript(threadId, "client", {
       type: "user_message",
       sessionId: rt.sessionId,
       text: trimmed,
+      ...(draftAttachments ? { attachments: draftAttachments } : {}),
       clientMessageId,
     });
 
@@ -336,6 +378,9 @@ export function createThreadEventReducer(deps: ThreadEventReducerDeps) {
       type: "user_message",
       sessionId,
       text: trimmed,
+      ...(normalizedMessage.attachments && normalizedMessage.attachments.length > 0
+        ? { attachments: normalizedMessage.attachments }
+        : {}),
       clientMessageId,
     }));
 
@@ -397,7 +442,7 @@ export function createThreadEventReducer(deps: ThreadEventReducerDeps) {
     set: StoreSet,
     threadId: string,
     evt: ServerEvent,
-    pendingFirstMessage?: string,
+    pendingFirstMessage?: string | PendingThreadMessage,
     pendingFirstMessageQueued = false,
   ) {
     if (evt.type !== "server_hello") {
@@ -476,18 +521,21 @@ export function createThreadEventReducer(deps: ThreadEventReducerDeps) {
       }
 
       let sentPendingFirstMessage = false;
-      if (pendingFirstMessage && pendingFirstMessage.trim()) {
+      const normalizedPendingFirstMessage = pendingFirstMessage
+        ? normalizePendingThreadMessage(pendingFirstMessage)
+        : null;
+      if (normalizedPendingFirstMessage && messageHasPayload(normalizedPendingFirstMessage)) {
         if (resumedBusy) {
           if (!pendingFirstMessageQueued) {
             RUNTIME.pendingThreadMessages.set(threadId, [
-              pendingFirstMessage.trim(),
+              normalizedPendingFirstMessage,
               ...(RUNTIME.pendingThreadMessages.get(threadId) ?? []),
             ]);
           }
         } else {
           sentPendingFirstMessage = pendingFirstMessageQueued
             ? flushOneQueuedThreadMessage(get, set, threadId)
-            : sendUserMessageToThread(get, set, threadId, pendingFirstMessage);
+            : sendUserMessageToThread(get, set, threadId, normalizedPendingFirstMessage);
         }
       }
 
@@ -805,7 +853,22 @@ export function createThreadEventReducer(deps: ThreadEventReducerDeps) {
       }
       if (cmid) {
         const seen = RUNTIME.optimisticUserMessageIds.get(threadId);
-        if (seen && seen.has(cmid)) return;
+        if (seen && seen.has(cmid)) {
+          if (evt.attachments && evt.attachments.length > 0) {
+            updateFeedItem(set, threadId, cmid, (item) =>
+              item.kind === "message" && item.role === "user"
+                ? { ...item, attachments: evt.attachments }
+                : item
+            );
+          }
+          if (evt.attachments && evt.attachments.length > 0) {
+            const thread = get().threads.find((entry) => entry.id === threadId);
+            if (thread) {
+              void get().refreshWorkspaceFiles(thread.workspaceId);
+            }
+          }
+          return;
+        }
       }
 
       pushFeedItem(set, threadId, {
@@ -814,7 +877,15 @@ export function createThreadEventReducer(deps: ThreadEventReducerDeps) {
         role: "user",
         ts: deps.nowIso(),
         text: evt.text,
+        ...(evt.attachments && evt.attachments.length > 0 ? { attachments: evt.attachments } : {}),
       });
+
+      if (evt.attachments && evt.attachments.length > 0) {
+        const thread = get().threads.find((entry) => entry.id === threadId);
+        if (thread) {
+          void get().refreshWorkspaceFiles(thread.workspaceId);
+        }
+      }
 
       set((s) => ({
         threads: s.threads.map((t) =>
@@ -987,7 +1058,7 @@ export function createThreadEventReducer(deps: ThreadEventReducerDeps) {
     set: StoreSet,
     threadId: string,
     url: string,
-    pendingFirstMessage?: string,
+    pendingFirstMessage?: string | PendingThreadMessage,
     pendingFirstMessageQueued = false,
   ) {
     if (RUNTIME.threadSockets.has(threadId)) return;

--- a/apps/desktop/src/app/types.ts
+++ b/apps/desktop/src/app/types.ts
@@ -1,5 +1,6 @@
 import type {
   ApprovalRiskCode,
+  ClientMessage,
   ChildModelRoutingMode,
   ConfigSubset,
   ProviderName,
@@ -79,6 +80,17 @@ export type WorkspaceDefaultsPatch = Partial<Omit<WorkspaceRecord, "userProfile"
 
 export type ThreadStatus = "active" | "disconnected";
 export type ThreadBusyPolicy = "reject" | "steer" | "queue";
+export type ThreadMessageDraftAttachment = NonNullable<Extract<ClientMessage, { type: "user_message" }>["attachments"]>[number];
+export type ThreadMessageAttachment = NonNullable<Extract<ServerEvent, { type: "user_message" }>["attachments"]>[number];
+export type PendingThreadMessage = {
+  text: string;
+  attachments?: ThreadMessageDraftAttachment[];
+};
+export type ComposerAttachment = ThreadMessageDraftAttachment & {
+  id: string;
+  kind: ThreadMessageAttachment["kind"];
+  sizeBytes: number;
+};
 
 export type ThreadTitleSource = "default" | "model" | "heuristic" | "manual";
 

--- a/apps/desktop/src/ui/ChatView.tsx
+++ b/apps/desktop/src/ui/ChatView.tsx
@@ -1,11 +1,33 @@
 import { createContext, memo, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
-import type { KeyboardEvent as ReactKeyboardEvent } from "react";
+import type {
+  ChangeEvent as ReactChangeEvent,
+  DragEvent as ReactDragEvent,
+  KeyboardEvent as ReactKeyboardEvent,
+} from "react";
 
-import { AlertTriangleIcon, LoaderCircleIcon, MessageSquareIcon, RotateCcwIcon } from "lucide-react";
+import {
+  AlertTriangleIcon,
+  FileTextIcon,
+  FilmIcon,
+  ImageIcon,
+  LoaderCircleIcon,
+  MessageSquareIcon,
+  Music4Icon,
+  PaperclipIcon,
+  RotateCcwIcon,
+  XIcon,
+} from "lucide-react";
 import coworkIconSvg from "../../build/icon.icon/Assets/svgviewer-output.svg";
 
 import { useAppStore } from "../app/store";
-import type { FeedItem, ThreadAgentSummary, ThreadPendingSteer, ThreadStatus } from "../app/types";
+import type {
+  ComposerAttachment,
+  FeedItem,
+  ThreadAgentSummary,
+  ThreadMessageAttachment,
+  ThreadPendingSteer,
+  ThreadStatus,
+} from "../app/types";
 import {
   Conversation,
   ConversationContent,
@@ -48,6 +70,12 @@ import type { ProviderName } from "../lib/wsProtocol";
 import { cn } from "../lib/utils";
 import { formatCost, formatTokenCount } from "../../../../src/session/pricing";
 import {
+  classifyUserMessageAttachmentKind,
+  inferUserMessageAttachmentMimeType,
+  supportsUserMessageAttachmentMimeType,
+  supportsUserMessageAttachments,
+} from "../../../../src/shared/messageAttachments";
+import {
   buildCitationOverflowFilePathsByMessageId,
   buildCitationSourcesByMessageId,
   buildCitationUrlsByMessageId,
@@ -74,6 +102,87 @@ function useChatViewContext(): ChatViewContextValue {
     throw new Error("ChatViewContext is not available");
   }
   return context;
+}
+
+function attachmentKindLabel(kind: ThreadMessageAttachment["kind"]): string {
+  switch (kind) {
+    case "image":
+      return "Image";
+    case "audio":
+      return "Audio";
+    case "video":
+      return "Video";
+    case "document":
+      return "PDF";
+  }
+}
+
+function AttachmentKindIcon(props: { kind: ThreadMessageAttachment["kind"]; className?: string }) {
+  switch (props.kind) {
+    case "image":
+      return <ImageIcon className={props.className} />;
+    case "audio":
+      return <Music4Icon className={props.className} />;
+    case "video":
+      return <FilmIcon className={props.className} />;
+    case "document":
+      return <FileTextIcon className={props.className} />;
+  }
+}
+
+function formatAttachmentSize(sizeBytes: number): string {
+  if (sizeBytes < 1024) return `${sizeBytes} B`;
+  if (sizeBytes < 1024 * 1024) return `${(sizeBytes / 1024).toFixed(1)} KB`;
+  return `${(sizeBytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function attachmentInputAcceptValue(opts: {
+  provider: string;
+  model: string;
+} | null): string | undefined {
+  if (!opts || !supportsUserMessageAttachments(opts.provider as ProviderName, opts.model)) {
+    return undefined;
+  }
+  if (opts.provider === "google") {
+    return "image/*,audio/*,video/*,application/pdf";
+  }
+  return "image/*";
+}
+
+function attachmentHintForTarget(opts: {
+  provider: string;
+  model: string;
+} | null): string {
+  if (!opts) return "Drop files to attach them.";
+  if (!supportsUserMessageAttachments(opts.provider as ProviderName, opts.model)) {
+    return "Current model does not support attachments.";
+  }
+  return opts.provider === "google"
+    ? "Drop images, audio, video, or PDFs."
+    : "Drop images to attach them.";
+}
+
+async function fileToBase64(file: File): Promise<string> {
+  const dataUrl = await new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (typeof reader.result !== "string") {
+        reject(new Error(`Failed to read ${file.name}.`));
+        return;
+      }
+      resolve(reader.result);
+    };
+    reader.onerror = () => {
+      reject(new Error(`Failed to read ${file.name}.`));
+    };
+    reader.readAsDataURL(file);
+  });
+
+  const separator = dataUrl.indexOf(",");
+  if (separator < 0) {
+    throw new Error(`Failed to read ${file.name}.`);
+  }
+  return dataUrl.slice(separator + 1);
 }
 
 export function reasoningLabelForMode(mode: "reasoning" | "summary"): string {
@@ -176,12 +285,15 @@ export function getComposerSubmitState(opts: {
   busy: boolean;
   hasPromptModal: boolean;
   composerText: string;
+  attachmentCount: number;
   pendingSteer: ThreadPendingSteer | null;
   sessionId: string | null;
   threadStatus: ThreadStatus;
 }): { status: "ready" | "streaming"; disabled: boolean; mode: "send" | "steer-ready" | "steer-pending" } {
   const composerText = opts.composerText.trim();
   const hasComposerText = composerText.length > 0;
+  const hasAttachments = opts.attachmentCount > 0;
+  const hasComposerInput = hasComposerText || hasAttachments;
   const steerPending = opts.busy
     && hasComposerText
     && opts.pendingSteer?.status === "sending"
@@ -200,13 +312,20 @@ export function getComposerSubmitState(opts: {
     mode: opts.busy ? (steerPending ? "steer-pending" : "steer-ready") : "send",
     disabled:
       opts.hasPromptModal
-      || !hasComposerText
+      || !hasComposerInput
+      || (opts.busy && hasAttachments)
       || steerPending
       || (opts.busy && (!opts.sessionId || opts.threadStatus !== "active")),
   };
 }
 
-export function composerBusyHint(submitState: ReturnType<typeof getComposerSubmitState>): string {
+export function composerBusyHint(
+  submitState: ReturnType<typeof getComposerSubmitState>,
+  opts?: { hasAttachments?: boolean; busy?: boolean },
+): string {
+  if (opts?.busy && opts?.hasAttachments) {
+    return "Wait for the current run to finish before sending attachments.";
+  }
   if (submitState.status === "streaming") {
     return "Type to steer, or use stop to cancel.";
   }
@@ -323,6 +442,50 @@ export function ChatThreadHeader(props: {
   );
 }
 
+function MessageAttachmentList(props: {
+  attachments: ThreadMessageAttachment[];
+  showSize?: boolean;
+  removable?: boolean;
+  onRemove?: (attachmentId: string) => void;
+  attachmentIds?: string[];
+  sizeById?: Record<string, number>;
+}) {
+  return (
+    <div className="mt-2 flex flex-wrap gap-2">
+      {props.attachments.map((attachment, index) => {
+        const attachmentId = props.attachmentIds?.[index];
+        const sizeBytes = attachmentId ? props.sizeById?.[attachmentId] : undefined;
+        return (
+          <div
+            key={`${attachment.filename}:${attachment.path ?? index}`}
+            className="inline-flex max-w-full items-center gap-2 rounded-full border border-border/60 bg-muted/30 px-2.5 py-1 text-xs text-foreground/90"
+            title={attachment.path ?? attachment.filename}
+          >
+            <AttachmentKindIcon kind={attachment.kind} className="size-3.5 shrink-0 text-muted-foreground" />
+            <span className="truncate font-medium">{attachment.filename}</span>
+            <span className="shrink-0 text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+              {attachmentKindLabel(attachment.kind)}
+            </span>
+            {props.showSize && typeof sizeBytes === "number" ? (
+              <span className="shrink-0 text-muted-foreground">{formatAttachmentSize(sizeBytes)}</span>
+            ) : null}
+            {props.removable && attachmentId && props.onRemove ? (
+              <button
+                type="button"
+                className="inline-flex size-4 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                onClick={() => props.onRemove?.(attachmentId)}
+                aria-label={`Remove ${attachment.filename}`}
+              >
+                <XIcon className="size-3" />
+              </button>
+            ) : null}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
 const FeedRow = memo(function FeedRow(props: {
   item: FeedItem;
   citationUrlsByIndex?: ReadonlyMap<number, string>;
@@ -346,7 +509,12 @@ const FeedRow = memo(function FeedRow(props: {
               {item.text}
             </MessageResponse>
           ) : (
-            <div className="whitespace-pre-wrap">{item.text}</div>
+            <div>
+              {item.text ? <div className="whitespace-pre-wrap">{item.text}</div> : null}
+              {item.attachments && item.attachments.length > 0 ? (
+                <MessageAttachmentList attachments={item.attachments} />
+              ) : null}
+            </div>
           )}
         </MessageContent>
         {hasSources && (
@@ -499,6 +667,8 @@ function ThreadModelSelector({
 export function ChatView() {
   const bootstrapPending = useAppStore((s) => s.bootstrapPending);
   const selectedThreadId = useAppStore((s) => s.selectedThreadId);
+  const workspaces = useAppStore((s) => s.workspaces);
+  const providerDefaultModelByProvider = useAppStore((s) => s.providerDefaultModelByProvider);
   const thread = useAppStore((s) => {
     if (!s.selectedThreadId) return null;
     return s.threads.find((t) => t.id === s.selectedThreadId) ?? null;
@@ -518,6 +688,9 @@ export function ChatView() {
     () => new Map(),
   );
   const [cancelScopeDialogOpen, setCancelScopeDialogOpen] = useState(false);
+  const [composerAttachments, setComposerAttachments] = useState<ComposerAttachment[]>([]);
+  const [composerAttachmentError, setComposerAttachmentError] = useState<string | null>(null);
+  const [composerDragActive, setComposerDragActive] = useState(false);
 
   const setComposerText = useAppStore((s) => s.setComposerText);
   const sendMessage = useAppStore((s) => s.sendMessage);
@@ -527,6 +700,7 @@ export function ChatView() {
   const newThread = useAppStore((s) => s.newThread);
 
   const feedRef = useRef<HTMLDivElement | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const lastCountRef = useRef<number>(0);
   const autoScrolledThreadIdRef = useRef<string | null>(null);
@@ -563,12 +737,44 @@ export function ChatView() {
     () => countActiveChildAgents(rt?.agents ?? []),
     [rt?.agents],
   );
+  const currentWorkspace = useMemo(
+    () => (thread ? workspaces.find((workspace) => workspace.id === thread.workspaceId) ?? null : null),
+    [thread, workspaces],
+  );
+  const attachmentTarget = useMemo(() => {
+    if (rt?.config?.provider && rt?.config?.model) {
+      return { provider: rt.config.provider, model: rt.config.model };
+    }
+    const provider = currentWorkspace?.defaultProvider ?? "google";
+    const model = currentWorkspace?.defaultModel ?? providerDefaultModelByProvider[provider];
+    return model ? { provider, model } : null;
+  }, [currentWorkspace, providerDefaultModelByProvider, rt?.config?.model, rt?.config?.provider]);
+  const attachmentsAvailable = !attachmentTarget
+    || supportsUserMessageAttachments(attachmentTarget.provider, attachmentTarget.model);
+  const composerAttachmentSizeById = useMemo<Record<string, number>>(
+    () => Object.fromEntries(composerAttachments.map((attachment) => [attachment.id, attachment.sizeBytes])),
+    [composerAttachments],
+  );
+  const composerFeedAttachments = useMemo<ThreadMessageAttachment[]>(
+    () =>
+      composerAttachments.map((attachment) => ({
+        filename: attachment.filename,
+        mimeType: attachment.mimeType,
+        kind: attachment.kind,
+      })),
+    [composerAttachments],
+  );
+  const composerAttachmentDrafts = useMemo(
+    () => composerAttachments.map(({ id: _id, kind: _kind, sizeBytes: _sizeBytes, ...draft }) => draft),
+    [composerAttachments],
+  );
   const contextValue = useMemo<ChatViewContextValue>(
     () => ({
       developerMode,
     }),
     [developerMode],
   );
+  const busy = rt?.busy === true;
 
   const handleStop = useCallback(() => {
     if (!selectedThreadId) return;
@@ -584,6 +790,84 @@ export function ChatView() {
     cancelThread(selectedThreadId, { includeSubagents });
     setCancelScopeDialogOpen(false);
   }, [cancelThread, selectedThreadId]);
+
+  const removeComposerAttachment = useCallback((attachmentId: string) => {
+    setComposerAttachments((current) => current.filter((attachment) => attachment.id !== attachmentId));
+    setComposerAttachmentError(null);
+  }, []);
+
+  const addFilesToComposer = useCallback(async (files: File[] | FileList) => {
+    const nextFiles = Array.from(files);
+    if (nextFiles.length === 0) return;
+
+    if (attachmentTarget && !supportsUserMessageAttachments(attachmentTarget.provider, attachmentTarget.model)) {
+      setComposerAttachmentError("Current model does not support attachments.");
+      return;
+    }
+
+    const nextAttachments: ComposerAttachment[] = [];
+    let firstError: string | null = null;
+    for (const file of nextFiles) {
+      const mimeType = inferUserMessageAttachmentMimeType(file.name, file.type);
+      if (!mimeType) {
+        firstError ??= `Unsupported file type for ${file.name}.`;
+        continue;
+      }
+      const kind = classifyUserMessageAttachmentKind(mimeType);
+      if (!kind) {
+        firstError ??= `Unsupported file type for ${file.name}.`;
+        continue;
+      }
+      if (
+        attachmentTarget
+        && !supportsUserMessageAttachmentMimeType(attachmentTarget.provider, attachmentTarget.model, mimeType)
+      ) {
+        firstError ??= `${file.name} is not supported by the current model. ${attachmentHintForTarget(attachmentTarget)}`;
+        continue;
+      }
+
+      try {
+        nextAttachments.push({
+          id: crypto.randomUUID(),
+          filename: file.name,
+          mimeType,
+          kind,
+          sizeBytes: file.size,
+          contentBase64: await fileToBase64(file),
+        });
+      } catch (error) {
+        firstError ??= error instanceof Error ? error.message : `Failed to read ${file.name}.`;
+      }
+    }
+
+    if (nextAttachments.length > 0) {
+      setComposerAttachments((current) => {
+        const seen = new Set(current.map((attachment) => `${attachment.filename}:${attachment.sizeBytes}:${attachment.mimeType}`));
+        const deduped = nextAttachments.filter((attachment) => {
+          const signature = `${attachment.filename}:${attachment.sizeBytes}:${attachment.mimeType}`;
+          if (seen.has(signature)) return false;
+          seen.add(signature);
+          return true;
+        });
+        return [...current, ...deduped];
+      });
+    }
+
+    setComposerAttachmentError(firstError);
+  }, [attachmentTarget]);
+
+  const handleComposerFileInput = useCallback(async (event: ReactChangeEvent<HTMLInputElement>) => {
+    if (!event.currentTarget.files) return;
+    await addFilesToComposer(event.currentTarget.files);
+    event.currentTarget.value = "";
+  }, [addFilesToComposer]);
+
+  const handleComposerDrop = useCallback(async (event: ReactDragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    setComposerDragActive(false);
+    if (!event.dataTransfer.files || event.dataTransfer.files.length === 0) return;
+    await addFilesToComposer(event.dataTransfer.files);
+  }, [addFilesToComposer]);
 
   useEffect(() => {
     const el = feedRef.current;
@@ -654,6 +938,12 @@ export function ChatView() {
   }, [selectedThreadId]);
 
   useEffect(() => {
+    setComposerAttachments([]);
+    setComposerAttachmentError(null);
+    setComposerDragActive(false);
+  }, [selectedThreadId]);
+
+  useEffect(() => {
     if (!rt?.busy || activeChildAgentCount === 0) {
       setCancelScopeDialogOpen(false);
     }
@@ -664,10 +954,24 @@ export function ChatView() {
     (event: ReactKeyboardEvent<HTMLTextAreaElement>) => {
       if (event.key === "Enter" && !event.shiftKey) {
         event.preventDefault();
-        void sendMessage(composerText, resolveComposerBusyPolicy(rt?.busy === true));
+        if (busy && composerAttachments.length > 0) {
+          setComposerAttachmentError("Wait for the current run to finish before sending attachments.");
+          return;
+        }
+        void (async () => {
+          await sendMessage(
+            composerText,
+            resolveComposerBusyPolicy(rt?.busy === true),
+            composerAttachmentDrafts,
+          );
+          if (!busy) {
+            setComposerAttachments([]);
+            setComposerAttachmentError(null);
+          }
+        })();
       }
     },
-    [composerText, rt?.busy, sendMessage],
+    [busy, composerAttachmentDrafts, composerAttachments.length, composerText, rt?.busy, sendMessage],
   );
 
   if (!selectedThreadId || !thread) {
@@ -688,7 +992,6 @@ export function ChatView() {
     );
   }
 
-  const busy = rt?.busy === true;
   const disabled = hasPromptModal;
   const transcriptOnly = rt?.transcriptOnly === true;
   const hydrating = rt?.hydrating === true || (bootstrapPending && Boolean(selectedThreadId) && Boolean(thread) && rt === null);
@@ -710,6 +1013,7 @@ export function ChatView() {
     busy,
     hasPromptModal,
     composerText,
+    attachmentCount: composerAttachments.length,
     pendingSteer: rt?.pendingSteer ?? null,
     sessionId: rt?.sessionId ?? null,
     threadStatus: thread.status,
@@ -796,15 +1100,74 @@ export function ChatView() {
 
       <div className="relative border-t border-border/60 px-4 py-1.5 flex flex-col shrink-0" style={{ height: messageBarHeight }}>
         <MessageBarResizer />
-        <PromptInputRoot>
+        <input
+          ref={fileInputRef}
+          type="file"
+          multiple
+          accept={attachmentInputAcceptValue(attachmentTarget)}
+          className="hidden"
+          onChange={(event) => {
+            void handleComposerFileInput(event);
+          }}
+        />
+        <PromptInputRoot
+          className={cn(
+            composerDragActive && "border border-primary/30 bg-primary/5 ring-2 ring-primary/25",
+          )}
+          onDragOver={(event) => {
+            event.preventDefault();
+            event.dataTransfer.dropEffect = "copy";
+            if (!composerDragActive) {
+              setComposerDragActive(true);
+            }
+          }}
+          onDragLeave={() => {
+            setComposerDragActive(false);
+          }}
+          onDrop={(event) => {
+            void handleComposerDrop(event);
+          }}
+        >
             <PromptInputForm
               onSubmit={(event) => {
                 event.preventDefault();
-                if (!composerText.trim()) return;
-                void sendMessage(composerText, resolveComposerBusyPolicy(busy));
+                if (!composerText.trim() && composerAttachments.length === 0) return;
+                if (busy && composerAttachments.length > 0) {
+                  setComposerAttachmentError("Wait for the current run to finish before sending attachments.");
+                  return;
+                }
+                void (async () => {
+                  await sendMessage(
+                    composerText,
+                    resolveComposerBusyPolicy(busy),
+                    composerAttachmentDrafts,
+                  );
+                  if (!busy) {
+                    setComposerAttachments([]);
+                    setComposerAttachmentError(null);
+                  }
+                })();
               }}
             >
-              <PromptInputBody>
+              <PromptInputBody className="flex-col gap-2">
+                {composerAttachments.length > 0 ? (
+                  <MessageAttachmentList
+                    attachments={composerFeedAttachments}
+                    removable
+                    showSize
+                    attachmentIds={composerAttachments.map((attachment) => attachment.id)}
+                    sizeById={composerAttachmentSizeById}
+                    onRemove={removeComposerAttachment}
+                  />
+                ) : null}
+                {composerDragActive ? (
+                  <div className="rounded-xl border border-dashed border-primary/40 bg-primary/5 px-3 py-2 text-xs text-primary">
+                    {attachmentHintForTarget(attachmentTarget)}
+                  </div>
+                ) : null}
+                {composerAttachmentError ? (
+                  <div className="px-1.5 text-xs text-destructive">{composerAttachmentError}</div>
+                ) : null}
                 <PromptInputTextarea
                   ref={textareaRef}
                   value={composerText}
@@ -817,6 +1180,18 @@ export function ChatView() {
               </PromptInputBody>
               <PromptInputFooter>
                 <PromptInputTools>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="ghost"
+                    className="h-7 rounded-full px-2.5 text-xs text-muted-foreground hover:text-foreground"
+                    disabled={!attachmentsAvailable}
+                    onClick={() => fileInputRef.current?.click()}
+                    title={attachmentHintForTarget(attachmentTarget)}
+                    aria-label="Attach files"
+                  >
+                    <PaperclipIcon className="size-3.5" />
+                  </Button>
                   {modelSelectorConfig ? (
                     <ThreadModelSelector
                       threadId={selectedThreadId}
@@ -828,7 +1203,10 @@ export function ChatView() {
                 </PromptInputTools>
                 <div className={cn("flex shrink-0 items-center gap-2", busy ? "opacity-100" : "opacity-70")}>
                   <span className="hidden max-w-[18rem] text-right text-xs leading-tight text-muted-foreground sm:block">
-                    {composerBusyHint(composerSubmitState)}
+                    {composerBusyHint(composerSubmitState, {
+                      busy,
+                      hasAttachments: composerAttachments.length > 0,
+                    })}
                   </span>
                   <PromptInputSubmit
                     mode={composerSubmitState.mode}

--- a/apps/desktop/test/store-feed-mapping.test.ts
+++ b/apps/desktop/test/store-feed-mapping.test.ts
@@ -8,6 +8,63 @@ import {
 } from "../src/app/store.feedMapping";
 
 describe("desktop transcript feed mapping", () => {
+  test("merges optimistic user attachment previews with the later server echo path", () => {
+    const transcript: TranscriptEvent[] = [
+      {
+        ts: "2024-01-01T00:00:00.000Z",
+        threadId: "thread-1",
+        direction: "client",
+        payload: {
+          type: "user_message",
+          text: "See attached.",
+          clientMessageId: "cm-attach",
+          attachments: [
+            {
+              filename: "photo.png",
+              mimeType: "image/png",
+              kind: "image",
+            },
+          ],
+        },
+      },
+      {
+        ts: "2024-01-01T00:00:01.000Z",
+        threadId: "thread-1",
+        direction: "server",
+        payload: {
+          type: "user_message",
+          sessionId: "thread-session",
+          text: "See attached.",
+          clientMessageId: "cm-attach",
+          attachments: [
+            {
+              filename: "photo.png",
+              mimeType: "image/png",
+              kind: "image",
+              path: "/workspace/photo.png",
+            },
+          ],
+        },
+      },
+    ];
+
+    const feed = mapTranscriptToFeed(transcript);
+    expect(feed).toHaveLength(1);
+    expect(feed[0]).toMatchObject({
+      kind: "message",
+      role: "user",
+      text: "See attached.",
+      attachments: [
+        {
+          filename: "photo.png",
+          mimeType: "image/png",
+          kind: "image",
+          path: "/workspace/photo.png",
+        },
+      ],
+    });
+  });
+
   test("dedupes streamed reasoning against legacy reasoning finals while preserving trace order", () => {
     const transcript: TranscriptEvent[] = [
       {

--- a/apps/desktop/test/thread-reconnect.test.ts
+++ b/apps/desktop/test/thread-reconnect.test.ts
@@ -1245,6 +1245,79 @@ describe("thread reconnect", () => {
     expect(state.threads.find((t) => t.id === activeThreadId)?.status).toBe("active");
   });
 
+  test("sendMessage supports attachment-only user messages and enriches them with the saved workspace path", async () => {
+    await useAppStore.getState().selectThread(threadId);
+
+    const threadSocket = socketByClient("desktop");
+    emitServerHello(threadSocket, "thread-session");
+    const activeThreadId = canonicalThreadId("thread-session", threadId);
+
+    await useAppStore.getState().sendMessage("", "reject", [
+      {
+        filename: "photo.png",
+        mimeType: "image/png",
+        contentBase64: "aGVsbG8=",
+      },
+    ]);
+
+    const sentUserMessages = threadSocket.sent.filter((message) => message?.type === "user_message");
+    expect(sentUserMessages).toHaveLength(1);
+    expect(sentUserMessages[0]).toMatchObject({
+      text: "",
+      attachments: [
+        {
+          filename: "photo.png",
+          mimeType: "image/png",
+          contentBase64: "aGVsbG8=",
+        },
+      ],
+    });
+
+    const optimisticFeed = useAppStore.getState().threadRuntimeById[activeThreadId]?.feed ?? [];
+    expect(optimisticFeed[0]).toMatchObject({
+      kind: "message",
+      role: "user",
+      text: "",
+      attachments: [
+        {
+          filename: "photo.png",
+          mimeType: "image/png",
+          kind: "image",
+        },
+      ],
+    });
+
+    threadSocket.emit({
+      type: "user_message",
+      sessionId: "thread-session",
+      text: "",
+      clientMessageId: sentUserMessages[0].clientMessageId,
+      attachments: [
+        {
+          filename: "photo.png",
+          mimeType: "image/png",
+          kind: "image",
+          path: "/tmp/workspace/photo.png",
+        },
+      ],
+    });
+
+    const updatedFeed = useAppStore.getState().threadRuntimeById[activeThreadId]?.feed ?? [];
+    expect(updatedFeed[0]).toMatchObject({
+      kind: "message",
+      role: "user",
+      text: "",
+      attachments: [
+        {
+          filename: "photo.png",
+          mimeType: "image/png",
+          kind: "image",
+          path: "/tmp/workspace/photo.png",
+        },
+      ],
+    });
+  });
+
   test("busy resume keeps reconnect firstMessage queued exactly once", async () => {
     await useAppStore.getState().selectThread(threadId);
 

--- a/src/runtime/googleNativeInteractions.ts
+++ b/src/runtime/googleNativeInteractions.ts
@@ -330,8 +330,18 @@ function turnFromToolMessage(message: ModelMessage): InteractionTurn | null {
         const textPart = buildTextContent(part.text);
         return textPart ? [textPart] : [];
       }
-      const imagePart = buildImageContent(part);
-      return imagePart ? [imagePart] : [];
+      if (part.type === "image") {
+        const imagePart = buildImageContent(part);
+        return imagePart ? [imagePart] : [];
+      }
+      return [];
+    });
+    const extraMultimodalParts = richResult.flatMap<Record<string, unknown>>((part) => {
+      if (part.type !== "audio" && part.type !== "video" && part.type !== "document") {
+        return [];
+      }
+      const multimodalPart = buildBinaryContent(part, part.type);
+      return multimodalPart ? [multimodalPart] : [];
     });
 
     const result =
@@ -350,6 +360,9 @@ function turnFromToolMessage(message: ModelMessage): InteractionTurn | null {
       ...(toolName ? { name: toolName } : {}),
       ...(signature ? { signature } : {}),
     });
+    if (extraMultimodalParts.length > 0) {
+      parts.push(...extraMultimodalParts);
+    }
   }
 
   return parts.length > 0 ? { role: "user", content: parts } : null;

--- a/src/runtime/googleNativeInteractions.ts
+++ b/src/runtime/googleNativeInteractions.ts
@@ -145,15 +145,22 @@ function buildTextContent(text: unknown): Record<string, unknown> | null {
   return value ? { type: "text", text: value } : null;
 }
 
-function buildImageContent(record: Record<string, unknown>): Record<string, unknown> | null {
+function buildBinaryContent(
+  record: Record<string, unknown>,
+  type: "image" | "audio" | "video" | "document",
+): Record<string, unknown> | null {
   const data = asNonEmptyString(record.data);
   const mimeType = asNonEmptyString(record.mimeType) ?? asNonEmptyString(record.mime_type);
   if (!data || !mimeType) return null;
   return {
-    type: "image",
+    type,
     data,
     mime_type: mimeType,
   };
+}
+
+function buildImageContent(record: Record<string, unknown>): Record<string, unknown> | null {
+  return buildBinaryContent(record, "image");
 }
 
 function convertRichContentParts(parts: unknown): Array<Record<string, unknown>> {
@@ -180,6 +187,12 @@ function convertRichContentParts(parts: unknown): Array<Record<string, unknown>>
     if (partType === "image" || partType === "input_image") {
       const imagePart = buildImageContent(record);
       if (imagePart) content.push(imagePart);
+      continue;
+    }
+
+    if (partType === "audio" || partType === "video" || partType === "document") {
+      const binaryPart = buildBinaryContent(record, partType);
+      if (binaryPart) content.push(binaryPart);
     }
   }
 

--- a/src/runtime/googleNativeInteractions.ts
+++ b/src/runtime/googleNativeInteractions.ts
@@ -311,10 +311,10 @@ function turnFromAssistantMessage(message: ModelMessage): InteractionTurn | null
   return parts.length > 0 ? { role: "model", content: parts } : null;
 }
 
-function turnFromToolMessage(message: ModelMessage): InteractionTurn | null {
-  if (!Array.isArray(message.content)) return null;
+function turnsFromToolMessage(message: ModelMessage): InteractionTurn[] {
+  if (!Array.isArray(message.content)) return [];
 
-  const parts: Array<Record<string, unknown>> = [];
+  const turns: InteractionTurn[] = [];
   for (const rawPart of message.content) {
     const record = asRecord(rawPart);
     if (!record) continue;
@@ -344,30 +344,34 @@ function turnFromToolMessage(message: ModelMessage): InteractionTurn | null {
       return multimodalPart ? [multimodalPart] : [];
     });
 
-    // Keep text + image/audio/video/document inside `function_result.result`, matching the
-    // Interactions schema for rich tool results. Do not emit binary parts as siblings of
-    // `function_result` (e.g. text-only `result` + top-level `document`) — the API rejects that.
-    const combinedResultParts = [...resultParts, ...extraMultimodalParts];
-    const firstPart = combinedResultParts[0];
     const result =
-      combinedResultParts.length === 0
+      resultParts.length === 0
         ? safeJsonStringify(record.output ?? record.content)
-        : combinedResultParts.length === 1 && firstPart?.type === "text"
-          ? firstPart.text
-          : combinedResultParts;
+        : resultParts.length === 1 && resultParts[0]?.type === "text"
+          ? resultParts[0].text
+          : resultParts;
     const signature = getGoogleThoughtSignature(record);
 
-    parts.push({
-      type: "function_result",
-      call_id: convertToolCallId(toolCallId),
-      result,
-      is_error: record.isError === true,
-      ...(toolName ? { name: toolName } : {}),
-      ...(signature ? { signature } : {}),
+    turns.push({
+      role: "user",
+      content: [{
+        type: "function_result",
+        call_id: convertToolCallId(toolCallId),
+        result,
+        is_error: record.isError === true,
+        ...(toolName ? { name: toolName } : {}),
+        ...(signature ? { signature } : {}),
+      }],
     });
+    if (extraMultimodalParts.length > 0) {
+      turns.push({
+        role: "user",
+        content: extraMultimodalParts,
+      });
+    }
   }
 
-  return parts.length > 0 ? { role: "user", content: parts } : null;
+  return turns;
 }
 
 function convertMessagesToInteractionsInput(
@@ -377,14 +381,16 @@ function convertMessagesToInteractionsInput(
 
   for (const msg of messages) {
     const role = msg.role;
+    if (role === "tool") {
+      input.push(...turnsFromToolMessage(msg));
+      continue;
+    }
     const turn =
       role === "user"
         ? turnFromUserMessage(msg)
         : role === "assistant"
           ? turnFromAssistantMessage(msg)
-          : role === "tool"
-            ? turnFromToolMessage(msg)
-            : null;
+          : null;
     if (turn) input.push(turn);
   }
 

--- a/src/runtime/googleNativeInteractions.ts
+++ b/src/runtime/googleNativeInteractions.ts
@@ -344,12 +344,17 @@ function turnFromToolMessage(message: ModelMessage): InteractionTurn | null {
       return multimodalPart ? [multimodalPart] : [];
     });
 
+    // Keep text + image/audio/video/document inside `function_result.result`, matching the
+    // Interactions schema for rich tool results. Do not emit binary parts as siblings of
+    // `function_result` (e.g. text-only `result` + top-level `document`) — the API rejects that.
+    const combinedResultParts = [...resultParts, ...extraMultimodalParts];
+    const firstPart = combinedResultParts[0];
     const result =
-      resultParts.length === 1 && resultParts[0]?.type === "text"
-        ? resultParts[0].text
-        : resultParts.length > 0
-          ? resultParts
-          : safeJsonStringify(record.output ?? record.content);
+      combinedResultParts.length === 0
+        ? safeJsonStringify(record.output ?? record.content)
+        : combinedResultParts.length === 1 && firstPart?.type === "text"
+          ? firstPart.text
+          : combinedResultParts;
     const signature = getGoogleThoughtSignature(record);
 
     parts.push({
@@ -360,9 +365,6 @@ function turnFromToolMessage(message: ModelMessage): InteractionTurn | null {
       ...(toolName ? { name: toolName } : {}),
       ...(signature ? { signature } : {}),
     });
-    if (extraMultimodalParts.length > 0) {
-      parts.push(...extraMultimodalParts);
-    }
   }
 
   return parts.length > 0 ? { role: "user", content: parts } : null;

--- a/src/runtime/openaiResponsesShared.ts
+++ b/src/runtime/openaiResponsesShared.ts
@@ -31,7 +31,13 @@ type ToolResultLike = {
   role: "toolResult";
   toolCallId: string;
   toolName: string;
-  content: Array<{ type: "text"; text: string } | { type: "image"; data: string; mimeType: string }>;
+  content: Array<
+    { type: "text"; text: string }
+    | { type: "image"; data: string; mimeType: string }
+    | { type: "audio"; data: string; mimeType: string }
+    | { type: "video"; data: string; mimeType: string }
+    | { type: "document"; data: string; mimeType: string }
+  >;
   isError?: boolean;
   timestamp?: number;
 };
@@ -331,11 +337,22 @@ export function convertResponsesMessages(
       .map((content) => content.text)
       .join("\n");
     const hasImages = msg.content.some((content) => content.type === "image");
+    const hasOtherFiles = msg.content.some(
+      (content) => content.type === "audio" || content.type === "video" || content.type === "document",
+    );
     const [callId] = msg.toolCallId.split("|");
     messages.push({
       type: "function_call_output",
       call_id: callId,
-      output: sanitizeSurrogates(textResult.length > 0 ? textResult : "(see attached image)"),
+      output: sanitizeSurrogates(
+        textResult.length > 0
+          ? textResult
+          : hasImages
+            ? "(see attached image)"
+            : hasOtherFiles
+              ? "(see attached file)"
+              : "",
+      ),
     });
 
     if (hasImages && model.input.includes("image")) {

--- a/src/runtime/openaiResponsesShared.ts
+++ b/src/runtime/openaiResponsesShared.ts
@@ -37,7 +37,7 @@ type ToolResultLike = {
 };
 
 type PiMessageLike =
-  | { role: "user"; content: string }
+  | { role: "user"; content: string | Array<Record<string, unknown>> }
   | AssistantMessageLike
   | ToolResultLike;
 
@@ -61,6 +61,50 @@ function shortHash(str: string): string {
 
 export function sanitizeSurrogates(text: string): string {
   return text.replace(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g, "");
+}
+
+function userContentToResponsesInput(
+  content: string | Array<Record<string, unknown>>,
+): Array<Record<string, unknown>> {
+  if (typeof content === "string") {
+    return [{ type: "input_text", text: sanitizeSurrogates(content) }];
+  }
+
+  const parts: Array<Record<string, unknown>> = [];
+  for (const rawPart of content) {
+    const part = typeof rawPart === "object" && rawPart !== null ? rawPart : null;
+    if (!part) continue;
+    const text =
+      typeof part.text === "string"
+        ? part.text
+        : typeof part.inputText === "string"
+          ? part.inputText
+          : null;
+    if ((part.type === "text" || part.type === "input_text") && text) {
+      parts.push({
+        type: "input_text",
+        text: sanitizeSurrogates(text),
+      });
+      continue;
+    }
+
+    if (part.type === "image" || part.type === "input_image") {
+      const mimeType =
+        typeof part.mimeType === "string"
+          ? part.mimeType
+          : typeof part.mime_type === "string"
+            ? part.mime_type
+            : null;
+      const data = typeof part.data === "string" ? part.data : null;
+      if (!mimeType || !data) continue;
+      parts.push({
+        type: "input_image",
+        detail: "auto",
+        image_url: `data:${mimeType};base64,${data}`,
+      });
+    }
+  }
+  return parts;
 }
 
 function transformMessages(
@@ -215,9 +259,11 @@ export function convertResponsesMessages(
   let msgIndex = 0;
   for (const msg of transformedMessages) {
     if (msg.role === "user") {
+      const content = userContentToResponsesInput(msg.content);
+      if (content.length === 0) continue;
       messages.push({
         role: "user",
-        content: [{ type: "input_text", text: sanitizeSurrogates(msg.content) }],
+        content,
       });
       msgIndex += 1;
       continue;

--- a/src/runtime/piMessageBridge.ts
+++ b/src/runtime/piMessageBridge.ts
@@ -49,7 +49,15 @@ function safeJsonStringify(value: unknown): string {
 
 type PiToolResultTextContent = { type: "text"; text: string };
 type PiToolResultImageContent = { type: "image"; data: string; mimeType: string };
-export type PiToolResultContentPart = PiToolResultTextContent | PiToolResultImageContent;
+type PiToolResultAudioContent = { type: "audio"; data: string; mimeType: string };
+type PiToolResultVideoContent = { type: "video"; data: string; mimeType: string };
+type PiToolResultDocumentContent = { type: "document"; data: string; mimeType: string };
+export type PiToolResultContentPart =
+  | PiToolResultTextContent
+  | PiToolResultImageContent
+  | PiToolResultAudioContent
+  | PiToolResultVideoContent
+  | PiToolResultDocumentContent;
 
 function contentTextParts(content: unknown): string[] {
   if (typeof content === "string") return content.trim() ? [content] : [];
@@ -207,6 +215,13 @@ function normalizeToolResultContentPart(part: unknown): PiToolResultContentPart 
     return { type: "image", data, mimeType };
   }
 
+  if (record.type === "audio" || record.type === "video" || record.type === "document") {
+    const data = asNonEmptyString(record.data);
+    const mimeType = asNonEmptyString(record.mimeType);
+    if (!data || !mimeType) return null;
+    return { type: record.type, data, mimeType };
+  }
+
   return null;
 }
 
@@ -256,7 +271,16 @@ function toolResultContentToText(content: unknown): string {
   const richContent = richToolResultContentFromOutput(content);
   if (richContent) {
     return richContent
-      .map((part) => (part.type === "text" ? part.text : "[image]"))
+      .map((part) =>
+        part.type === "text"
+          ? part.text
+          : part.type === "image"
+            ? "[image]"
+            : part.type === "audio"
+              ? "[audio]"
+              : part.type === "video"
+                ? "[video]"
+                : "[document]")
       .join("\n");
   }
   return safeJsonStringify(content);
@@ -264,7 +288,7 @@ function toolResultContentToText(content: unknown): string {
 
 export function toolOutputFromPiToolResultContent(content: unknown): unknown {
   const richContent = richToolResultContentFromOutput(content);
-  if (richContent?.some((part) => part.type === "image")) {
+  if (richContent?.some((part) => part.type !== "text")) {
     return { type: "content", content: richContent };
   }
 

--- a/src/runtime/piMessageBridge.ts
+++ b/src/runtime/piMessageBridge.ts
@@ -80,6 +80,11 @@ function contentTextParts(content: unknown): string[] {
       continue;
     }
 
+    if (partType === "audio" || partType === "video" || partType === "document") {
+      parts.push("[non-text content]");
+      continue;
+    }
+
     if (
       record.image !== undefined ||
       record.imageUrl !== undefined ||
@@ -88,6 +93,50 @@ function contentTextParts(content: unknown): string[] {
     ) {
       parts.push("[non-text content]");
     }
+  }
+  return parts;
+}
+
+function userContentFromModelContent(
+  content: unknown,
+): string | Array<Record<string, unknown>> | null {
+  if (typeof content === "string") {
+    const text = content.trim();
+    return text ? text : null;
+  }
+  if (!Array.isArray(content)) return null;
+
+  const parts: Array<Record<string, unknown>> = [];
+  let hasNonTextPart = false;
+  for (const rawPart of content) {
+    if (typeof rawPart === "string") {
+      if (rawPart.trim()) {
+        parts.push({ type: "text", text: rawPart });
+      }
+      continue;
+    }
+
+    const record = asRecord(rawPart);
+    if (!record) continue;
+    const partType = asString(record.type);
+    const text = asString(record.text) ?? asString(record.inputText);
+    if ((partType === "text" || partType === "input_text") && text?.trim()) {
+      parts.push({ type: "text", text });
+      continue;
+    }
+
+    if (partType === "image" || partType === "input_image") {
+      const data = asNonEmptyString(record.data);
+      const mimeType = asNonEmptyString(record.mimeType) ?? asNonEmptyString(record.mime_type);
+      if (!data || !mimeType) continue;
+      hasNonTextPart = true;
+      parts.push({ type: "image", data, mimeType });
+    }
+  }
+
+  if (parts.length === 0) return null;
+  if (!hasNonTextPart && parts.length === 1 && parts[0]?.type === "text" && typeof parts[0]?.text === "string") {
+    return parts[0].text;
   }
   return parts;
 }
@@ -279,12 +328,11 @@ export function modelMessagesToPiMessages(messages: ModelMessage[], provider: st
     if (!role) continue;
 
     if (role === "user") {
-      const textParts = contentTextParts(message.content);
-      const text = textParts.join("\n").trim();
-      if (!text) continue;
+      const content = userContentFromModelContent(message.content);
+      if (!content) continue;
       out.push({
         role: "user",
-        content: text,
+        content,
         timestamp: now,
       } as PiMessage);
       continue;

--- a/src/runtime/toolOutputOverflow.ts
+++ b/src/runtime/toolOutputOverflow.ts
@@ -46,7 +46,7 @@ function joinToolResultText(parts: PiToolResultContentPart[]): string {
 
 function serializeToolOutputForSpill(output: unknown): string | null {
   const content = toolResultContentFromOutput(output);
-  if (content.some((part) => part.type === "image")) return null;
+  if (content.some((part) => part.type !== "text")) return null;
 
   if (typeof output === "string") return output;
   if (typeof output === "number" || typeof output === "boolean" || typeof output === "bigint") {
@@ -132,7 +132,7 @@ export async function maybeSpillToolOutputToWorkspace(opts: {
   if (isToolOutputOverflowExempt(opts.toolName)) return null;
 
   const content = toolResultContentFromOutput(opts.output);
-  if (content.some((part) => part.type === "image")) return null;
+  if (content.some((part) => part.type !== "text")) return null;
 
   const inlineText = joinToolResultText(content);
   if (inlineText.length <= threshold) return null;

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -37,6 +37,10 @@ import type {
   PersistentAgentSummary,
   SessionKind,
 } from "../shared/agents";
+import type {
+  UserMessageAttachment,
+  UserMessageAttachmentDraft,
+} from "../shared/messageAttachments";
 export { ASK_SKIP_TOKEN } from "../shared/ask";
 
 export type MCPServerEventSource = "workspace" | "user" | "system" | "workspace_legacy" | "user_legacy";
@@ -89,7 +93,13 @@ export type SessionConfigState = {
 
 export type ClientMessage =
   | { type: "client_hello"; client: "tui" | "cli" | string; version?: string }
-  | { type: "user_message"; sessionId: string; text: string; clientMessageId?: string }
+  | {
+    type: "user_message";
+    sessionId: string;
+    text: string;
+    attachments?: UserMessageAttachmentDraft[];
+    clientMessageId?: string;
+  }
   | {
     type: "steer_message";
     sessionId: string;
@@ -362,7 +372,13 @@ export type ServerEvent =
     text: string;
     clientMessageId?: string;
   }
-  | { type: "user_message"; sessionId: string; text: string; clientMessageId?: string }
+  | {
+    type: "user_message";
+    sessionId: string;
+    text: string;
+    attachments?: UserMessageAttachment[];
+    clientMessageId?: string;
+  }
   | {
     type: "model_stream_chunk";
     sessionId: string;
@@ -531,7 +547,7 @@ export type ServerEvent =
   | { type: "error"; sessionId: string; message: string; code: ServerErrorCode; source: ServerErrorSource }
   | { type: "pong"; sessionId: string };
 
-export const WEBSOCKET_PROTOCOL_VERSION = "7.28";
+export const WEBSOCKET_PROTOCOL_VERSION = "7.29";
 
 export const CLIENT_MESSAGE_TYPES = [
   "client_hello",

--- a/src/server/protocolEventParser.ts
+++ b/src/server/protocolEventParser.ts
@@ -10,6 +10,7 @@ import {
   OPENAI_TEXT_VERBOSITY_VALUES,
 } from "../shared/openaiCompatibleOptions";
 import { CHILD_MODEL_ROUTING_MODES } from "../types";
+import type { UserMessageAttachment } from "../shared/messageAttachments";
 import {
   agentExecutionStateSchema,
   agentModeSchema,
@@ -32,6 +33,12 @@ const nonEmptyTrimmedStringSchema = z.preprocess((value) => {
 const stringArraySchema = z.array(z.string());
 const unknownArraySchema = z.array(z.unknown());
 const recordUnknownSchema = z.record(z.string(), z.unknown());
+const userMessageAttachmentSchema: z.ZodType<UserMessageAttachment> = z.object({
+  filename: z.string().trim().min(1),
+  mimeType: z.string().trim().min(1),
+  kind: z.enum(["image", "audio", "video", "document"]),
+  path: z.string().optional(),
+}).strict();
 const openAiCompatibleProviderOptionsSchema = z.object({
   reasoningEffort: z.enum(OPENAI_REASONING_EFFORT_VALUES).optional(),
   reasoningSummary: z.enum(OPENAI_REASONING_SUMMARY_VALUES).optional(),
@@ -300,6 +307,7 @@ const serverEventSchema = z.discriminatedUnion("type", [
     type: z.literal("user_message"),
     sessionId: nonEmptyTrimmedStringSchema,
     text: z.string(),
+    attachments: z.array(userMessageAttachmentSchema).optional(),
     clientMessageId: z.string().optional(),
   }).passthrough(),
   modelStreamChunkSchema,

--- a/src/server/protocolParser.ts
+++ b/src/server/protocolParser.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 import { parseMCPServerConfig, parseMCPServersDocument } from "../mcp/configRegistry";
 import { resolveProviderAuthMethod } from "../providers/authRegistry";
+import type { UserMessageAttachmentDraft } from "../shared/messageAttachments";
 import {
   CODEX_WEB_SEARCH_BACKEND_VALUES,
   CODEX_WEB_SEARCH_CONTEXT_SIZE_VALUES,
@@ -122,6 +123,11 @@ const googleProviderOptionsSchema = z.object({
   thinkingConfig: z.object({
     thinkingLevel: z.enum(GOOGLE_THINKING_LEVEL_VALUES).optional(),
   }).strict().optional(),
+}).strict();
+const userMessageAttachmentDraftSchema: z.ZodType<UserMessageAttachmentDraft> = z.object({
+  filename: requiredNonEmptyTrimmedString("user_message attachments[].filename must be non-empty"),
+  mimeType: requiredNonEmptyTrimmedString("user_message attachments[].mimeType must be non-empty"),
+  contentBase64: requiredNonEmptyTrimmedString("user_message attachments[].contentBase64 must be non-empty"),
 }).strict();
 
 const editableOpenAiProviderOptionsByProviderSchema = z.object({
@@ -413,6 +419,9 @@ const clientHelloSchema = schemaWithType("client_hello", {
 const userMessageSchema = schemaWithType("user_message", {
   sessionId: requiredSessionId("user_message"),
   text: requiredString("user_message missing text"),
+  attachments: z.array(userMessageAttachmentDraftSchema).min(1, {
+    error: "user_message attachments must contain at least one item",
+  }).optional(),
   clientMessageId: optionalString("user_message invalid clientMessageId"),
 });
 

--- a/src/server/session/AgentSession.ts
+++ b/src/server/session/AgentSession.ts
@@ -59,7 +59,9 @@ import { SessionSnapshotBuilder } from "./SessionSnapshotBuilder";
 import { SkillManager } from "./SkillManager";
 import { TurnExecutionManager } from "./TurnExecutionManager";
 import type { AgentReasoningEffort, AgentRole } from "../../shared/agents";
+import type { UserMessageAttachmentDraft } from "../../shared/messageAttachments";
 import type { SessionSnapshot } from "../../shared/sessionSnapshot";
+import { importUserMessageAttachments } from "./userMessageAttachments";
 
 function makeId(): string {
   return crypto.randomUUID();
@@ -1340,9 +1342,29 @@ export class AgentSession {
     await this.backupController.reloadSessionBackupStateFromDisk();
   }
 
-  async sendUserMessage(text: string, clientMessageId?: string, displayText?: string) {
+  async sendUserMessage(
+    text: string,
+    clientMessageId?: string,
+    displayText?: string,
+    attachmentDrafts?: UserMessageAttachmentDraft[],
+  ) {
     await this.pendingConfigMutation.catch(() => {});
-    await this.turnExecutionManager.sendUserMessage(text, clientMessageId, displayText);
+    if (!attachmentDrafts || attachmentDrafts.length === 0) {
+      await this.turnExecutionManager.sendUserMessage(text, clientMessageId, displayText);
+      return;
+    }
+
+    const imported = await importUserMessageAttachments({
+      config: this.state.config,
+      text,
+      attachments: attachmentDrafts,
+    });
+
+    await this.turnExecutionManager.sendUserMessage(text, clientMessageId, displayText, {
+      content: imported.content,
+      attachments: imported.attachments,
+      titleText: imported.titleText,
+    });
   }
 
   async sendSteerMessage(text: string, expectedTurnId: string, clientMessageId?: string) {

--- a/src/server/session/SessionSnapshotProjector.ts
+++ b/src/server/session/SessionSnapshotProjector.ts
@@ -744,6 +744,7 @@ export class SessionSnapshotProjector {
         role: "user",
         ts,
         text: evt.text,
+        ...(evt.attachments && evt.attachments.length > 0 ? { attachments: structuredClone(evt.attachments) } : {}),
       });
       return;
     }

--- a/src/server/session/TurnExecutionManager.ts
+++ b/src/server/session/TurnExecutionManager.ts
@@ -6,6 +6,7 @@ import {
 } from "../modelStream";
 import { supportsOpenAiContinuation } from "../../shared/openaiContinuation";
 import { supportsProviderManagedContinuationProvider } from "../../shared/providerContinuation";
+import type { UserMessageAttachment } from "../../shared/messageAttachments";
 import type { AgentExecutionState } from "../../shared/agents";
 import type { TurnUsage } from "../../session/costTracker";
 import {
@@ -354,7 +355,16 @@ export class TurnExecutionManager {
     this.context.emitError("validation_failed", "session", message);
   }
 
-  async sendUserMessage(text: string, clientMessageId?: string, displayText?: string) {
+  async sendUserMessage(
+    text: string,
+    clientMessageId?: string,
+    displayText?: string,
+    extras?: {
+      content?: ModelMessage["content"];
+      attachments?: UserMessageAttachment[];
+      titleText?: string;
+    },
+  ) {
     if (this.context.state.running) {
       this.context.emitError("busy", "session", "Agent is busy");
       return;
@@ -379,10 +389,13 @@ export class TurnExecutionManager {
     this.context.state.acceptingSteers = true;
     const turnStartedAt = Date.now();
     const turnId = makeId();
+    const visibleText = displayText ?? text;
+    const userMessageContent = extras?.content ?? text;
+    const titleText = extras?.titleText ?? text;
     this.context.state.currentTurnId = turnId;
     this.context.state.currentTurnOutcome = "completed";
     this.updateSessionExecutionState("running");
-    const cause: "user_message" | "command" = displayText?.startsWith("/") ? "command" : "user_message";
+    const cause: "user_message" | "command" = visibleText.startsWith("/") ? "command" : "user_message";
     let lastStreamError: unknown = null;
     let lastMessagePreview: string | undefined;
     let aggregatedUsage: TurnUsage | undefined;
@@ -582,15 +595,23 @@ export class TurnExecutionManager {
         },
       });
     try {
-      this.context.emit({ type: "user_message", sessionId: this.context.id, text: displayText ?? text, clientMessageId });
+      this.context.emit({
+        type: "user_message",
+        sessionId: this.context.id,
+        text: visibleText,
+        ...(extras?.attachments && extras.attachments.length > 0 ? { attachments: extras.attachments } : {}),
+        ...(clientMessageId ? { clientMessageId } : {}),
+      });
       this.context.emit({ type: "session_busy", sessionId: this.context.id, busy: true, turnId, cause });
       this.context.emitTelemetry("agent.turn.started", "ok", {
         sessionId: this.context.id,
         provider: this.context.state.config.provider,
         model: this.context.state.config.model,
       });
-      this.deps.historyManager.appendMessagesToHistory([{ role: "user", content: text }]);
-      this.deps.metadataManager.maybeGenerateTitleFromQuery(text);
+      this.deps.historyManager.appendMessagesToHistory([{ role: "user", content: userMessageContent }]);
+      if (titleText.trim().length > 0) {
+        this.deps.metadataManager.maybeGenerateTitleFromQuery(titleText);
+      }
       this.context.queuePersistSessionSnapshot("session.user_message");
       let continueSameTurn = true;
       while (continueSameTurn) {

--- a/src/server/session/userMessageAttachments.ts
+++ b/src/server/session/userMessageAttachments.ts
@@ -1,0 +1,183 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import {
+  USER_MESSAGE_ATTACHMENT_MAX_BASE64_SIZE,
+  classifyUserMessageAttachmentKind,
+  describeSupportedUserMessageAttachments,
+  supportsUserMessageAttachmentMimeType,
+  type UserMessageAttachment,
+  type UserMessageAttachmentDraft,
+} from "../../shared/messageAttachments";
+import type { AgentConfig, ModelMessage } from "../../types";
+
+type ImportedUserMessage = {
+  content: ModelMessage["content"];
+  attachments: UserMessageAttachment[];
+  titleText: string;
+};
+
+type ValidationError = Error & {
+  code: "validation_failed";
+  source: "session";
+};
+
+function makeValidationError(message: string): ValidationError {
+  return Object.assign(new Error(message), {
+    code: "validation_failed" as const,
+    source: "session" as const,
+  });
+}
+
+function attachmentTitleSummary(attachments: UserMessageAttachment[]): string {
+  if (attachments.length === 0) return "";
+  if (attachments.length === 1) {
+    return `Attachment: ${attachments[0]!.filename}`;
+  }
+  return `Attachments: ${attachments.map((attachment) => attachment.filename).join(", ")}`;
+}
+
+function attachmentWorkspaceNote(attachments: UserMessageAttachment[]): string {
+  const lines = [
+    "Imported attachment files are now available in the workspace at these paths:",
+    ...attachments.map((attachment) => `- ${attachment.path} (${attachment.mimeType})`),
+  ];
+  return lines.join("\n");
+}
+
+async function resolveUniqueImportPath(targetDirectory: string, filename: string): Promise<{
+  filename: string;
+  filePath: string;
+}> {
+  const parsed = path.parse(filename);
+  const baseName = (parsed.name || "attachment").trim() || "attachment";
+  const ext = parsed.ext || "";
+  const normalizedTargetDirectory = path.resolve(targetDirectory);
+
+  for (let index = 0; index < 1000; index += 1) {
+    const candidateName = index === 0 ? `${baseName}${ext}` : `${baseName}-${index + 1}${ext}`;
+    const candidatePath = path.resolve(normalizedTargetDirectory, candidateName);
+    if (!candidatePath.startsWith(normalizedTargetDirectory)) {
+      throw makeValidationError("Invalid filename (path traversal)");
+    }
+    try {
+      await fs.access(candidatePath);
+    } catch {
+      return {
+        filename: candidateName,
+        filePath: candidatePath,
+      };
+    }
+  }
+
+  throw makeValidationError(`Unable to import attachment ${filename}: too many files with the same name already exist.`);
+}
+
+async function importAttachmentFile(
+  workingDirectory: string,
+  attachment: UserMessageAttachmentDraft,
+): Promise<UserMessageAttachment> {
+  const rawFilename = path.basename(attachment.filename);
+  if (!rawFilename || rawFilename === "." || rawFilename === "..") {
+    throw makeValidationError("Invalid attachment filename.");
+  }
+
+  if (attachment.contentBase64.length > USER_MESSAGE_ATTACHMENT_MAX_BASE64_SIZE) {
+    throw makeValidationError(`Attachment ${rawFilename} is too large (max ~7.5MB).`);
+  }
+
+  const kind = classifyUserMessageAttachmentKind(attachment.mimeType);
+  if (!kind) {
+    throw makeValidationError(`Unsupported attachment type for ${rawFilename}: ${attachment.mimeType}.`);
+  }
+
+  const { filename, filePath } = await resolveUniqueImportPath(workingDirectory, rawFilename);
+  const decoded = Buffer.from(attachment.contentBase64, "base64");
+  await fs.writeFile(filePath, decoded);
+  return {
+    filename,
+    mimeType: attachment.mimeType,
+    kind,
+    path: filePath,
+  };
+}
+
+function buildImportedMessageContent(
+  text: string,
+  importedAttachments: UserMessageAttachment[],
+  attachmentDrafts: UserMessageAttachmentDraft[],
+): ModelMessage["content"] {
+  if (importedAttachments.length === 0) {
+    return text;
+  }
+
+  const parts: Array<Record<string, unknown>> = [];
+  if (text.trim().length > 0) {
+    parts.push({ type: "text", text });
+  }
+
+  parts.push({
+    type: "text",
+    text: attachmentWorkspaceNote(importedAttachments),
+  });
+
+  for (let index = 0; index < importedAttachments.length; index += 1) {
+    const imported = importedAttachments[index]!;
+    const draft = attachmentDrafts[index]!;
+    parts.push({
+      type: imported.kind,
+      data: draft.contentBase64,
+      mimeType: imported.mimeType,
+    });
+  }
+
+  return parts;
+}
+
+export async function importUserMessageAttachments(opts: {
+  config: AgentConfig;
+  text: string;
+  attachments?: UserMessageAttachmentDraft[];
+}): Promise<ImportedUserMessage> {
+  const attachments = opts.attachments ?? [];
+  if (attachments.length === 0) {
+    return {
+      content: opts.text,
+      attachments: [],
+      titleText: opts.text.trim(),
+    };
+  }
+
+  const unsupported = attachments.find((attachment) =>
+    !supportsUserMessageAttachmentMimeType(opts.config.provider, opts.config.model, attachment.mimeType)
+  );
+  if (unsupported) {
+    throw makeValidationError(
+      `The current ${opts.config.provider} model does not accept ${unsupported.mimeType} attachments. Supported attachment kinds: ${describeSupportedUserMessageAttachments(
+        opts.config.provider,
+        opts.config.model,
+      )}.`
+    );
+  }
+
+  const importedAttachments: UserMessageAttachment[] = [];
+  for (const attachment of attachments) {
+    importedAttachments.push(
+      await importAttachmentFile(opts.config.workingDirectory, attachment),
+    );
+  }
+
+  return {
+    content: buildImportedMessageContent(opts.text, importedAttachments, attachments),
+    attachments: importedAttachments,
+    titleText: opts.text.trim() || attachmentTitleSummary(importedAttachments),
+  };
+}
+
+export const __internal = {
+  attachmentTitleSummary,
+  attachmentWorkspaceNote,
+  buildImportedMessageContent,
+  importAttachmentFile,
+  resolveUniqueImportPath,
+} as const;

--- a/src/server/startServer/dispatchClientMessage.ts
+++ b/src/server/startServer/dispatchClientMessage.ts
@@ -39,7 +39,7 @@ export function dispatchClientMessage({
       }
       return;
     case "user_message":
-      return void session.sendUserMessage(message.text, message.clientMessageId);
+      return void session.sendUserMessage(message.text, message.clientMessageId, undefined, message.attachments);
     case "steer_message":
       return void session.sendSteerMessage(message.text, message.expectedTurnId, message.clientMessageId);
     case "ask_response":

--- a/src/shared/messageAttachments.ts
+++ b/src/shared/messageAttachments.ts
@@ -1,0 +1,133 @@
+import { supportsImageInput } from "../models/registry";
+import type { ProviderName } from "../types";
+
+export const USER_MESSAGE_ATTACHMENT_MAX_BASE64_SIZE = 10 * 1024 * 1024;
+
+export const USER_MESSAGE_ATTACHMENT_KINDS = [
+  "image",
+  "audio",
+  "video",
+  "document",
+] as const;
+
+export type UserMessageAttachmentKind = (typeof USER_MESSAGE_ATTACHMENT_KINDS)[number];
+
+export type UserMessageAttachmentDraft = {
+  filename: string;
+  mimeType: string;
+  contentBase64: string;
+};
+
+export type UserMessageAttachment = {
+  filename: string;
+  mimeType: string;
+  kind: UserMessageAttachmentKind;
+  path?: string;
+};
+
+const GOOGLE_AUDIO_MIME_TYPES = new Set([
+  "audio/wav",
+  "audio/mp3",
+  "audio/aiff",
+  "audio/aac",
+  "audio/ogg",
+  "audio/flac",
+]);
+
+const GOOGLE_VIDEO_MIME_TYPES = new Set([
+  "video/mp4",
+  "video/mpeg",
+  "video/mpg",
+  "video/mov",
+  "video/avi",
+  "video/x-flv",
+  "video/webm",
+  "video/wmv",
+  "video/3gpp",
+]);
+
+const EXTENSION_TO_MIME_TYPE: Record<string, string> = {
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".webp": "image/webp",
+  ".gif": "image/gif",
+  ".wav": "audio/wav",
+  ".mp3": "audio/mp3",
+  ".aiff": "audio/aiff",
+  ".aac": "audio/aac",
+  ".ogg": "audio/ogg",
+  ".flac": "audio/flac",
+  ".pdf": "application/pdf",
+  ".mp4": "video/mp4",
+  ".mpeg": "video/mpeg",
+  ".mpg": "video/mpg",
+  ".mov": "video/mov",
+  ".avi": "video/avi",
+  ".flv": "video/x-flv",
+  ".webm": "video/webm",
+  ".wmv": "video/wmv",
+  ".3gp": "video/3gpp",
+  ".3gpp": "video/3gpp",
+};
+
+export function normalizeUserMessageAttachmentMimeType(mimeType: string): string {
+  return mimeType.trim().toLowerCase();
+}
+
+export function inferUserMessageAttachmentMimeType(filename: string, mimeType?: string | null): string | null {
+  const normalizedMimeType = mimeType ? normalizeUserMessageAttachmentMimeType(mimeType) : "";
+  if (normalizedMimeType) return normalizedMimeType;
+
+  const lastDotIndex = filename.lastIndexOf(".");
+  if (lastDotIndex < 0) return null;
+  const extension = filename.slice(lastDotIndex).toLowerCase();
+  return EXTENSION_TO_MIME_TYPE[extension] ?? null;
+}
+
+export function classifyUserMessageAttachmentKind(mimeType: string): UserMessageAttachmentKind | null {
+  const normalized = normalizeUserMessageAttachmentMimeType(mimeType);
+  if (!normalized) return null;
+  if (normalized.startsWith("image/")) return "image";
+  if (GOOGLE_AUDIO_MIME_TYPES.has(normalized)) return "audio";
+  if (GOOGLE_VIDEO_MIME_TYPES.has(normalized)) return "video";
+  if (normalized === "application/pdf") return "document";
+  return null;
+}
+
+export function supportsUserMessageAttachments(provider: ProviderName, modelId: string): boolean {
+  return supportedUserMessageAttachmentKinds(provider, modelId).length > 0;
+}
+
+export function supportedUserMessageAttachmentKinds(
+  provider: ProviderName,
+  modelId: string,
+): UserMessageAttachmentKind[] {
+  const supported: UserMessageAttachmentKind[] = [];
+  if (supportsImageInput(provider, modelId)) {
+    supported.push("image");
+  }
+  if (provider === "google") {
+    supported.push("audio", "video", "document");
+  }
+  return supported;
+}
+
+export function supportsUserMessageAttachmentMimeType(
+  provider: ProviderName,
+  modelId: string,
+  mimeType: string,
+): boolean {
+  const kind = classifyUserMessageAttachmentKind(mimeType);
+  if (!kind) return false;
+  return supportedUserMessageAttachmentKinds(provider, modelId).includes(kind);
+}
+
+export function describeSupportedUserMessageAttachments(
+  provider: ProviderName,
+  modelId: string,
+): string {
+  const supportedKinds = supportedUserMessageAttachmentKinds(provider, modelId);
+  if (supportedKinds.length === 0) return "none";
+  return supportedKinds.join(", ");
+}

--- a/src/shared/sessionSnapshot.ts
+++ b/src/shared/sessionSnapshot.ts
@@ -27,6 +27,7 @@ import {
   type ServerErrorSource,
   type TodoItem,
 } from "../types";
+import type { UserMessageAttachment } from "./messageAttachments";
 
 const isoTimestampSchema = z.string().datetime({ offset: true });
 const providerNameSchema = z.enum(PROVIDER_NAMES);
@@ -55,6 +56,7 @@ export type SessionFeedItem =
       ts: string;
       text: string;
       annotations?: Array<Record<string, unknown>>;
+      attachments?: UserMessageAttachment[];
     }
   | { id: string; kind: "reasoning"; mode: "reasoning" | "summary"; ts: string; text: string }
   | {
@@ -127,6 +129,12 @@ const feedItemSchema: z.ZodType<SessionFeedItem> = z.discriminatedUnion("kind", 
     ts: isoTimestampSchema,
     text: z.string(),
     annotations: z.array(z.record(z.string(), z.unknown())).optional(),
+    attachments: z.array(z.object({
+      filename: z.string().trim().min(1),
+      mimeType: z.string().trim().min(1),
+      kind: z.enum(["image", "audio", "video", "document"]),
+      path: z.string().optional(),
+    }).strict()).optional(),
   }).strict(),
   z.object({
     id: z.string().trim().min(1),

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -7,29 +7,41 @@ import { z } from "zod";
 
 import type { ToolContext } from "./context";
 import { defineTool } from "./defineTool";
+import {
+  classifyUserMessageAttachmentKind,
+  inferUserMessageAttachmentMimeType,
+  type UserMessageAttachmentKind,
+} from "../shared/messageAttachments";
 import { resolveMaybeRelative, truncateLine } from "../utils/paths";
 import { assertReadPathAllowed } from "../utils/permissions";
 
-function supportedImageMimeType(filePath: string): string | null {
-  switch (path.extname(filePath).toLowerCase()) {
-    case ".png":
-      return "image/png";
-    case ".jpg":
-    case ".jpeg":
-      return "image/jpeg";
-    case ".webp":
-      return "image/webp";
-    case ".gif":
-      return "image/gif";
-    default:
-      return null;
-  }
+type SupportedReadMultimodalFile = {
+  kind: UserMessageAttachmentKind;
+  mimeType: string;
+  label: string;
+};
+
+function supportedReadMultimodalFile(filePath: string): SupportedReadMultimodalFile | null {
+  const mimeType = inferUserMessageAttachmentMimeType(path.basename(filePath), undefined);
+  if (!mimeType) return null;
+  const kind = classifyUserMessageAttachmentKind(mimeType);
+  if (!kind) return null;
+
+  const label =
+    kind === "image"
+      ? "Image"
+      : kind === "audio"
+        ? "Audio"
+        : kind === "video"
+          ? "Video"
+          : "PDF";
+  return { kind, mimeType, label };
 }
 
 export function createReadTool(ctx: ToolContext) {
   return defineTool({
     description:
-      "Read a file from the filesystem. Returns line-numbered text for text files and visual content for supported images. Use offset/limit for large text files.",
+      "Read a file from the filesystem. Returns line-numbered text for text files and multimodal content for supported images, audio, video, and PDFs. Use offset/limit for large text files.",
     inputSchema: z.object({
       filePath: z.string().describe("Path to the file (prefer absolute)"),
       offset: z.number().int().min(1).optional().describe("Start line (1-indexed)"),
@@ -52,18 +64,18 @@ export function createReadTool(ctx: ToolContext) {
         "read"
       );
 
-      const imageMimeType = supportedImageMimeType(abs);
-      if (imageMimeType) {
+      const multimodalFile = supportedReadMultimodalFile(abs);
+      if (multimodalFile) {
         const buffer = await fs.readFile(abs);
         const result = {
           type: "content",
           content: [
-            { type: "text", text: `Image file: ${path.basename(abs)}` },
-            { type: "image", data: buffer.toString("base64"), mimeType: imageMimeType },
+            { type: "text", text: `${multimodalFile.label} file: ${path.basename(abs)}` },
+            { type: multimodalFile.kind, data: buffer.toString("base64"), mimeType: multimodalFile.mimeType },
           ],
         };
         ctx.log(
-          `tool< read ${JSON.stringify({ image: true, mimeType: imageMimeType, bytes: buffer.length })}`
+          `tool< read ${JSON.stringify({ multimodal: true, kind: multimodalFile.kind, mimeType: multimodalFile.mimeType, bytes: buffer.length })}`
         );
         return result;
       }

--- a/test/protocol.test.ts
+++ b/test/protocol.test.ts
@@ -103,6 +103,32 @@ describe("safeParseClientMessage", () => {
       }
     });
 
+    test("user_message with multimodal attachments", () => {
+      const msg = expectOk(
+        JSON.stringify({
+          type: "user_message",
+          sessionId: "s1",
+          text: "describe this",
+          attachments: [
+            {
+              filename: "photo.png",
+              mimeType: "image/png",
+              contentBase64: "aGVsbG8=",
+            },
+          ],
+        }),
+      );
+      if (msg.type === "user_message") {
+        expect(msg.attachments).toEqual([
+          {
+            filename: "photo.png",
+            mimeType: "image/png",
+            contentBase64: "aGVsbG8=",
+          },
+        ]);
+      }
+    });
+
     test("user_message with empty text", () => {
       const msg = expectOk(
         JSON.stringify({ type: "user_message", sessionId: "s1", text: "" }),
@@ -131,6 +157,25 @@ describe("safeParseClientMessage", () => {
         }),
       );
       expect(err).toBe("user_message invalid clientMessageId");
+    });
+
+    test("user_message validates attachment fields", () => {
+      expect(expectErr(
+        JSON.stringify({
+          type: "user_message",
+          sessionId: "s1",
+          text: "hello",
+          attachments: [],
+        }),
+      )).toBe("user_message attachments must contain at least one item");
+      expect(expectErr(
+        JSON.stringify({
+          type: "user_message",
+          sessionId: "s1",
+          text: "hello",
+          attachments: [{ filename: "photo.png", mimeType: "", contentBase64: "aGVsbG8=" }],
+        }),
+      )).toBe("user_message attachments[].mimeType must be non-empty");
     });
   });
 
@@ -2370,6 +2415,34 @@ describe("safeParseClientMessage", () => {
       if (evt?.type === "steer_accepted") {
         expect(evt.turnId).toBe("turn-1");
         expect(evt.clientMessageId).toBe("cm-steer");
+      }
+    });
+
+    test("safeParseServerEvent accepts user_message attachments", () => {
+      const evt = safeParseServerEvent({
+        type: "user_message",
+        sessionId: "s1",
+        text: "",
+        clientMessageId: "cm-attach",
+        attachments: [
+          {
+            filename: "clip.mp4",
+            mimeType: "video/mp4",
+            kind: "video",
+            path: "/workspace/clip.mp4",
+          },
+        ],
+      });
+
+      expect(evt).not.toBeNull();
+      expect(evt?.type).toBe("user_message");
+      if (evt?.type === "user_message") {
+        expect(evt.attachments?.[0]).toEqual({
+          filename: "clip.mp4",
+          mimeType: "video/mp4",
+          kind: "video",
+          path: "/workspace/clip.mp4",
+        });
       }
     });
 

--- a/test/runtime.google-interactions.test.ts
+++ b/test/runtime.google-interactions.test.ts
@@ -1033,13 +1033,11 @@ describe("google native interactions request building", () => {
             type: "function_result",
             call_id: "call_pdf",
             name: "read",
-            result: "PDF file: sample.pdf",
+            result: [
+              { type: "text", text: "PDF file: sample.pdf" },
+              { type: "document", data: "pdf64", mime_type: "application/pdf" },
+            ],
             is_error: false,
-          },
-          {
-            type: "document",
-            data: "pdf64",
-            mime_type: "application/pdf",
           },
         ],
       },

--- a/test/runtime.google-interactions.test.ts
+++ b/test/runtime.google-interactions.test.ts
@@ -1003,6 +1003,49 @@ describe("google native interactions request building", () => {
     ]);
   });
 
+  test("convertMessagesToInteractionsInput forwards read-tool PDFs as Gemini document content", () => {
+    const input = googleNativeInternal.convertMessagesToInteractionsInput([
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "call_pdf",
+            toolName: "read",
+            output: {
+              type: "content",
+              content: [
+                { type: "text", text: "PDF file: sample.pdf" },
+                { type: "document", data: "pdf64", mimeType: "application/pdf" },
+              ],
+            },
+            isError: false,
+          },
+        ],
+      },
+    ] as ModelMessage[]);
+
+    expect(input).toEqual([
+      {
+        role: "user",
+        content: [
+          {
+            type: "function_result",
+            call_id: "call_pdf",
+            name: "read",
+            result: "PDF file: sample.pdf",
+            is_error: false,
+          },
+          {
+            type: "document",
+            data: "pdf64",
+            mime_type: "application/pdf",
+          },
+        ],
+      },
+    ]);
+  });
+
   test("convertToolsToInteractionsTools maps to function type", () => {
     const tools = googleNativeInternal.convertToolsToInteractionsTools([
       { name: "readFile", description: "Read a file", parameters: { type: "object", properties: { path: { type: "string" } } } },

--- a/test/runtime.google-interactions.test.ts
+++ b/test/runtime.google-interactions.test.ts
@@ -839,6 +839,32 @@ describe("google native interactions request building", () => {
     ]);
   });
 
+  test("convertMessagesToInteractionsInput preserves Gemini audio, video, and PDF inputs", () => {
+    const input = googleNativeInternal.convertMessagesToInteractionsInput([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "Analyze these files" },
+          { type: "audio", data: "audio64", mimeType: "audio/wav" },
+          { type: "video", data: "video64", mimeType: "video/mp4" },
+          { type: "document", data: "pdf64", mimeType: "application/pdf" },
+        ],
+      },
+    ] as ModelMessage[]);
+
+    expect(input).toEqual([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "Analyze these files" },
+          { type: "audio", data: "audio64", mime_type: "audio/wav" },
+          { type: "video", data: "video64", mime_type: "video/mp4" },
+          { type: "document", data: "pdf64", mime_type: "application/pdf" },
+        ],
+      },
+    ]);
+  });
+
   test("convertMessagesToInteractionsInput handles assistant tool calls with repaired thought signatures", () => {
     const input = googleNativeInternal.convertMessagesToInteractionsInput([
       {

--- a/test/runtime.google-interactions.test.ts
+++ b/test/runtime.google-interactions.test.ts
@@ -1033,12 +1033,15 @@ describe("google native interactions request building", () => {
             type: "function_result",
             call_id: "call_pdf",
             name: "read",
-            result: [
-              { type: "text", text: "PDF file: sample.pdf" },
-              { type: "document", data: "pdf64", mime_type: "application/pdf" },
-            ],
+            result: "PDF file: sample.pdf",
             is_error: false,
           },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          { type: "document", data: "pdf64", mime_type: "application/pdf" },
         ],
       },
     ]);

--- a/test/runtime.openai-responses-runtime.test.ts
+++ b/test/runtime.openai-responses-runtime.test.ts
@@ -722,6 +722,57 @@ describe("openai responses runtime", () => {
     expect(request.include).toBeUndefined();
   });
 
+  test("request builder converts user image parts into Responses input_image blocks", () => {
+    const request = openAiNativeInternal.buildOpenAiNativeRequest({
+      provider: "openai",
+      model: {
+        id: "gpt-5.2",
+        name: "gpt-5.2",
+        api: "openai-responses",
+        provider: "openai",
+        baseUrl: "https://api.openai.com/v1",
+        reasoning: true,
+        input: ["text", "image"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 32768,
+      },
+      systemPrompt: "You are helpful.",
+      piMessages: [{
+        role: "user",
+        content: [
+          { type: "text", text: "Describe this image." },
+          { type: "image", data: "abc123", mimeType: "image/png" },
+        ],
+      }],
+      tools: [],
+      streamOptions: {},
+    });
+
+    expect((request.input as Array<Record<string, unknown>>)[0]).toEqual(
+      {
+        role: "user",
+        content: [
+          { type: "input_text", text: "Describe this image." },
+          { type: "input_image", detail: "auto", image_url: "data:image/png;base64,abc123" },
+        ],
+      },
+    );
+    expect(request.input).toEqual([
+      {
+        role: "user",
+        content: [
+          { type: "input_text", text: "Describe this image." },
+          { type: "input_image", detail: "auto", image_url: "data:image/png;base64,abc123" },
+        ],
+      },
+      {
+        role: "developer",
+        content: [{ type: "input_text", text: "# Juice: 0 !important" }],
+      },
+    ]);
+  });
+
   test("request builder keeps legacy webSearch when codex is explicitly configured for exa", () => {
     const request = openAiNativeInternal.buildOpenAiNativeRequest({
       provider: "codex-cli",

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -220,6 +220,60 @@ describe("read tool", () => {
       ],
     });
   });
+
+  test("returns multimodal content for supported PDF files", async () => {
+    const dir = await tmpDir();
+    const p = path.join(dir, "sample.pdf");
+    const pdfBase64 = Buffer.from("%PDF-test").toString("base64");
+    await fs.writeFile(p, Buffer.from(pdfBase64, "base64"));
+
+    const t: any = createReadTool(makeCtx(dir));
+    const out = await t.execute({ filePath: p, limit: 2000 });
+
+    expect(out).toEqual({
+      type: "content",
+      content: [
+        { type: "text", text: "PDF file: sample.pdf" },
+        { type: "document", data: pdfBase64, mimeType: "application/pdf" },
+      ],
+    });
+  });
+
+  test("returns multimodal content for supported audio files", async () => {
+    const dir = await tmpDir();
+    const p = path.join(dir, "sample.wav");
+    const audioBase64 = Buffer.from("audio-bytes").toString("base64");
+    await fs.writeFile(p, Buffer.from(audioBase64, "base64"));
+
+    const t: any = createReadTool(makeCtx(dir));
+    const out = await t.execute({ filePath: p, limit: 2000 });
+
+    expect(out).toEqual({
+      type: "content",
+      content: [
+        { type: "text", text: "Audio file: sample.wav" },
+        { type: "audio", data: audioBase64, mimeType: "audio/wav" },
+      ],
+    });
+  });
+
+  test("returns multimodal content for supported video files", async () => {
+    const dir = await tmpDir();
+    const p = path.join(dir, "sample.mp4");
+    const videoBase64 = Buffer.from("video-bytes").toString("base64");
+    await fs.writeFile(p, Buffer.from(videoBase64, "base64"));
+
+    const t: any = createReadTool(makeCtx(dir));
+    const out = await t.execute({ filePath: p, limit: 2000 });
+
+    expect(out).toEqual({
+      type: "content",
+      content: [
+        { type: "text", text: "Video file: sample.mp4" },
+        { type: "video", data: videoBase64, mimeType: "video/mp4" },
+      ],
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/test/user-message-attachments.test.ts
+++ b/test/user-message-attachments.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, test } from "bun:test";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { importUserMessageAttachments } from "../src/server/session/userMessageAttachments";
+import type { AgentConfig } from "../src/types";
+
+function makeConfig(
+  workingDirectory: string,
+  overrides: Partial<AgentConfig> = {},
+): AgentConfig {
+  return {
+    provider: "openai",
+    model: "gpt-5.2",
+    preferredChildModel: "gpt-5.2",
+    workingDirectory,
+    outputDirectory: path.join(workingDirectory, "output"),
+    uploadsDirectory: path.join(workingDirectory, "uploads"),
+    userName: "",
+    knowledgeCutoff: "unknown",
+    projectAgentDir: path.join(workingDirectory, ".agent-project"),
+    userAgentDir: path.join(workingDirectory, ".agent"),
+    builtInDir: workingDirectory,
+    builtInConfigDir: path.join(workingDirectory, "config"),
+    skillsDirs: [],
+    memoryDirs: [],
+    configDirs: [],
+    ...overrides,
+  };
+}
+
+describe("importUserMessageAttachments", () => {
+  test("imports image attachments into the workspace and builds multimodal user content", async () => {
+    const workingDirectory = await fs.mkdtemp(path.join(os.tmpdir(), "message-attachments-image-"));
+    const imageBase64 = Buffer.from("image-bytes").toString("base64");
+
+    const imported = await importUserMessageAttachments({
+      config: makeConfig(workingDirectory),
+      text: "Describe this image.",
+      attachments: [
+        {
+          filename: "photo.png",
+          mimeType: "image/png",
+          contentBase64: imageBase64,
+        },
+      ],
+    });
+
+    expect(imported.attachments).toHaveLength(1);
+    expect(imported.attachments[0]).toMatchObject({
+      filename: "photo.png",
+      mimeType: "image/png",
+      kind: "image",
+      path: path.join(workingDirectory, "photo.png"),
+    });
+    expect(await fs.readFile(path.join(workingDirectory, "photo.png"), "utf8")).toBe("image-bytes");
+    expect(imported.content).toEqual([
+      { type: "text", text: "Describe this image." },
+      {
+        type: "text",
+        text: `Imported attachment files are now available in the workspace at these paths:\n- ${path.join(workingDirectory, "photo.png")} (image/png)`,
+      },
+      {
+        type: "image",
+        data: imageBase64,
+        mimeType: "image/png",
+      },
+    ]);
+    expect(imported.titleText).toBe("Describe this image.");
+  });
+
+  test("imports Gemini-native audio and PDF attachments", async () => {
+    const workingDirectory = await fs.mkdtemp(path.join(os.tmpdir(), "message-attachments-google-"));
+
+    const imported = await importUserMessageAttachments({
+      config: makeConfig(workingDirectory, {
+        provider: "google",
+        model: "gemini-3-flash-preview",
+        preferredChildModel: "gemini-3-flash-preview",
+      }),
+      text: "",
+      attachments: [
+        {
+          filename: "voice.wav",
+          mimeType: "audio/wav",
+          contentBase64: Buffer.from("audio").toString("base64"),
+        },
+        {
+          filename: "report.pdf",
+          mimeType: "application/pdf",
+          contentBase64: Buffer.from("pdf").toString("base64"),
+        },
+      ],
+    });
+
+    expect(imported.attachments.map((attachment) => attachment.kind)).toEqual(["audio", "document"]);
+    expect(imported.content).toEqual([
+      {
+        type: "text",
+        text: [
+          "Imported attachment files are now available in the workspace at these paths:",
+          `- ${path.join(workingDirectory, "voice.wav")} (audio/wav)`,
+          `- ${path.join(workingDirectory, "report.pdf")} (application/pdf)`,
+        ].join("\n"),
+      },
+      {
+        type: "audio",
+        data: Buffer.from("audio").toString("base64"),
+        mimeType: "audio/wav",
+      },
+      {
+        type: "document",
+        data: Buffer.from("pdf").toString("base64"),
+        mimeType: "application/pdf",
+      },
+    ]);
+    expect(imported.titleText).toBe("Attachments: voice.wav, report.pdf");
+  });
+
+  test("rejects unsupported attachment types for the current model", async () => {
+    const workingDirectory = await fs.mkdtemp(path.join(os.tmpdir(), "message-attachments-reject-"));
+
+    await expect(importUserMessageAttachments({
+      config: makeConfig(workingDirectory),
+      text: "",
+      attachments: [
+        {
+          filename: "voice.wav",
+          mimeType: "audio/wav",
+          contentBase64: Buffer.from("audio").toString("base64"),
+        },
+      ],
+    })).rejects.toMatchObject({
+      message: expect.stringContaining("does not accept audio/wav attachments"),
+      code: "validation_failed",
+      source: "session",
+    });
+  });
+
+  test("avoids overwriting existing workspace files by generating unique names", async () => {
+    const workingDirectory = await fs.mkdtemp(path.join(os.tmpdir(), "message-attachments-collision-"));
+    await fs.writeFile(path.join(workingDirectory, "photo.png"), "existing");
+
+    const imported = await importUserMessageAttachments({
+      config: makeConfig(workingDirectory),
+      text: "",
+      attachments: [
+        {
+          filename: "photo.png",
+          mimeType: "image/png",
+          contentBase64: Buffer.from("new-image").toString("base64"),
+        },
+      ],
+    });
+
+    expect(imported.attachments[0]?.filename).toBe("photo-2.png");
+    expect(await fs.readFile(path.join(workingDirectory, "photo.png"), "utf8")).toBe("existing");
+    expect(await fs.readFile(path.join(workingDirectory, "photo-2.png"), "utf8")).toBe("new-image");
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add structured user-message attachments to the websocket/session pipeline
- import dropped/attached files into the workspace and inject hidden workspace-path notes into model input
- support images for vision-capable models and Gemini-native image/audio/video/PDF inputs
- extend the `read` tool to return multimodal image/audio/video/PDF content and preserve those results through the runtime bridges
- split Gemini multimodal `read` follow-up content into provider-accepted user turns so reopened PDFs/audio/video remain usable after a tool call
- add desktop composer attachment UI plus transcript/feed persistence for attachment metadata
- extend protocol/runtime/desktop tests for multimodal message handling

## Testing
- bun run typecheck
- bun test test/tools.test.ts test/runtime.google-interactions.test.ts test/runtime.openai-responses-runtime.test.ts test/user-message-attachments.test.ts test/protocol.test.ts apps/desktop/test/store-feed-mapping.test.ts apps/desktop/test/thread-reconnect.test.ts
- live runtime check: direct attachment path returned `red` for OpenAI image input and `Yes` for Gemini PDF input
- live runtime check: reopened-file `read` path returned `red` for OpenAI image tool output and `Yes` for Gemini PDF tool output

## Notes
- inspected `origin/linux-ui-fixes`; it contains Linux chrome/background polish but not a preload-bridge fix
- manual desktop verification is still blocked by an existing Electron renderer/preload bridge failure in this environment (`window.cowork` is unavailable, leaving the desktop app blank).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e8f9d061-8bb6-498b-934d-a44e9b8ae66d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e8f9d061-8bb6-498b-934d-a44e9b8ae66d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

