### PR TITLE
refactor: extract shared JSON-RPC projection core

### DIFF
--- a/src/server/jsonrpc/eventProjector.ts
+++ b/src/server/jsonrpc/eventProjector.ts
@@ -1,28 +1,6 @@
 import type { ServerEvent } from "../protocol";
-import {
-  clearModelStreamReplayRuntime,
-  createModelStreamReplayRuntime,
-  replayModelStreamRawEvent,
-  shouldIgnoreNormalizedChunkForRawBackedTurn,
-  type ModelStreamReplayRuntime,
-} from "../../client/modelStreamReplay";
-import {
-  mapModelStreamChunk,
-  type ModelStreamChunkEvent,
-  type ModelStreamRawEvent,
-  type ModelStreamUpdate,
-} from "../../client/modelStream";
-import {
-  hasVisibleAssistantText,
-  makeItemId,
-  normalizeReasoningText,
-  normalizeToolArgsFromInput,
-  normalizeTranscriptReplayText,
-  occurrenceItemId,
-  readPartString,
-  reasoningModeFromPart,
-  type ProjectedReasoningMode,
-} from "./projectorShared";
+import { createProjectionCore } from "./projectionCore";
+import type { ProjectedEvent } from "./projectionCore.types";
 
 type JsonRpcOutboundMessage =
   | { id: string | number; method: string; params?: unknown }
@@ -43,607 +21,107 @@ type CreateJsonRpcEventProjectorOptions = {
   }) => void;
 };
 
-type BufferedReasoningState = {
-  itemId: string;
-  mode: ProjectedReasoningMode;
-  text: string;
-  started: boolean;
-};
-
-type BufferedAssistantState = {
-  itemId: string;
-  text: string;
-  started: boolean;
-};
-
-type BufferedToolState = {
-  itemId: string;
-  name: string;
-  args?: unknown;
-  inputText: string;
-  started: boolean;
-};
-
 export function createJsonRpcEventProjector(opts: CreateJsonRpcEventProjectorOptions) {
-  let activeTurnId: string | null = opts.initialActiveTurnId ?? null;
-  let lastUserMessageText: string | null = null;
-  let lastUserMessageClientMessageId: string | null = null;
-  const userItemIdByTurn = new Map<string, string>();
-  const activeAssistantByTurn = new Map<string, BufferedAssistantState>();
-  const assistantOccurrenceByTurn = new Map<string, number>();
-  const assistantHistoryByTurn = new Map<string, string>();
-  const reasoningByKey = new Map<string, BufferedReasoningState>();
-  const reasoningOccurrenceByKey = new Map<string, number>();
-  const reasoningTextsSeenInTurn = new Set<string>();
-  const reasoningTextHistoryInTurn: string[] = [];
-  const toolByKey = new Map<string, BufferedToolState>();
-  const toolOccurrenceByKey = new Map<string, number>();
-  const replayRuntime: ModelStreamReplayRuntime = createModelStreamReplayRuntime();
-  if (activeTurnId) {
-    activeAssistantByTurn.set(activeTurnId, {
-      itemId: makeItemId("agentMessage", activeTurnId),
-      text: opts.initialAgentText ?? "",
-      started: true,
-    });
-    assistantOccurrenceByTurn.set(activeTurnId, 1);
-  }
-
   const shouldSendNotification = (method: string) => opts.shouldSendNotification?.(method) ?? true;
   const sendNotification = (method: string, params?: unknown) => {
     if (!shouldSendNotification(method)) return;
     opts.send({ method, params });
   };
 
-  const handleAsk = (evt: Extract<ServerEvent, { type: "ask" }>) => {
-    opts.onServerRequest?.({
-      id: evt.requestId,
-      threadId: opts.threadId,
-      type: "ask",
-      method: "item/tool/requestUserInput",
-      params: {
-        threadId: opts.threadId,
-        turnId: activeTurnId,
-        requestId: evt.requestId,
-        itemId: makeItemId("requestUserInput", evt.requestId),
-        question: evt.question,
-        options: evt.options,
-      },
-    });
-  };
-
-  const handleApproval = (evt: Extract<ServerEvent, { type: "approval" }>) => {
-    opts.onServerRequest?.({
-      id: evt.requestId,
-      threadId: opts.threadId,
-      type: "approval",
-      method: "item/commandExecution/requestApproval",
-      params: {
-        threadId: opts.threadId,
-        turnId: activeTurnId,
-        requestId: evt.requestId,
-        itemId: makeItemId("commandExecution", evt.requestId),
-        command: evt.command,
-        dangerous: evt.dangerous,
-        reason: evt.reasonCode,
-      },
-    });
-  };
-
-  const ensureActiveAssistantState = (turnId: string) => {
-    const existing = activeAssistantByTurn.get(turnId);
-    if (existing) return existing;
-    const nextOccurrence = (assistantOccurrenceByTurn.get(turnId) ?? 0) + 1;
-    assistantOccurrenceByTurn.set(turnId, nextOccurrence);
-    const next: BufferedAssistantState = {
-      itemId: occurrenceItemId(makeItemId("agentMessage", turnId), nextOccurrence),
-      text: "",
-      started: false,
-    };
-    activeAssistantByTurn.set(turnId, next);
-    return next;
-  };
-
-  const startAssistantState = (turnId: string, state: BufferedAssistantState) => {
-    if (state.started) return;
-    state.started = true;
-    sendNotification("item/started", {
-      threadId: opts.threadId,
-      turnId,
-      item: {
-        id: state.itemId,
-        type: "agentMessage",
-        text: "",
-      },
-    });
-  };
-
-  const completeAssistantState = (turnId: string, finalText?: string) => {
-    const state = activeAssistantByTurn.get(turnId);
-    if (!state) return;
-    const text = finalText ?? state.text;
-    activeAssistantByTurn.delete(turnId);
-    if (!hasVisibleAssistantText(text)) return;
-    startAssistantState(turnId, state);
-    sendNotification("item/completed", {
-      threadId: opts.threadId,
-      turnId,
-      item: {
-        id: state.itemId,
-        type: "agentMessage",
-        text,
-      },
-    });
-    assistantHistoryByTurn.set(turnId, `${assistantHistoryByTurn.get(turnId) ?? ""}${text}`);
-  };
-
-  const completeAssistantStateBeforeStep = (turnId: string) => {
-    const state = activeAssistantByTurn.get(turnId);
-    if (!state) return;
-    if (state.text) {
-      completeAssistantState(turnId, state.text);
-      return;
-    }
-    activeAssistantByTurn.delete(turnId);
-  };
-
-  const assistantRemainderForTurn = (turnId: string, text: string) => {
-    const history = assistantHistoryByTurn.get(turnId) ?? "";
-    if (!history) return text;
-    if (text.startsWith(history)) return text.slice(history.length);
-
-    const trimmedHistory = history.trimStart();
-    if (trimmedHistory && text.startsWith(trimmedHistory)) {
-      return text.slice(trimmedHistory.length);
-    }
-
-    const normalizedHistory = normalizeTranscriptReplayText(history);
-    const normalizedText = normalizeTranscriptReplayText(text);
-    if (normalizedHistory && normalizedText === normalizedHistory) {
-      return "";
-    }
-
-    return text;
-  };
-
-  const reasoningStreamKey = (turnId: string, part: Record<string, unknown> | undefined) =>
-    `${turnId}:${readPartString(part, "id") ?? "default"}`;
-
-  const ensureBufferedReasoning = (turnId: string, part: Record<string, unknown> | undefined) => {
-    const key = reasoningStreamKey(turnId, part);
-    const existing = reasoningByKey.get(key);
-    if (existing) {
-      existing.mode = reasoningModeFromPart(part);
-      return { key, state: existing };
-    }
-    const streamId = readPartString(part, "id") ?? "default";
-    const nextOccurrence = (reasoningOccurrenceByKey.get(key) ?? 0) + 1;
-    reasoningOccurrenceByKey.set(key, nextOccurrence);
-    const next: BufferedReasoningState = {
-      itemId: occurrenceItemId(
-        makeItemId("reasoning", `${turnId}:${streamId}`),
-        nextOccurrence,
-      ),
-      mode: reasoningModeFromPart(part),
-      text: "",
-      started: false,
-    };
-    reasoningByKey.set(key, next);
-    return { key, state: next };
-  };
-
-  const startBufferedReasoning = (turnId: string, state: BufferedReasoningState) => {
-    if (state.started) return;
-    state.started = true;
-    sendNotification("item/started", {
-      threadId: opts.threadId,
-      turnId,
-      item: {
-        id: state.itemId,
-        type: "reasoning",
-        mode: state.mode,
-        text: "",
-      },
-    });
-  };
-
-  const emitReasoningItem = (
-    turnId: string,
-    mode: ProjectedReasoningMode,
-    text: string,
-    itemId = makeItemId("reasoning", `${turnId}:${crypto.randomUUID()}`),
-  ) => {
-    if (!text.trim()) return false;
-    if (hasMatchingStreamedReasoningText(text)) {
-      return false;
-    }
-    sendNotification("item/started", {
-      threadId: opts.threadId,
-      turnId,
-      item: {
-        id: itemId,
-        type: "reasoning",
-        mode,
-        text,
-      },
-    });
-    sendNotification("item/completed", {
-      threadId: opts.threadId,
-      turnId,
-      item: {
-        id: itemId,
-        type: "reasoning",
-        mode,
-        text,
-      },
-    });
-    return true;
-  };
-
-  const flushBufferedReasoning = (turnId: string, key: string) => {
-    const state = reasoningByKey.get(key);
-    if (!state) return;
-    reasoningByKey.delete(key);
-    startBufferedReasoning(turnId, state);
-    sendNotification("item/completed", {
-      threadId: opts.threadId,
-      turnId,
-      item: {
-        id: state.itemId,
-        type: "reasoning",
-        mode: state.mode,
-        text: state.text,
-      },
-    });
-    rememberStreamedReasoningText(state.text);
-  };
-
-  const clearReasoningStateForTurn = (turnId: string) => {
-    for (const key of reasoningByKey.keys()) {
-      if (key.startsWith(`${turnId}:`)) {
-        reasoningByKey.delete(key);
-      }
-    }
-    for (const key of reasoningOccurrenceByKey.keys()) {
-      if (key.startsWith(`${turnId}:`)) {
-        reasoningOccurrenceByKey.delete(key);
-      }
-    }
-  };
-
-  const clearToolStateForTurn = (turnId: string) => {
-    for (const key of toolByKey.keys()) {
-      if (key.startsWith(`${turnId}:`)) {
-        toolByKey.delete(key);
-      }
-    }
-    for (const key of toolOccurrenceByKey.keys()) {
-      if (key.startsWith(`${turnId}:`)) {
-        toolOccurrenceByKey.delete(key);
-      }
-    }
-  };
-
-  const clearTurnProjectionState = (turnId: string | null) => {
-    if (turnId) {
-      activeAssistantByTurn.delete(turnId);
-      assistantOccurrenceByTurn.delete(turnId);
-      assistantHistoryByTurn.delete(turnId);
-      clearReasoningStateForTurn(turnId);
-      clearToolStateForTurn(turnId);
-    } else {
-      activeAssistantByTurn.clear();
-      assistantOccurrenceByTurn.clear();
-      assistantHistoryByTurn.clear();
-      reasoningByKey.clear();
-      reasoningOccurrenceByKey.clear();
-      toolByKey.clear();
-      toolOccurrenceByKey.clear();
-    }
-    reasoningTextsSeenInTurn.clear();
-    reasoningTextHistoryInTurn.length = 0;
-    clearModelStreamReplayRuntime(replayRuntime);
-  };
-
-  const rememberStreamedReasoningText = (text: string) => {
-    const normalized = normalizeReasoningText(text);
-    if (!normalized) return;
-    reasoningTextsSeenInTurn.add(normalized);
-    reasoningTextHistoryInTurn.push(normalized);
-  };
-
-  const hasMatchingStreamedReasoningText = (text: string): boolean => {
-    const normalized = normalizeReasoningText(text);
-    if (!normalized) return false;
-    if (reasoningTextsSeenInTurn.has(normalized)) return true;
-
-    for (const state of reasoningByKey.values()) {
-      if (normalizeReasoningText(state.text) === normalized) {
-        return true;
-      }
-    }
-
-    const aggregate = normalizeTranscriptReplayText([
-      ...reasoningTextHistoryInTurn,
-      ...[...reasoningByKey.values()]
-        .map((state) => normalizeReasoningText(state.text))
-        .filter((current): current is string => current !== null),
-    ].join("\n\n"));
-    return Boolean(aggregate && aggregate === normalizeTranscriptReplayText(normalized));
-  };
-
-  const toolStreamKey = (turnId: string, key: string) => `${turnId}:${key}`;
-
-  const ensureToolState = (turnId: string, key: string, name: string) => {
-    const fullKey = toolStreamKey(turnId, key);
-    const existing = toolByKey.get(fullKey);
-    if (existing) {
-      existing.name = name;
-      return { fullKey, state: existing };
-    }
-    const nextOccurrence = (toolOccurrenceByKey.get(fullKey) ?? 0) + 1;
-    toolOccurrenceByKey.set(fullKey, nextOccurrence);
-    const next: BufferedToolState = {
-      itemId: occurrenceItemId(
-        makeItemId("toolCall", `${turnId}:${key}`),
-        nextOccurrence,
-      ),
-      name,
-      inputText: "",
-      started: false,
-    };
-    toolByKey.set(fullKey, next);
-    return { fullKey, state: next };
-  };
-
-  const emitToolStarted = (turnId: string, state: BufferedToolState) => {
-    if (state.started) return;
-    state.started = true;
-    sendNotification("item/started", {
-      threadId: opts.threadId,
-      turnId,
-      item: {
-        id: state.itemId,
-        type: "toolCall",
-        toolName: state.name,
-        state: "input-streaming",
-        ...(state.args !== undefined ? { args: state.args } : {}),
-      },
-    });
-  };
-
-  const emitToolCompleted = (
-    turnId: string,
-    key: string,
-    state: BufferedToolState,
-    itemState: "output-available" | "output-error" | "output-denied",
-    result: unknown,
-  ) => {
-    sendNotification("item/completed", {
-      threadId: opts.threadId,
-      turnId,
-      item: {
-        id: state.itemId,
-        type: "toolCall",
-        toolName: state.name,
-        state: itemState,
-        ...(state.args !== undefined ? { args: state.args } : {}),
-        result,
-      },
-    });
-    toolByKey.delete(toolStreamKey(turnId, key));
-  };
-
-  const handleModelStreamUpdate = (update: ModelStreamUpdate) => {
-    if (update.kind === "assistant_delta") {
-      if (update.phase === "commentary") return;
-      const currentText = update.text;
-      const state = ensureActiveAssistantState(update.turnId);
-      state.text = `${state.text}${currentText}`;
-      startAssistantState(update.turnId, state);
-      if (currentText) {
+  const handleProjectedEvent = (event: ProjectedEvent) => {
+    switch (event.type) {
+      case "turn/started":
+        sendNotification("turn/started", {
+          threadId: opts.threadId,
+          turn: event.turn,
+        });
+        return;
+      case "turn/completed":
+        sendNotification("turn/completed", {
+          threadId: opts.threadId,
+          turn: event.turn,
+        });
+        return;
+      case "item/started":
+        sendNotification("item/started", {
+          threadId: opts.threadId,
+          turnId: event.turnId,
+          item: event.item,
+        });
+        return;
+      case "item/completed":
+        sendNotification("item/completed", {
+          threadId: opts.threadId,
+          turnId: event.turnId,
+          item: event.item,
+        });
+        return;
+      case "item/agentMessage/delta":
         sendNotification("item/agentMessage/delta", {
           threadId: opts.threadId,
-          turnId: update.turnId,
-          itemId: state.itemId,
-          delta: currentText,
+          turnId: event.turnId,
+          itemId: event.itemId,
+          delta: event.delta,
         });
-      }
-      return;
-    }
-
-    if (update.kind === "assistant_text_end") {
-      completeAssistantStateBeforeStep(update.turnId);
-      return;
-    }
-
-    completeAssistantStateBeforeStep(update.turnId);
-
-    if (update.kind === "reasoning_start") {
-      const { state } = ensureBufferedReasoning(update.turnId, { id: update.streamId, mode: update.mode });
-      startBufferedReasoning(update.turnId, state);
-      return;
-    }
-
-    if (update.kind === "reasoning_delta") {
-      const { state } = ensureBufferedReasoning(update.turnId, { id: update.streamId, mode: update.mode });
-      startBufferedReasoning(update.turnId, state);
-      state.text = `${state.text}${update.text}`;
-      if (update.text) {
+        return;
+      case "item/reasoning/delta":
         sendNotification("item/reasoning/delta", {
           threadId: opts.threadId,
-          turnId: update.turnId,
-          itemId: state.itemId,
-          mode: state.mode,
-          delta: update.text,
+          turnId: event.turnId,
+          itemId: event.itemId,
+          mode: event.mode,
+          delta: event.delta,
         });
-      }
-      return;
-    }
-
-    if (update.kind === "reasoning_end") {
-      flushBufferedReasoning(update.turnId, `${update.turnId}:${update.streamId}`);
-      return;
-    }
-
-    if (update.kind === "tool_input_start") {
-      const { state } = ensureToolState(update.turnId, update.key, update.name);
-      if (update.args !== undefined) {
-        state.args = update.args;
-      }
-      emitToolStarted(update.turnId, state);
-      return;
-    }
-
-    if (update.kind === "tool_input_delta") {
-      const { state } = ensureToolState(update.turnId, update.key, "tool");
-      state.inputText = `${state.inputText}${update.delta}`;
-      state.args = normalizeToolArgsFromInput(state.inputText, state.args);
-      return;
-    }
-
-    if (update.kind === "tool_call") {
-      const { state } = ensureToolState(update.turnId, update.key, update.name);
-      if (update.args !== undefined) {
-        state.args = update.args;
-      }
-      emitToolStarted(update.turnId, state);
-      return;
-    }
-
-    if (update.kind === "tool_result") {
-      const { state } = ensureToolState(update.turnId, update.key, update.name);
-      emitToolCompleted(update.turnId, update.key, state, "output-available", update.result);
-      return;
-    }
-
-    if (update.kind === "tool_error") {
-      const { state } = ensureToolState(update.turnId, update.key, update.name);
-      emitToolCompleted(update.turnId, update.key, state, "output-error", { error: update.error });
-      return;
-    }
-
-    if (update.kind === "tool_output_denied") {
-      const { state } = ensureToolState(update.turnId, update.key, update.name);
-      emitToolCompleted(update.turnId, update.key, state, "output-denied", { denied: true, reason: update.reason });
+        return;
+      case "ask":
+        opts.onServerRequest?.({
+          id: event.requestId,
+          threadId: opts.threadId,
+          type: "ask",
+          method: "item/tool/requestUserInput",
+          params: {
+            threadId: opts.threadId,
+            turnId: event.turnId,
+            requestId: event.requestId,
+            itemId: event.itemId,
+            question: event.question,
+            ...(event.options ? { options: event.options } : {}),
+          },
+        });
+        return;
+      case "approval":
+        opts.onServerRequest?.({
+          id: event.requestId,
+          threadId: opts.threadId,
+          type: "approval",
+          method: "item/commandExecution/requestApproval",
+          params: {
+            threadId: opts.threadId,
+            turnId: event.turnId,
+            requestId: event.requestId,
+            itemId: event.itemId,
+            command: event.command,
+            dangerous: event.dangerous,
+            reason: event.reason,
+          },
+        });
+        return;
     }
   };
+
+  const core = createProjectionCore({
+    threadId: opts.threadId,
+    sink: { emit: handleProjectedEvent },
+    initialActiveTurnId: opts.initialActiveTurnId,
+    initialAgentText: opts.initialAgentText,
+  });
 
   return {
     handle(event: ServerEvent) {
+      if (core.handle(event)) return;
       if (event.sessionId !== opts.threadId) return;
 
       switch (event.type) {
-        case "user_message":
-          lastUserMessageText = event.text;
-          lastUserMessageClientMessageId = typeof event.clientMessageId === "string" ? event.clientMessageId : null;
-          return;
-        case "session_busy":
-          if (event.busy) {
-            if (activeTurnId && event.turnId && activeTurnId !== event.turnId) {
-              completeAssistantStateBeforeStep(activeTurnId);
-              clearTurnProjectionState(activeTurnId);
-            }
-            activeTurnId = event.turnId ?? null;
-            if (!activeTurnId) return;
-            sendNotification("turn/started", {
-              threadId: opts.threadId,
-              turn: {
-                id: activeTurnId,
-                status: "inProgress",
-                items: [],
-              },
-            });
-            if (lastUserMessageText) {
-              const itemId = makeItemId("userMessage", activeTurnId);
-              userItemIdByTurn.set(activeTurnId, itemId);
-              sendNotification("item/started", {
-                threadId: opts.threadId,
-                turnId: activeTurnId,
-                item: {
-                  id: itemId,
-                  type: "userMessage",
-                  content: [{ type: "text", text: lastUserMessageText }],
-                  ...(lastUserMessageClientMessageId ? { clientMessageId: lastUserMessageClientMessageId } : {}),
-                },
-              });
-              sendNotification("item/completed", {
-                threadId: opts.threadId,
-                turnId: activeTurnId,
-                item: {
-                  id: itemId,
-                  type: "userMessage",
-                  content: [{ type: "text", text: lastUserMessageText }],
-                  ...(lastUserMessageClientMessageId ? { clientMessageId: lastUserMessageClientMessageId } : {}),
-                },
-              });
-              lastUserMessageText = null;
-              lastUserMessageClientMessageId = null;
-            }
-            return;
-          }
-
-          if (event.turnId) {
-            completeAssistantStateBeforeStep(event.turnId);
-            clearTurnProjectionState(event.turnId);
-            sendNotification("turn/completed", {
-              threadId: opts.threadId,
-              turn: {
-                id: event.turnId,
-                status:
-                  event.outcome === "cancelled"
-                    ? "interrupted"
-                    : event.outcome === "error"
-                      ? "failed"
-                      : "completed",
-              },
-            });
-          }
-          activeTurnId = null;
-          return;
-        case "model_stream_raw": {
-          const updates = replayModelStreamRawEvent(replayRuntime, event as ModelStreamRawEvent);
-          for (const update of updates) {
-            handleModelStreamUpdate(update);
-          }
-          return;
-        }
-        case "model_stream_chunk":
-          if (shouldIgnoreNormalizedChunkForRawBackedTurn(replayRuntime, event as ModelStreamChunkEvent)) {
-            return;
-          }
-          {
-            const update = mapModelStreamChunk(event as ModelStreamChunkEvent);
-            if (update) {
-              handleModelStreamUpdate(update);
-            }
-          }
-          return;
-        case "assistant_message":
-          if (!activeTurnId) return;
-          {
-            const remainder = assistantRemainderForTurn(activeTurnId, event.text);
-            const activeAssistant = activeAssistantByTurn.get(activeTurnId);
-            if (activeAssistant) {
-              completeAssistantState(activeTurnId, remainder || activeAssistant.text);
-            } else if (remainder) {
-              const state = ensureActiveAssistantState(activeTurnId);
-              state.text = remainder;
-              startAssistantState(activeTurnId, state);
-              sendNotification("item/agentMessage/delta", {
-                threadId: opts.threadId,
-                turnId: activeTurnId,
-                itemId: state.itemId,
-                delta: remainder,
-              });
-              completeAssistantState(activeTurnId, remainder);
-            }
-          }
-          return;
-        case "reasoning":
-          if (!activeTurnId) return;
-          completeAssistantStateBeforeStep(activeTurnId);
-          emitReasoningItem(activeTurnId, event.kind, event.text, makeItemId("reasoning", `${activeTurnId}:${crypto.randomUUID()}`));
-          return;
         case "session_settings":
           sendNotification("cowork/session/settings", event);
           return;
@@ -688,12 +166,6 @@ export function createJsonRpcEventProjector(opts: CreateJsonRpcEventProjectorOpt
           return;
         case "agent_wait_result":
           sendNotification("cowork/session/agentWaitResult", event);
-          return;
-        case "ask":
-          handleAsk(event);
-          return;
-        case "approval":
-          handleApproval(event);
           return;
         case "log":
           sendNotification("cowork/log", event);

--- a/src/server/jsonrpc/journalProjector.ts
+++ b/src/server/jsonrpc/journalProjector.ts
@@ -1,29 +1,7 @@
 import type { ServerEvent } from "../protocol";
 import type { PersistedThreadJournalEvent } from "../sessionDb";
-import {
-  clearModelStreamReplayRuntime,
-  createModelStreamReplayRuntime,
-  replayModelStreamRawEvent,
-  shouldIgnoreNormalizedChunkForRawBackedTurn,
-  type ModelStreamReplayRuntime,
-} from "../../client/modelStreamReplay";
-import {
-  mapModelStreamChunk,
-  type ModelStreamChunkEvent,
-  type ModelStreamRawEvent,
-  type ModelStreamUpdate,
-} from "../../client/modelStream";
-import {
-  hasVisibleAssistantText,
-  makeItemId,
-  normalizeReasoningText,
-  normalizeToolArgsFromInput,
-  normalizeTranscriptReplayText,
-  occurrenceItemId,
-  readPartString,
-  reasoningModeFromPart,
-  type ProjectedReasoningMode,
-} from "./projectorShared";
+import { createProjectionCore } from "./projectionCore";
+import type { ProjectedEvent } from "./projectionCore.types";
 
 type ThreadJournalEmission = Omit<PersistedThreadJournalEvent, "seq">;
 
@@ -32,42 +10,7 @@ type CreateThreadJournalProjectorOptions = {
   emit: (event: ThreadJournalEmission) => void;
 };
 
-type BufferedReasoningState = {
-  itemId: string;
-  mode: ProjectedReasoningMode;
-  text: string;
-  started: boolean;
-};
-
-type BufferedAssistantState = {
-  itemId: string;
-  text: string;
-  started: boolean;
-};
-
-type BufferedToolState = {
-  itemId: string;
-  name: string;
-  args?: unknown;
-  inputText: string;
-  started: boolean;
-};
-
 export function createThreadJournalProjector(opts: CreateThreadJournalProjectorOptions) {
-  let activeTurnId: string | null = null;
-  let lastUserMessageText: string | null = null;
-  let lastUserMessageClientMessageId: string | null = null;
-  const activeAssistantByTurn = new Map<string, BufferedAssistantState>();
-  const assistantOccurrenceByTurn = new Map<string, number>();
-  const assistantHistoryByTurn = new Map<string, string>();
-  const reasoningByKey = new Map<string, BufferedReasoningState>();
-  const reasoningOccurrenceByKey = new Map<string, number>();
-  const reasoningTextsSeenInTurn = new Set<string>();
-  const reasoningTextHistoryInTurn: string[] = [];
-  const toolByKey = new Map<string, BufferedToolState>();
-  const toolOccurrenceByKey = new Map<string, number>();
-  const replayRuntime: ModelStreamReplayRuntime = createModelStreamReplayRuntime();
-
   const emit = (eventType: string, payload: unknown, meta?: {
     turnId?: string | null;
     itemId?: string | null;
@@ -84,536 +27,83 @@ export function createThreadJournalProjector(opts: CreateThreadJournalProjectorO
     });
   };
 
-  const ensureActiveAssistantState = (turnId: string) => {
-    const existing = activeAssistantByTurn.get(turnId);
-    if (existing) return existing;
-    const nextOccurrence = (assistantOccurrenceByTurn.get(turnId) ?? 0) + 1;
-    assistantOccurrenceByTurn.set(turnId, nextOccurrence);
-    const next: BufferedAssistantState = {
-      itemId: occurrenceItemId(makeItemId("agentMessage", turnId), nextOccurrence),
-      text: "",
-      started: false,
-    };
-    activeAssistantByTurn.set(turnId, next);
-    return next;
-  };
-
-  const startAssistantState = (turnId: string, state: BufferedAssistantState) => {
-    if (state.started) return;
-    state.started = true;
-    emit("item/started", {
-      threadId: opts.threadId,
-      turnId,
-      item: {
-        id: state.itemId,
-        type: "agentMessage",
-        text: "",
-      },
-    }, { turnId, itemId: state.itemId });
-  };
-
-  const completeAssistantState = (turnId: string, finalText?: string) => {
-    const state = activeAssistantByTurn.get(turnId);
-    if (!state) return;
-    const text = finalText ?? state.text;
-    activeAssistantByTurn.delete(turnId);
-    if (!hasVisibleAssistantText(text)) return;
-    startAssistantState(turnId, state);
-    emit("item/completed", {
-      threadId: opts.threadId,
-      turnId,
-      item: {
-        id: state.itemId,
-        type: "agentMessage",
-        text,
-      },
-    }, { turnId, itemId: state.itemId });
-    assistantHistoryByTurn.set(turnId, `${assistantHistoryByTurn.get(turnId) ?? ""}${text}`);
-  };
-
-  const completeAssistantStateBeforeStep = (turnId: string) => {
-    const state = activeAssistantByTurn.get(turnId);
-    if (!state) return;
-    if (state.text) {
-      completeAssistantState(turnId, state.text);
-      return;
-    }
-    activeAssistantByTurn.delete(turnId);
-  };
-
-  const assistantRemainderForTurn = (turnId: string, text: string) => {
-    const history = assistantHistoryByTurn.get(turnId) ?? "";
-    if (!history) return text;
-    if (text.startsWith(history)) return text.slice(history.length);
-
-    const trimmedHistory = history.trimStart();
-    if (trimmedHistory && text.startsWith(trimmedHistory)) {
-      return text.slice(trimmedHistory.length);
-    }
-
-    const normalizedHistory = normalizeTranscriptReplayText(history);
-    const normalizedText = normalizeTranscriptReplayText(text);
-    if (normalizedHistory && normalizedText === normalizedHistory) {
-      return "";
-    }
-
-    return text;
-  };
-
-  const reasoningStreamKey = (turnId: string, part: Record<string, unknown> | undefined) =>
-    `${turnId}:${readPartString(part, "id") ?? "default"}`;
-
-  const ensureBufferedReasoning = (turnId: string, part: Record<string, unknown> | undefined) => {
-    const key = reasoningStreamKey(turnId, part);
-    const existing = reasoningByKey.get(key);
-    if (existing) {
-      existing.mode = reasoningModeFromPart(part);
-      return { key, state: existing };
-    }
-    const streamId = readPartString(part, "id") ?? "default";
-    const nextOccurrence = (reasoningOccurrenceByKey.get(key) ?? 0) + 1;
-    reasoningOccurrenceByKey.set(key, nextOccurrence);
-    const next: BufferedReasoningState = {
-      itemId: occurrenceItemId(
-        makeItemId("reasoning", `${turnId}:${streamId}`),
-        nextOccurrence,
-      ),
-      mode: reasoningModeFromPart(part),
-      text: "",
-      started: false,
-    };
-    reasoningByKey.set(key, next);
-    return { key, state: next };
-  };
-
-  const startBufferedReasoning = (turnId: string, state: BufferedReasoningState) => {
-    if (state.started) return;
-    state.started = true;
-    emit("item/started", {
-      threadId: opts.threadId,
-      turnId,
-      item: {
-        id: state.itemId,
-        type: "reasoning",
-        mode: state.mode,
-        text: "",
-      },
-    }, { turnId, itemId: state.itemId });
-  };
-
-  const emitReasoningItem = (
-    turnId: string,
-    mode: ProjectedReasoningMode,
-    text: string,
-    itemId = makeItemId("reasoning", `${turnId}:${crypto.randomUUID()}`),
-  ) => {
-    if (!text.trim()) return false;
-    if (hasMatchingStreamedReasoningText(text)) {
-      return false;
-    }
-    const item = {
-      id: itemId,
-      type: "reasoning",
-      mode,
-      text,
-    };
-    emit("item/started", {
-      threadId: opts.threadId,
-      turnId,
-      item,
-    }, { turnId, itemId });
-    emit("item/completed", {
-      threadId: opts.threadId,
-      turnId,
-      item,
-    }, { turnId, itemId });
-    return true;
-  };
-
-  const flushBufferedReasoning = (turnId: string, key: string) => {
-    const state = reasoningByKey.get(key);
-    if (!state) return;
-    reasoningByKey.delete(key);
-    startBufferedReasoning(turnId, state);
-    emit("item/completed", {
-      threadId: opts.threadId,
-      turnId,
-      item: {
-        id: state.itemId,
-        type: "reasoning",
-        mode: state.mode,
-        text: state.text,
-      },
-    }, { turnId, itemId: state.itemId });
-    rememberStreamedReasoningText(state.text);
-  };
-
-  const clearReasoningStateForTurn = (turnId: string) => {
-    for (const key of reasoningByKey.keys()) {
-      if (key.startsWith(`${turnId}:`)) {
-        reasoningByKey.delete(key);
-      }
-    }
-    for (const key of reasoningOccurrenceByKey.keys()) {
-      if (key.startsWith(`${turnId}:`)) {
-        reasoningOccurrenceByKey.delete(key);
-      }
-    }
-  };
-
-  const clearToolStateForTurn = (turnId: string) => {
-    for (const key of toolByKey.keys()) {
-      if (key.startsWith(`${turnId}:`)) {
-        toolByKey.delete(key);
-      }
-    }
-    for (const key of toolOccurrenceByKey.keys()) {
-      if (key.startsWith(`${turnId}:`)) {
-        toolOccurrenceByKey.delete(key);
-      }
-    }
-  };
-
-  const clearTurnProjectionState = (turnId: string | null) => {
-    if (turnId) {
-      activeAssistantByTurn.delete(turnId);
-      assistantOccurrenceByTurn.delete(turnId);
-      assistantHistoryByTurn.delete(turnId);
-      clearReasoningStateForTurn(turnId);
-      clearToolStateForTurn(turnId);
-    } else {
-      activeAssistantByTurn.clear();
-      assistantOccurrenceByTurn.clear();
-      assistantHistoryByTurn.clear();
-      reasoningByKey.clear();
-      reasoningOccurrenceByKey.clear();
-      toolByKey.clear();
-      toolOccurrenceByKey.clear();
-    }
-    reasoningTextsSeenInTurn.clear();
-    reasoningTextHistoryInTurn.length = 0;
-    clearModelStreamReplayRuntime(replayRuntime);
-  };
-
-  const rememberStreamedReasoningText = (text: string) => {
-    const normalized = normalizeReasoningText(text);
-    if (!normalized) return;
-    reasoningTextsSeenInTurn.add(normalized);
-    reasoningTextHistoryInTurn.push(normalized);
-  };
-
-  const hasMatchingStreamedReasoningText = (text: string): boolean => {
-    const normalized = normalizeReasoningText(text);
-    if (!normalized) return false;
-    if (reasoningTextsSeenInTurn.has(normalized)) return true;
-
-    for (const state of reasoningByKey.values()) {
-      if (normalizeReasoningText(state.text) === normalized) {
-        return true;
-      }
-    }
-
-    const aggregate = normalizeTranscriptReplayText([
-      ...reasoningTextHistoryInTurn,
-      ...[...reasoningByKey.values()]
-        .map((state) => normalizeReasoningText(state.text))
-        .filter((current): current is string => current !== null),
-    ].join("\n\n"));
-    return Boolean(aggregate && aggregate === normalizeTranscriptReplayText(normalized));
-  };
-
-  const toolStreamKey = (turnId: string, key: string) => `${turnId}:${key}`;
-
-  const ensureToolState = (turnId: string, key: string, name: string) => {
-    const fullKey = toolStreamKey(turnId, key);
-    const existing = toolByKey.get(fullKey);
-    if (existing) {
-      existing.name = name;
-      return { fullKey, state: existing };
-    }
-    const nextOccurrence = (toolOccurrenceByKey.get(fullKey) ?? 0) + 1;
-    toolOccurrenceByKey.set(fullKey, nextOccurrence);
-    const next: BufferedToolState = {
-      itemId: occurrenceItemId(
-        makeItemId("toolCall", `${turnId}:${key}`),
-        nextOccurrence,
-      ),
-      name,
-      inputText: "",
-      started: false,
-    };
-    toolByKey.set(fullKey, next);
-    return { fullKey, state: next };
-  };
-
-  const emitToolStarted = (turnId: string, state: BufferedToolState) => {
-    if (state.started) return;
-    state.started = true;
-    emit("item/started", {
-      threadId: opts.threadId,
-      turnId,
-      item: {
-        id: state.itemId,
-        type: "toolCall",
-        toolName: state.name,
-        state: "input-streaming",
-        ...(state.args !== undefined ? { args: state.args } : {}),
-      },
-    }, { turnId, itemId: state.itemId });
-  };
-
-  const emitToolCompleted = (
-    turnId: string,
-    key: string,
-    state: BufferedToolState,
-    itemState: "output-available" | "output-error" | "output-denied",
-    result: unknown,
-  ) => {
-    emit("item/completed", {
-      threadId: opts.threadId,
-      turnId,
-      item: {
-        id: state.itemId,
-        type: "toolCall",
-        toolName: state.name,
-        state: itemState,
-        ...(state.args !== undefined ? { args: state.args } : {}),
-        result,
-      },
-    }, { turnId, itemId: state.itemId });
-    toolByKey.delete(toolStreamKey(turnId, key));
-  };
-
-  const handleModelStreamUpdate = (update: ModelStreamUpdate) => {
-    if (update.kind === "assistant_delta") {
-      if (update.phase === "commentary") return;
-      const delta = update.text;
-      const state = ensureActiveAssistantState(update.turnId);
-      state.text = `${state.text}${delta}`;
-      startAssistantState(update.turnId, state);
-      if (delta) {
+  const handleProjectedEvent = (event: ProjectedEvent) => {
+    switch (event.type) {
+      case "turn/started":
+        emit("turn/started", {
+          threadId: opts.threadId,
+          turn: event.turn,
+        }, { turnId: event.turnId });
+        return;
+      case "turn/completed":
+        emit("turn/completed", {
+          threadId: opts.threadId,
+          turn: event.turn,
+        }, { turnId: event.turnId });
+        return;
+      case "item/started":
+        emit("item/started", {
+          threadId: opts.threadId,
+          turnId: event.turnId,
+          item: event.item,
+        }, { turnId: event.turnId, itemId: event.item.id });
+        return;
+      case "item/completed":
+        emit("item/completed", {
+          threadId: opts.threadId,
+          turnId: event.turnId,
+          item: event.item,
+        }, { turnId: event.turnId, itemId: event.item.id });
+        return;
+      case "item/agentMessage/delta":
         emit("item/agentMessage/delta", {
           threadId: opts.threadId,
-          turnId: update.turnId,
-          itemId: state.itemId,
-          delta,
-        }, { turnId: update.turnId, itemId: state.itemId });
-      }
-      return;
-    }
-
-    if (update.kind === "assistant_text_end") {
-      completeAssistantStateBeforeStep(update.turnId);
-      return;
-    }
-
-    completeAssistantStateBeforeStep(update.turnId);
-
-    if (update.kind === "reasoning_start") {
-      const { state } = ensureBufferedReasoning(update.turnId, { id: update.streamId, mode: update.mode });
-      startBufferedReasoning(update.turnId, state);
-      return;
-    }
-
-    if (update.kind === "reasoning_delta") {
-      const { state } = ensureBufferedReasoning(update.turnId, { id: update.streamId, mode: update.mode });
-      startBufferedReasoning(update.turnId, state);
-      state.text = `${state.text}${update.text}`;
-      if (update.text) {
+          turnId: event.turnId,
+          itemId: event.itemId,
+          delta: event.delta,
+        }, { turnId: event.turnId, itemId: event.itemId });
+        return;
+      case "item/reasoning/delta":
         emit("item/reasoning/delta", {
           threadId: opts.threadId,
-          turnId: update.turnId,
-          itemId: state.itemId,
-          mode: state.mode,
-          delta: update.text,
-        }, { turnId: update.turnId, itemId: state.itemId });
-      }
-      return;
-    }
-
-    if (update.kind === "reasoning_end") {
-      flushBufferedReasoning(update.turnId, `${update.turnId}:${update.streamId}`);
-      return;
-    }
-
-    if (update.kind === "tool_input_start") {
-      const { state } = ensureToolState(update.turnId, update.key, update.name);
-      if (update.args !== undefined) {
-        state.args = update.args;
-      }
-      emitToolStarted(update.turnId, state);
-      return;
-    }
-
-    if (update.kind === "tool_input_delta") {
-      const { state } = ensureToolState(update.turnId, update.key, "tool");
-      state.inputText = `${state.inputText}${update.delta}`;
-      state.args = normalizeToolArgsFromInput(state.inputText, state.args);
-      return;
-    }
-
-    if (update.kind === "tool_call") {
-      const { state } = ensureToolState(update.turnId, update.key, update.name);
-      if (update.args !== undefined) {
-        state.args = update.args;
-      }
-      emitToolStarted(update.turnId, state);
-      return;
-    }
-
-    if (update.kind === "tool_result") {
-      const { state } = ensureToolState(update.turnId, update.key, update.name);
-      emitToolCompleted(update.turnId, update.key, state, "output-available", update.result);
-      return;
-    }
-
-    if (update.kind === "tool_error") {
-      const { state } = ensureToolState(update.turnId, update.key, update.name);
-      emitToolCompleted(update.turnId, update.key, state, "output-error", { error: update.error });
-      return;
-    }
-
-    if (update.kind === "tool_output_denied") {
-      const { state } = ensureToolState(update.turnId, update.key, update.name);
-      emitToolCompleted(update.turnId, update.key, state, "output-denied", { denied: true, reason: update.reason });
+          turnId: event.turnId,
+          itemId: event.itemId,
+          mode: event.mode,
+          delta: event.delta,
+        }, { turnId: event.turnId, itemId: event.itemId });
+        return;
+      case "ask":
+        emit("request:item/tool/requestUserInput", {
+          threadId: opts.threadId,
+          turnId: event.turnId,
+          requestId: event.requestId,
+          itemId: event.itemId,
+          question: event.question,
+          ...(event.options ? { options: event.options } : {}),
+        }, { turnId: event.turnId, requestId: event.requestId, itemId: event.itemId });
+        return;
+      case "approval":
+        emit("request:item/commandExecution/requestApproval", {
+          threadId: opts.threadId,
+          turnId: event.turnId,
+          requestId: event.requestId,
+          itemId: event.itemId,
+          command: event.command,
+          dangerous: event.dangerous,
+          reason: event.reason,
+        }, { turnId: event.turnId, requestId: event.requestId, itemId: event.itemId });
+        return;
     }
   };
+
+  const core = createProjectionCore({
+    threadId: opts.threadId,
+    sink: { emit: handleProjectedEvent },
+  });
 
   return {
     handle(event: ServerEvent) {
-      if (event.sessionId !== opts.threadId) return;
-
-      switch (event.type) {
-        case "user_message":
-          lastUserMessageText = event.text;
-          lastUserMessageClientMessageId = typeof event.clientMessageId === "string" ? event.clientMessageId : null;
-          return;
-        case "session_busy":
-          if (event.busy) {
-            if (activeTurnId && event.turnId && activeTurnId !== event.turnId) {
-              completeAssistantStateBeforeStep(activeTurnId);
-              clearTurnProjectionState(activeTurnId);
-            }
-            activeTurnId = event.turnId ?? null;
-            if (!activeTurnId) return;
-            emit("turn/started", {
-              threadId: opts.threadId,
-              turn: {
-                id: activeTurnId,
-                status: "inProgress",
-                items: [],
-              },
-            }, { turnId: activeTurnId });
-            if (lastUserMessageText) {
-              const itemId = makeItemId("userMessage", activeTurnId);
-              const item = {
-                id: itemId,
-                type: "userMessage",
-                content: [{ type: "text", text: lastUserMessageText }],
-                ...(lastUserMessageClientMessageId ? { clientMessageId: lastUserMessageClientMessageId } : {}),
-              };
-              emit("item/started", {
-                threadId: opts.threadId,
-                turnId: activeTurnId,
-                item,
-              }, { turnId: activeTurnId, itemId });
-              emit("item/completed", {
-                threadId: opts.threadId,
-                turnId: activeTurnId,
-                item,
-              }, { turnId: activeTurnId, itemId });
-              lastUserMessageText = null;
-              lastUserMessageClientMessageId = null;
-            }
-            return;
-          }
-
-          if (event.turnId) {
-            completeAssistantStateBeforeStep(event.turnId);
-            clearTurnProjectionState(event.turnId);
-            emit("turn/completed", {
-              threadId: opts.threadId,
-              turn: {
-                id: event.turnId,
-                status:
-                  event.outcome === "cancelled"
-                    ? "interrupted"
-                    : event.outcome === "error"
-                      ? "failed"
-                      : "completed",
-              },
-            }, { turnId: event.turnId });
-          }
-          activeTurnId = null;
-          return;
-        case "model_stream_raw": {
-          const updates = replayModelStreamRawEvent(replayRuntime, event as ModelStreamRawEvent);
-          for (const update of updates) {
-            handleModelStreamUpdate(update);
-          }
-          return;
-        }
-        case "model_stream_chunk":
-          if (shouldIgnoreNormalizedChunkForRawBackedTurn(replayRuntime, event as ModelStreamChunkEvent)) {
-            return;
-          }
-          {
-            const update = mapModelStreamChunk(event as ModelStreamChunkEvent);
-            if (update) {
-              handleModelStreamUpdate(update);
-            }
-          }
-          return;
-        case "assistant_message":
-          if (!activeTurnId) return;
-          {
-            const remainder = assistantRemainderForTurn(activeTurnId, event.text);
-            const activeAssistant = activeAssistantByTurn.get(activeTurnId);
-            if (activeAssistant) {
-              completeAssistantState(activeTurnId, remainder || activeAssistant.text);
-            } else if (remainder) {
-              const state = ensureActiveAssistantState(activeTurnId);
-              state.text = remainder;
-              startAssistantState(activeTurnId, state);
-              emit("item/agentMessage/delta", {
-                threadId: opts.threadId,
-                turnId: activeTurnId,
-                itemId: state.itemId,
-                delta: remainder,
-              }, { turnId: activeTurnId, itemId: state.itemId });
-              completeAssistantState(activeTurnId, remainder);
-            }
-          }
-          return;
-        case "reasoning":
-          if (!activeTurnId) return;
-          completeAssistantStateBeforeStep(activeTurnId);
-          emitReasoningItem(activeTurnId, event.kind, event.text, makeItemId("reasoning", `${activeTurnId}:${crypto.randomUUID()}`));
-          return;
-        case "ask":
-          emit("request:item/tool/requestUserInput", {
-            threadId: opts.threadId,
-            turnId: activeTurnId,
-            requestId: event.requestId,
-            itemId: makeItemId("requestUserInput", event.requestId),
-            question: event.question,
-            options: event.options,
-          }, { turnId: activeTurnId, requestId: event.requestId, itemId: makeItemId("requestUserInput", event.requestId) });
-          return;
-        case "approval":
-          emit("request:item/commandExecution/requestApproval", {
-            threadId: opts.threadId,
-            turnId: activeTurnId,
-            requestId: event.requestId,
-            itemId: makeItemId("commandExecution", event.requestId),
-            command: event.command,
-            dangerous: event.dangerous,
-            reason: event.reasonCode,
-          }, { turnId: activeTurnId, requestId: event.requestId, itemId: makeItemId("commandExecution", event.requestId) });
-          return;
-        default:
-          return;
-      }
+      core.handle(event);
     },
   };
 }

--- a/src/server/jsonrpc/projectionCore.ts
+++ b/src/server/jsonrpc/projectionCore.ts
@@ -1,0 +1,635 @@
+import type { ServerEvent } from "../protocol";
+import {
+  clearModelStreamReplayRuntime,
+  createModelStreamReplayRuntime,
+  replayModelStreamRawEvent,
+  shouldIgnoreNormalizedChunkForRawBackedTurn,
+  type ModelStreamReplayRuntime,
+} from "../../client/modelStreamReplay";
+import {
+  mapModelStreamChunk,
+  type ModelStreamChunkEvent,
+  type ModelStreamRawEvent,
+  type ModelStreamUpdate,
+} from "../../client/modelStream";
+import {
+  hasVisibleAssistantText,
+  makeItemId,
+  normalizeReasoningText,
+  normalizeToolArgsFromInput,
+  normalizeTranscriptReplayText,
+  occurrenceItemId,
+  readPartString,
+  reasoningModeFromPart,
+  type ProjectedReasoningMode,
+} from "./projectorShared";
+import type {
+  ProjectionSink,
+  ProjectedAgentMessageItem,
+  ProjectedItem,
+  ProjectedReasoningItem,
+  ProjectedToolCallItem,
+  ProjectedUserMessageItem,
+} from "./projectionCore.types";
+
+type CreateProjectionCoreOptions = {
+  threadId: string;
+  sink: ProjectionSink;
+  initialActiveTurnId?: string | null;
+  initialAgentText?: string | null;
+};
+
+type BufferedReasoningState = {
+  itemId: string;
+  mode: ProjectedReasoningMode;
+  text: string;
+  started: boolean;
+};
+
+type BufferedAssistantState = {
+  itemId: string;
+  text: string;
+  started: boolean;
+};
+
+type BufferedToolState = {
+  itemId: string;
+  name: string;
+  args?: unknown;
+  inputText: string;
+  started: boolean;
+};
+
+export function createProjectionCore(opts: CreateProjectionCoreOptions) {
+  let activeTurnId: string | null = opts.initialActiveTurnId ?? null;
+  let lastUserMessageText: string | null = null;
+  let lastUserMessageClientMessageId: string | null = null;
+  const activeAssistantByTurn = new Map<string, BufferedAssistantState>();
+  const assistantOccurrenceByTurn = new Map<string, number>();
+  const assistantHistoryByTurn = new Map<string, string>();
+  const reasoningByKey = new Map<string, BufferedReasoningState>();
+  const reasoningOccurrenceByKey = new Map<string, number>();
+  const reasoningTextsSeenInTurn = new Set<string>();
+  const reasoningTextHistoryInTurn: string[] = [];
+  const toolByKey = new Map<string, BufferedToolState>();
+  const toolOccurrenceByKey = new Map<string, number>();
+  const replayRuntime: ModelStreamReplayRuntime = createModelStreamReplayRuntime();
+
+  if (activeTurnId) {
+    activeAssistantByTurn.set(activeTurnId, {
+      itemId: makeItemId("agentMessage", activeTurnId),
+      text: opts.initialAgentText ?? "",
+      started: true,
+    });
+    assistantOccurrenceByTurn.set(activeTurnId, 1);
+  }
+
+  const emit = (event: Parameters<ProjectionSink["emit"]>[0]) => {
+    opts.sink.emit(event);
+  };
+
+  const emitTurnStarted = (turnId: string) => {
+    emit({
+      type: "turn/started",
+      turnId,
+      turn: {
+        id: turnId,
+        status: "inProgress",
+        items: [],
+      },
+    });
+  };
+
+  const emitTurnCompleted = (
+    turnId: string,
+    status: "completed" | "interrupted" | "failed",
+  ) => {
+    emit({
+      type: "turn/completed",
+      turnId,
+      turn: {
+        id: turnId,
+        status,
+      },
+    });
+  };
+
+  const emitItemStarted = (turnId: string, item: ProjectedItem) => {
+    emit({ type: "item/started", turnId, item });
+  };
+
+  const emitItemCompleted = (turnId: string, item: ProjectedItem) => {
+    emit({ type: "item/completed", turnId, item });
+  };
+
+  const emitAssistantDelta = (turnId: string, itemId: string, delta: string) => {
+    emit({ type: "item/agentMessage/delta", turnId, itemId, delta });
+  };
+
+  const emitReasoningDelta = (
+    turnId: string,
+    itemId: string,
+    mode: ProjectedReasoningMode,
+    delta: string,
+  ) => {
+    emit({ type: "item/reasoning/delta", turnId, itemId, mode, delta });
+  };
+
+  const emitAsk = (evt: Extract<ServerEvent, { type: "ask" }>) => {
+    emit({
+      type: "ask",
+      turnId: activeTurnId,
+      requestId: evt.requestId,
+      itemId: makeItemId("requestUserInput", evt.requestId),
+      question: evt.question,
+      ...(evt.options ? { options: evt.options } : {}),
+    });
+  };
+
+  const emitApproval = (evt: Extract<ServerEvent, { type: "approval" }>) => {
+    emit({
+      type: "approval",
+      turnId: activeTurnId,
+      requestId: evt.requestId,
+      itemId: makeItemId("commandExecution", evt.requestId),
+      command: evt.command,
+      dangerous: evt.dangerous,
+      reason: evt.reasonCode,
+    });
+  };
+
+  const agentMessageItem = (itemId: string, text: string): ProjectedAgentMessageItem => ({
+    id: itemId,
+    type: "agentMessage",
+    text,
+  });
+
+  const userMessageItem = (
+    turnId: string,
+    text: string,
+    clientMessageId: string | null,
+  ): ProjectedUserMessageItem => ({
+    id: makeItemId("userMessage", turnId),
+    type: "userMessage",
+    content: [{ type: "text", text }],
+    ...(clientMessageId ? { clientMessageId } : {}),
+  });
+
+  const reasoningItem = (
+    itemId: string,
+    mode: ProjectedReasoningMode,
+    text: string,
+  ): ProjectedReasoningItem => ({
+    id: itemId,
+    type: "reasoning",
+    mode,
+    text,
+  });
+
+  const toolCallItem = (
+    itemId: string,
+    name: string,
+    state: ProjectedToolCallItem["state"],
+    args?: unknown,
+    result?: unknown,
+  ): ProjectedToolCallItem => ({
+    id: itemId,
+    type: "toolCall",
+    toolName: name,
+    state,
+    ...(args !== undefined ? { args } : {}),
+    ...(result !== undefined ? { result } : {}),
+  });
+
+  const ensureActiveAssistantState = (turnId: string) => {
+    const existing = activeAssistantByTurn.get(turnId);
+    if (existing) return existing;
+    const nextOccurrence = (assistantOccurrenceByTurn.get(turnId) ?? 0) + 1;
+    assistantOccurrenceByTurn.set(turnId, nextOccurrence);
+    const next: BufferedAssistantState = {
+      itemId: occurrenceItemId(makeItemId("agentMessage", turnId), nextOccurrence),
+      text: "",
+      started: false,
+    };
+    activeAssistantByTurn.set(turnId, next);
+    return next;
+  };
+
+  const startAssistantState = (turnId: string, state: BufferedAssistantState) => {
+    if (state.started) return;
+    state.started = true;
+    emitItemStarted(turnId, agentMessageItem(state.itemId, ""));
+  };
+
+  const completeAssistantState = (turnId: string, finalText?: string) => {
+    const state = activeAssistantByTurn.get(turnId);
+    if (!state) return;
+    const text = finalText ?? state.text;
+    activeAssistantByTurn.delete(turnId);
+    if (!hasVisibleAssistantText(text)) return;
+    startAssistantState(turnId, state);
+    emitItemCompleted(turnId, agentMessageItem(state.itemId, text));
+    assistantHistoryByTurn.set(turnId, `${assistantHistoryByTurn.get(turnId) ?? ""}${text}`);
+  };
+
+  const completeAssistantStateBeforeStep = (turnId: string) => {
+    const state = activeAssistantByTurn.get(turnId);
+    if (!state) return;
+    if (state.text) {
+      completeAssistantState(turnId, state.text);
+      return;
+    }
+    activeAssistantByTurn.delete(turnId);
+  };
+
+  const assistantRemainderForTurn = (turnId: string, text: string) => {
+    const history = assistantHistoryByTurn.get(turnId) ?? "";
+    if (!history) return text;
+    if (text.startsWith(history)) return text.slice(history.length);
+
+    const trimmedHistory = history.trimStart();
+    if (trimmedHistory && text.startsWith(trimmedHistory)) {
+      return text.slice(trimmedHistory.length);
+    }
+
+    const normalizedHistory = normalizeTranscriptReplayText(history);
+    const normalizedText = normalizeTranscriptReplayText(text);
+    if (normalizedHistory && normalizedText === normalizedHistory) {
+      return "";
+    }
+
+    return text;
+  };
+
+  const reasoningStreamKey = (turnId: string, part: Record<string, unknown> | undefined) =>
+    `${turnId}:${readPartString(part, "id") ?? "default"}`;
+
+  const ensureBufferedReasoning = (turnId: string, part: Record<string, unknown> | undefined) => {
+    const key = reasoningStreamKey(turnId, part);
+    const existing = reasoningByKey.get(key);
+    if (existing) {
+      existing.mode = reasoningModeFromPart(part);
+      return { key, state: existing };
+    }
+    const streamId = readPartString(part, "id") ?? "default";
+    const nextOccurrence = (reasoningOccurrenceByKey.get(key) ?? 0) + 1;
+    reasoningOccurrenceByKey.set(key, nextOccurrence);
+    const next: BufferedReasoningState = {
+      itemId: occurrenceItemId(
+        makeItemId("reasoning", `${turnId}:${streamId}`),
+        nextOccurrence,
+      ),
+      mode: reasoningModeFromPart(part),
+      text: "",
+      started: false,
+    };
+    reasoningByKey.set(key, next);
+    return { key, state: next };
+  };
+
+  const startBufferedReasoning = (turnId: string, state: BufferedReasoningState) => {
+    if (state.started) return;
+    state.started = true;
+    emitItemStarted(turnId, reasoningItem(state.itemId, state.mode, ""));
+  };
+
+  const emitReasoningItem = (
+    turnId: string,
+    mode: ProjectedReasoningMode,
+    text: string,
+    itemId = makeItemId("reasoning", `${turnId}:${crypto.randomUUID()}`),
+  ) => {
+    if (!text.trim()) return false;
+    if (hasMatchingStreamedReasoningText(text)) {
+      return false;
+    }
+    const item = reasoningItem(itemId, mode, text);
+    emitItemStarted(turnId, item);
+    emitItemCompleted(turnId, item);
+    return true;
+  };
+
+  const flushBufferedReasoning = (turnId: string, key: string) => {
+    const state = reasoningByKey.get(key);
+    if (!state) return;
+    reasoningByKey.delete(key);
+    startBufferedReasoning(turnId, state);
+    emitItemCompleted(turnId, reasoningItem(state.itemId, state.mode, state.text));
+    rememberStreamedReasoningText(state.text);
+  };
+
+  const clearReasoningStateForTurn = (turnId: string) => {
+    for (const key of reasoningByKey.keys()) {
+      if (key.startsWith(`${turnId}:`)) {
+        reasoningByKey.delete(key);
+      }
+    }
+    for (const key of reasoningOccurrenceByKey.keys()) {
+      if (key.startsWith(`${turnId}:`)) {
+        reasoningOccurrenceByKey.delete(key);
+      }
+    }
+  };
+
+  const clearToolStateForTurn = (turnId: string) => {
+    for (const key of toolByKey.keys()) {
+      if (key.startsWith(`${turnId}:`)) {
+        toolByKey.delete(key);
+      }
+    }
+    for (const key of toolOccurrenceByKey.keys()) {
+      if (key.startsWith(`${turnId}:`)) {
+        toolOccurrenceByKey.delete(key);
+      }
+    }
+  };
+
+  const clearTurnProjectionState = (turnId: string | null) => {
+    if (turnId) {
+      activeAssistantByTurn.delete(turnId);
+      assistantOccurrenceByTurn.delete(turnId);
+      assistantHistoryByTurn.delete(turnId);
+      clearReasoningStateForTurn(turnId);
+      clearToolStateForTurn(turnId);
+    } else {
+      activeAssistantByTurn.clear();
+      assistantOccurrenceByTurn.clear();
+      assistantHistoryByTurn.clear();
+      reasoningByKey.clear();
+      reasoningOccurrenceByKey.clear();
+      toolByKey.clear();
+      toolOccurrenceByKey.clear();
+    }
+    reasoningTextsSeenInTurn.clear();
+    reasoningTextHistoryInTurn.length = 0;
+    clearModelStreamReplayRuntime(replayRuntime);
+  };
+
+  const rememberStreamedReasoningText = (text: string) => {
+    const normalized = normalizeReasoningText(text);
+    if (!normalized) return;
+    reasoningTextsSeenInTurn.add(normalized);
+    reasoningTextHistoryInTurn.push(normalized);
+  };
+
+  const hasMatchingStreamedReasoningText = (text: string): boolean => {
+    const normalized = normalizeReasoningText(text);
+    if (!normalized) return false;
+    if (reasoningTextsSeenInTurn.has(normalized)) return true;
+
+    for (const state of reasoningByKey.values()) {
+      if (normalizeReasoningText(state.text) === normalized) {
+        return true;
+      }
+    }
+
+    const aggregate = normalizeTranscriptReplayText([
+      ...reasoningTextHistoryInTurn,
+      ...[...reasoningByKey.values()]
+        .map((state) => normalizeReasoningText(state.text))
+        .filter((current): current is string => current !== null),
+    ].join("\n\n"));
+    return Boolean(aggregate && aggregate === normalizeTranscriptReplayText(normalized));
+  };
+
+  const toolStreamKey = (turnId: string, key: string) => `${turnId}:${key}`;
+
+  const ensureToolState = (turnId: string, key: string, name: string) => {
+    const fullKey = toolStreamKey(turnId, key);
+    const existing = toolByKey.get(fullKey);
+    if (existing) {
+      existing.name = name;
+      return { fullKey, state: existing };
+    }
+    const nextOccurrence = (toolOccurrenceByKey.get(fullKey) ?? 0) + 1;
+    toolOccurrenceByKey.set(fullKey, nextOccurrence);
+    const next: BufferedToolState = {
+      itemId: occurrenceItemId(
+        makeItemId("toolCall", `${turnId}:${key}`),
+        nextOccurrence,
+      ),
+      name,
+      inputText: "",
+      started: false,
+    };
+    toolByKey.set(fullKey, next);
+    return { fullKey, state: next };
+  };
+
+  const emitToolStarted = (turnId: string, state: BufferedToolState) => {
+    if (state.started) return;
+    state.started = true;
+    emitItemStarted(
+      turnId,
+      toolCallItem(state.itemId, state.name, "input-streaming", state.args),
+    );
+  };
+
+  const emitToolCompleted = (
+    turnId: string,
+    key: string,
+    state: BufferedToolState,
+    itemState: "output-available" | "output-error" | "output-denied",
+    result: unknown,
+  ) => {
+    emitItemCompleted(
+      turnId,
+      toolCallItem(state.itemId, state.name, itemState, state.args, result),
+    );
+    toolByKey.delete(toolStreamKey(turnId, key));
+  };
+
+  const handleModelStreamUpdate = (update: ModelStreamUpdate) => {
+    if (update.kind === "assistant_delta") {
+      if (update.phase === "commentary") return;
+      const currentText = update.text;
+      const state = ensureActiveAssistantState(update.turnId);
+      state.text = `${state.text}${currentText}`;
+      startAssistantState(update.turnId, state);
+      if (currentText) {
+        emitAssistantDelta(update.turnId, state.itemId, currentText);
+      }
+      return;
+    }
+
+    if (update.kind === "assistant_text_end") {
+      completeAssistantStateBeforeStep(update.turnId);
+      return;
+    }
+
+    completeAssistantStateBeforeStep(update.turnId);
+
+    if (update.kind === "reasoning_start") {
+      const { state } = ensureBufferedReasoning(update.turnId, { id: update.streamId, mode: update.mode });
+      startBufferedReasoning(update.turnId, state);
+      return;
+    }
+
+    if (update.kind === "reasoning_delta") {
+      const { state } = ensureBufferedReasoning(update.turnId, { id: update.streamId, mode: update.mode });
+      startBufferedReasoning(update.turnId, state);
+      state.text = `${state.text}${update.text}`;
+      if (update.text) {
+        emitReasoningDelta(update.turnId, state.itemId, state.mode, update.text);
+      }
+      return;
+    }
+
+    if (update.kind === "reasoning_end") {
+      flushBufferedReasoning(update.turnId, `${update.turnId}:${update.streamId}`);
+      return;
+    }
+
+    if (update.kind === "tool_input_start") {
+      const { state } = ensureToolState(update.turnId, update.key, update.name);
+      if (update.args !== undefined) {
+        state.args = update.args;
+      }
+      emitToolStarted(update.turnId, state);
+      return;
+    }
+
+    if (update.kind === "tool_input_delta") {
+      const { state } = ensureToolState(update.turnId, update.key, "tool");
+      state.inputText = `${state.inputText}${update.delta}`;
+      state.args = normalizeToolArgsFromInput(state.inputText, state.args);
+      return;
+    }
+
+    if (update.kind === "tool_call") {
+      const { state } = ensureToolState(update.turnId, update.key, update.name);
+      if (update.args !== undefined) {
+        state.args = update.args;
+      }
+      emitToolStarted(update.turnId, state);
+      return;
+    }
+
+    if (update.kind === "tool_result") {
+      const { state } = ensureToolState(update.turnId, update.key, update.name);
+      emitToolCompleted(update.turnId, update.key, state, "output-available", update.result);
+      return;
+    }
+
+    if (update.kind === "tool_error") {
+      const { state } = ensureToolState(update.turnId, update.key, update.name);
+      emitToolCompleted(update.turnId, update.key, state, "output-error", { error: update.error });
+      return;
+    }
+
+    if (update.kind === "tool_output_denied") {
+      const { state } = ensureToolState(update.turnId, update.key, update.name);
+      emitToolCompleted(
+        update.turnId,
+        update.key,
+        state,
+        "output-denied",
+        { denied: true, reason: update.reason },
+      );
+    }
+  };
+
+  return {
+    handle(event: ServerEvent): boolean {
+      if (event.sessionId !== opts.threadId) return false;
+
+      switch (event.type) {
+        case "user_message":
+          lastUserMessageText = event.text;
+          lastUserMessageClientMessageId = typeof event.clientMessageId === "string"
+            ? event.clientMessageId
+            : null;
+          return true;
+        case "session_busy":
+          if (event.busy) {
+            if (activeTurnId && event.turnId && activeTurnId !== event.turnId) {
+              completeAssistantStateBeforeStep(activeTurnId);
+              clearTurnProjectionState(activeTurnId);
+            }
+            activeTurnId = event.turnId ?? null;
+            if (!activeTurnId) return true;
+            emitTurnStarted(activeTurnId);
+            if (lastUserMessageText) {
+              const item = userMessageItem(
+                activeTurnId,
+                lastUserMessageText,
+                lastUserMessageClientMessageId,
+              );
+              emitItemStarted(activeTurnId, item);
+              emitItemCompleted(activeTurnId, item);
+              lastUserMessageText = null;
+              lastUserMessageClientMessageId = null;
+            }
+            return true;
+          }
+
+          if (event.turnId) {
+            completeAssistantStateBeforeStep(event.turnId);
+            clearTurnProjectionState(event.turnId);
+            emitTurnCompleted(
+              event.turnId,
+              event.outcome === "cancelled"
+                ? "interrupted"
+                : event.outcome === "error"
+                  ? "failed"
+                  : "completed",
+            );
+          }
+          activeTurnId = null;
+          return true;
+        case "model_stream_raw": {
+          const updates = replayModelStreamRawEvent(replayRuntime, event as ModelStreamRawEvent);
+          for (const update of updates) {
+            handleModelStreamUpdate(update);
+          }
+          return true;
+        }
+        case "model_stream_chunk":
+          if (shouldIgnoreNormalizedChunkForRawBackedTurn(replayRuntime, event as ModelStreamChunkEvent)) {
+            return true;
+          }
+          {
+            const update = mapModelStreamChunk(event as ModelStreamChunkEvent);
+            if (update) {
+              handleModelStreamUpdate(update);
+            }
+          }
+          return true;
+        case "assistant_message":
+          if (!activeTurnId) return true;
+          {
+            const remainder = assistantRemainderForTurn(activeTurnId, event.text);
+            const activeAssistant = activeAssistantByTurn.get(activeTurnId);
+            if (activeAssistant) {
+              completeAssistantState(activeTurnId, remainder || activeAssistant.text);
+            } else if (remainder) {
+              const state = ensureActiveAssistantState(activeTurnId);
+              state.text = remainder;
+              startAssistantState(activeTurnId, state);
+              emitAssistantDelta(activeTurnId, state.itemId, remainder);
+              completeAssistantState(activeTurnId, remainder);
+            }
+          }
+          return true;
+        case "reasoning":
+          if (!activeTurnId) return true;
+          completeAssistantStateBeforeStep(activeTurnId);
+          emitReasoningItem(
+            activeTurnId,
+            event.kind,
+            event.text,
+            makeItemId("reasoning", `${activeTurnId}:${crypto.randomUUID()}`),
+          );
+          return true;
+        case "ask":
+          emitAsk(event);
+          return true;
+        case "approval":
+          emitApproval(event);
+          return true;
+        default:
+          return false;
+      }
+    },
+  };
+}

--- a/src/server/jsonrpc/projectionCore.types.ts
+++ b/src/server/jsonrpc/projectionCore.types.ts
@@ -1,0 +1,82 @@
+import type { ProjectedReasoningMode } from "./projectorShared";
+
+export type ProjectedUserMessageItem = {
+  id: string;
+  type: "userMessage";
+  content: Array<{ type: "text"; text: string }>;
+  clientMessageId?: string;
+};
+
+export type ProjectedAgentMessageItem = {
+  id: string;
+  type: "agentMessage";
+  text: string;
+};
+
+export type ProjectedReasoningItem = {
+  id: string;
+  type: "reasoning";
+  mode: ProjectedReasoningMode;
+  text: string;
+};
+
+export type ProjectedToolCallItem = {
+  id: string;
+  type: "toolCall";
+  toolName: string;
+  state: "input-streaming" | "output-available" | "output-error" | "output-denied";
+  args?: unknown;
+  result?: unknown;
+};
+
+export type ProjectedItem =
+  | ProjectedUserMessageItem
+  | ProjectedAgentMessageItem
+  | ProjectedReasoningItem
+  | ProjectedToolCallItem;
+
+export type ProjectedTurnStarted = {
+  id: string;
+  status: "inProgress";
+  items: ProjectedItem[];
+};
+
+export type ProjectedTurnCompleted = {
+  id: string;
+  status: "completed" | "interrupted" | "failed";
+};
+
+export type ProjectedEvent =
+  | { type: "turn/started"; turnId: string; turn: ProjectedTurnStarted }
+  | { type: "turn/completed"; turnId: string; turn: ProjectedTurnCompleted }
+  | { type: "item/started"; turnId: string; item: ProjectedItem }
+  | { type: "item/completed"; turnId: string; item: ProjectedItem }
+  | { type: "item/agentMessage/delta"; turnId: string; itemId: string; delta: string }
+  | {
+      type: "item/reasoning/delta";
+      turnId: string;
+      itemId: string;
+      mode: ProjectedReasoningMode;
+      delta: string;
+    }
+  | {
+      type: "ask";
+      turnId: string | null;
+      requestId: string;
+      itemId: string;
+      question: string;
+      options?: string[];
+    }
+  | {
+      type: "approval";
+      turnId: string | null;
+      requestId: string;
+      itemId: string;
+      command: string;
+      dangerous: boolean;
+      reason: string;
+    };
+
+export type ProjectionSink = {
+  emit: (event: ProjectedEvent) => void;
+};

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -372,3 +372,19 @@
 - `src/server/startServer.ts` and `src/server/jsonrpc/routes/skillsMemoryAndWorkspaceBackup.ts` now treat emitted validation errors from `cowork/skills/installation/read` and `cowork/skills/installation/{enable,disable,delete,update}` as terminal JSON-RPC errors instead of waiting for the capture timeout.
 - `apps/desktop/test/workspace-settings-sync.test.ts`, `test/jsonrpc.routes.review-fixes.test.ts`, and `test/server.jsonrpc.control.test.ts` now lock down the thread-response envelope state path plus the skill-installation error returns in both extracted-route and live-server coverage.
 - Verification passed with `bun test apps/desktop/test/workspace-settings-sync.test.ts`, `bun test test/jsonrpc.routes.review-fixes.test.ts`, `bun test test/server.jsonrpc.control.test.ts`, `bun run typecheck`, and `bun run test`.
+
+## Extract Shared JSON-RPC Projection Core
+
+- [x] Create canonical projected-event types and a shared projection sink contract for JSON-RPC model-stream projection.
+- [x] Extract the duplicated stateful projection engine from `src/server/jsonrpc/eventProjector.ts` and `src/server/jsonrpc/journalProjector.ts` into `src/server/jsonrpc/projectionCore.ts` without changing wire output.
+- [x] Refactor the live event projector and thread journal projector into thin adapters over the shared core, preserving reconnect bootstrap, request wiring, journal metadata, and passthrough notifications.
+- [x] Add direct unit coverage for the shared projection core and rerun the focused JSON-RPC/server regression slices plus full repo verification.
+- [x] Manually validate desktop streaming parity, reconnect replay, and journal-backed thread reads after the refactor.
+
+## Extract Shared JSON-RPC Projection Core Review
+
+- Added `src/server/jsonrpc/projectionCore.types.ts` and `src/server/jsonrpc/projectionCore.ts`, so the buffered assistant/reasoning/tool state machine, raw replay handling, occurrence-stable item IDs, dedupe rules, turn lifecycle, and ask/approval projection now live in one shared projector core instead of being duplicated in the live and journal adapters.
+- `src/server/jsonrpc/eventProjector.ts` is now a thin JSON-RPC mapper over the shared core plus the existing passthrough notification surface, and `src/server/jsonrpc/journalProjector.ts` is now a thin journal-envelope mapper that preserves timestamps plus `turnId` / `itemId` / `requestId` metadata.
+- Added `test/jsonrpc.projectionCore.test.ts` to lock down the extracted core directly for assistant/reasoning/tool ordering, commentary suppression, streamed-reasoning dedupe, repeated tool occurrences, assistant remainder handling, raw Google/OpenAI replay, per-turn cleanup, and reconnect bootstrap.
+- Automated verification passed with `bun test test/jsonrpc.projectionCore.test.ts`, `bun test test/jsonrpc.projectionCore.test.ts test/jsonrpc.projectors.test.ts test/jsonrpc.thread-read-projector.test.ts test/server.jsonrpc.flow.test.ts test/server.jsonrpc.test.ts test/harness.ws.e2e.test.ts`, `bun run typecheck`, and full `bun test`.
+- Manual desktop validation passed by sending `Read package.json and tell me the package name.` in the Electron app, confirming live reasoning/tool activity, restarting the workspace server from Settings > Workspaces > Advanced, verifying the same thread replayed intact after reconnect, and capturing the matching post-restart `thread/read` response in `/opt/cursor/artifacts/projection_core_thread_read_after_reconnect.json`.

--- a/test/jsonrpc.projectionCore.test.ts
+++ b/test/jsonrpc.projectionCore.test.ts
@@ -1,0 +1,462 @@
+import { describe, expect, test } from "bun:test";
+
+import { createProjectionCore } from "../src/server/jsonrpc/projectionCore";
+import type { ProjectedEvent } from "../src/server/jsonrpc/projectionCore.types";
+import type { ServerEvent } from "../src/server/protocol";
+
+const sessionId = "session-1";
+const turnId = "turn-1";
+
+function streamChunk(
+  partType: Extract<ServerEvent, { type: "model_stream_chunk" }>["partType"],
+  part: Record<string, unknown>,
+  overrides?: Partial<Extract<ServerEvent, { type: "model_stream_chunk" }>>,
+): ServerEvent {
+  return {
+    type: "model_stream_chunk",
+    sessionId,
+    turnId,
+    index: 0,
+    provider: "openai",
+    model: "gpt-5.4-mini",
+    partType,
+    part,
+    ...overrides,
+  };
+}
+
+function googleRaw(index: number, event: Record<string, unknown>): ServerEvent {
+  return {
+    type: "model_stream_raw",
+    sessionId,
+    turnId,
+    index,
+    provider: "google",
+    model: "gemini-3.1-pro-preview-customtools",
+    format: "google-interactions-v1",
+    normalizerVersion: 1,
+    event,
+  };
+}
+
+function openAiRaw(index: number, event: Record<string, unknown>): ServerEvent {
+  return {
+    type: "model_stream_raw",
+    sessionId,
+    turnId,
+    index,
+    provider: "openai",
+    model: "gpt-5.4-mini",
+    format: "openai-responses-v1",
+    normalizerVersion: 1,
+    event,
+  };
+}
+
+function createCore(
+  opts?: {
+    threadId?: string;
+    initialActiveTurnId?: string | null;
+    initialAgentText?: string | null;
+  },
+) {
+  const events: ProjectedEvent[] = [];
+  const core = createProjectionCore({
+    threadId: opts?.threadId ?? sessionId,
+    initialActiveTurnId: opts?.initialActiveTurnId,
+    initialAgentText: opts?.initialAgentText,
+    sink: {
+      emit: (event) => events.push(event),
+    },
+  });
+  return { core, events };
+}
+
+function projectedOfType<TType extends ProjectedEvent["type"]>(
+  events: ProjectedEvent[],
+  type: TType,
+): Array<Extract<ProjectedEvent, { type: TType }>> {
+  return events.filter((event): event is Extract<ProjectedEvent, { type: TType }> => event.type === type);
+}
+
+describe("projectionCore", () => {
+  test("completes assistant output before reasoning and tools", () => {
+    const { core, events } = createCore();
+
+    core.handle({
+      type: "session_busy",
+      sessionId,
+      busy: true,
+      turnId,
+      cause: "user_message",
+    });
+    core.handle(streamChunk("text_delta", { id: "text-1", text: "First answer." }));
+    core.handle(streamChunk("reasoning_start", { id: "reasoning-1", mode: "summary" }));
+    core.handle(streamChunk("reasoning_delta", { id: "reasoning-1", mode: "summary", text: "Checking details." }));
+    core.handle(streamChunk("reasoning_end", { id: "reasoning-1", mode: "summary" }));
+    core.handle(streamChunk("tool_call", { toolCallId: "tool-1", toolName: "read", input: { path: "/tmp/test.txt" } }));
+    core.handle(streamChunk("tool_result", { toolCallId: "tool-1", toolName: "read", output: { ok: true } }));
+
+    const assistantCompleted = projectedOfType(events, "item/completed")
+      .find((event) => event.item.type === "agentMessage");
+    const reasoningStarted = projectedOfType(events, "item/started")
+      .find((event) => event.item.type === "reasoning");
+    const toolStarted = projectedOfType(events, "item/started")
+      .find((event) => event.item.type === "toolCall");
+
+    expect(assistantCompleted?.item).toMatchObject({
+      type: "agentMessage",
+      text: "First answer.",
+    });
+    expect(reasoningStarted?.item).toMatchObject({
+      type: "reasoning",
+      mode: "summary",
+      text: "",
+    });
+    expect(toolStarted?.item).toMatchObject({
+      type: "toolCall",
+      toolName: "read",
+      state: "input-streaming",
+    });
+
+    expect(events.findIndex((event) => event === assistantCompleted))
+      .toBeLessThan(events.findIndex((event) => event === reasoningStarted));
+    expect(events.findIndex((event) => event === reasoningStarted))
+      .toBeLessThan(events.findIndex((event) => event === toolStarted));
+  });
+
+  test("drops commentary assistant deltas", () => {
+    const { core, events } = createCore();
+
+    core.handle({
+      type: "session_busy",
+      sessionId,
+      busy: true,
+      turnId,
+      cause: "user_message",
+    });
+    core.handle(streamChunk("text_delta", { id: "text-1", phase: "commentary", text: "Internal note" }));
+
+    expect(projectedOfType(events, "item/agentMessage/delta")).toHaveLength(0);
+    expect(projectedOfType(events, "item/started").filter((event) => event.item.type === "agentMessage")).toHaveLength(0);
+  });
+
+  test("dedupes duplicate final reasoning when it matches streamed reasoning", () => {
+    const { core, events } = createCore();
+
+    core.handle({
+      type: "session_busy",
+      sessionId,
+      busy: true,
+      turnId,
+      cause: "user_message",
+    });
+    core.handle(streamChunk("reasoning_start", { id: "reasoning-1", mode: "summary" }));
+    core.handle(streamChunk("reasoning_delta", { id: "reasoning-1", mode: "summary", text: "Inspecting the reports." }));
+    core.handle(streamChunk("reasoning_end", { id: "reasoning-1", mode: "summary" }));
+    core.handle({
+      type: "reasoning",
+      sessionId,
+      kind: "summary",
+      text: "Inspecting the reports.",
+    });
+
+    const completedReasoning = projectedOfType(events, "item/completed")
+      .filter((event) => event.item.type === "reasoning");
+    expect(completedReasoning).toHaveLength(1);
+    expect(completedReasoning[0]?.item).toMatchObject({
+      type: "reasoning",
+      text: "Inspecting the reports.",
+    });
+  });
+
+  test("tracks repeated tool occurrences for the same key", () => {
+    const { core, events } = createCore();
+
+    core.handle({
+      type: "session_busy",
+      sessionId,
+      busy: true,
+      turnId,
+      cause: "user_message",
+    });
+    core.handle(streamChunk("tool_call", { toolCallId: "tool-1", toolName: "read", input: { path: "/tmp/a.txt" } }));
+    core.handle(streamChunk("tool_result", { toolCallId: "tool-1", toolName: "read", output: { ok: true } }));
+    core.handle(streamChunk("tool_call", { toolCallId: "tool-1", toolName: "read", input: { path: "/tmp/b.txt" } }, { index: 1 }));
+    core.handle(streamChunk("tool_result", { toolCallId: "tool-1", toolName: "read", output: { ok: true, second: true } }, { index: 1 }));
+
+    const completedToolItems = projectedOfType(events, "item/completed")
+      .filter((event) => event.item.type === "toolCall")
+      .map((event) => event.item.id);
+
+    expect(completedToolItems).toEqual([
+      `toolCall:${turnId}:tool-1`,
+      `toolCall:${turnId}:tool-1:2`,
+    ]);
+  });
+
+  test("splits assistant segments when reasoning interleaves", () => {
+    const { core, events } = createCore();
+
+    core.handle({
+      type: "session_busy",
+      sessionId,
+      busy: true,
+      turnId,
+      cause: "user_message",
+    });
+    core.handle(streamChunk("text_delta", { id: "s0", text: "First answer." }));
+    core.handle(streamChunk("reasoning_start", { id: "r1", mode: "reasoning" }));
+    core.handle(streamChunk("reasoning_delta", { id: "r1", mode: "reasoning", text: "Need one more step." }));
+    core.handle(streamChunk("reasoning_end", { id: "r1", mode: "reasoning" }));
+    core.handle(streamChunk("text_delta", { id: "s0", text: "\n\nSecond answer." }));
+    core.handle({
+      type: "assistant_message",
+      sessionId,
+      text: "First answer.\n\nSecond answer.",
+    });
+
+    const assistantStarted = projectedOfType(events, "item/started")
+      .filter((event) => event.item.type === "agentMessage");
+    const assistantCompleted = projectedOfType(events, "item/completed")
+      .filter((event) => event.item.type === "agentMessage");
+
+    expect(assistantStarted.map((event) => event.item.id)).toEqual([
+      `agentMessage:${turnId}`,
+      `agentMessage:${turnId}:2`,
+    ]);
+    expect(assistantCompleted.map((event) => event.item.text)).toEqual([
+      "First answer.",
+      "\n\nSecond answer.",
+    ]);
+  });
+
+  test("uses assistant history to emit only the final remainder", () => {
+    const { core, events } = createCore();
+
+    core.handle({
+      type: "session_busy",
+      sessionId,
+      busy: true,
+      turnId,
+      cause: "user_message",
+    });
+    core.handle(streamChunk("text_delta", { id: "s0", text: "First answer." }));
+    core.handle(streamChunk("text_end", { id: "s0" }));
+    core.handle({
+      type: "assistant_message",
+      sessionId,
+      text: "First answer.\n\nSecond answer.",
+    });
+
+    const assistantDeltas = projectedOfType(events, "item/agentMessage/delta")
+      .map((event) => event.delta);
+    const assistantCompleted = projectedOfType(events, "item/completed")
+      .filter((event) => event.item.type === "agentMessage")
+      .map((event) => event.item.text);
+
+    expect(assistantDeltas).toEqual([
+      "First answer.",
+      "\n\nSecond answer.",
+    ]);
+    expect(assistantCompleted).toEqual([
+      "First answer.",
+      "\n\nSecond answer.",
+    ]);
+  });
+
+  test("replays raw google interactions reasoning and tool activity", () => {
+    const { core, events } = createCore();
+
+    core.handle({
+      type: "session_busy",
+      sessionId,
+      busy: true,
+      turnId,
+      cause: "user_message",
+    });
+    core.handle(googleRaw(0, { event_type: "interaction.start" }));
+    core.handle(googleRaw(1, { event_type: "content.start", index: 0, content: { type: "thought" } }));
+    core.handle(googleRaw(2, {
+      event_type: "content.delta",
+      index: 0,
+      delta: { type: "thought_summary", content: { type: "text", text: "First pass." } },
+    }));
+    core.handle(googleRaw(3, { event_type: "content.stop", index: 0 }));
+    core.handle(googleRaw(4, {
+      event_type: "content.start",
+      index: 1,
+      content: { type: "google_search_call", id: "search-call" },
+    }));
+    core.handle(googleRaw(5, {
+      event_type: "content.delta",
+      index: 1,
+      delta: { type: "google_search_call", id: "search-call", arguments: { queries: ["Project Hail Mary movie reviews"] } },
+    }));
+    core.handle(googleRaw(6, { event_type: "content.stop", index: 1 }));
+    core.handle(googleRaw(7, {
+      event_type: "content.start",
+      index: 2,
+      content: {
+        type: "google_search_result",
+        call_id: "search-call",
+        result: {
+          results: [{ title: "MovieWeb" }],
+          sources: [{ url: "https://example.com/review" }],
+        },
+      },
+    }));
+    core.handle(googleRaw(8, { event_type: "content.stop", index: 2 }));
+    core.handle({
+      type: "reasoning",
+      sessionId,
+      kind: "reasoning",
+      text: "First pass.",
+    });
+
+    const completedReasoning = projectedOfType(events, "item/completed")
+      .filter((event) => event.item.type === "reasoning")
+      .map((event) => event.item.text);
+    const completedTool = projectedOfType(events, "item/completed")
+      .find((event) => event.item.type === "toolCall");
+
+    expect(completedReasoning).toEqual(["First pass."]);
+    expect(completedTool?.item).toMatchObject({
+      type: "toolCall",
+      toolName: "nativeWebSearch",
+      state: "output-available",
+      args: { queries: ["Project Hail Mary movie reviews"] },
+    });
+  });
+
+  test("replays raw openai responses and ignores duplicate normalized chunks for raw-backed turns", () => {
+    const { core, events } = createCore();
+
+    core.handle({
+      type: "session_busy",
+      sessionId,
+      busy: true,
+      turnId,
+      cause: "user_message",
+    });
+    core.handle(openAiRaw(0, {
+      type: "response.output_item.added",
+      item: { type: "reasoning", id: "rs_1", summary: [] },
+    }));
+    core.handle(openAiRaw(1, {
+      type: "response.reasoning_summary_part.added",
+      part: { type: "summary_text", text: "" },
+    }));
+    core.handle(openAiRaw(2, {
+      type: "response.reasoning_summary_text.delta",
+      delta: "Raw plan.",
+    }));
+    core.handle(openAiRaw(3, {
+      type: "response.output_item.done",
+      item: { type: "reasoning", id: "rs_1", summary: [{ text: "Raw plan." }] },
+    }));
+    core.handle(openAiRaw(4, {
+      type: "response.output_item.added",
+      item: { type: "message", id: "msg_1", content: [] },
+    }));
+    core.handle(openAiRaw(5, {
+      type: "response.content_part.added",
+      part: { type: "output_text", text: "" },
+    }));
+    core.handle(openAiRaw(6, {
+      type: "response.output_text.delta",
+      delta: "Raw answer.",
+    }));
+    core.handle(openAiRaw(7, {
+      type: "response.output_item.done",
+      item: { type: "message", id: "msg_1", content: [{ type: "output_text", text: "Raw answer." }] },
+    }));
+    core.handle(streamChunk("reasoning_delta", { id: "reasoning-duplicate", mode: "summary", text: "Ignored normalized reasoning." }, { index: 1 }));
+    core.handle(streamChunk("text_delta", { id: "text-duplicate", text: "Ignored normalized text." }, { index: 2 }));
+
+    const reasoningDeltas = projectedOfType(events, "item/reasoning/delta")
+      .map((event) => event.delta);
+    const assistantDeltas = projectedOfType(events, "item/agentMessage/delta")
+      .map((event) => event.delta);
+
+    expect(reasoningDeltas).toEqual(["Raw plan."]);
+    expect(assistantDeltas).toEqual(["Raw answer."]);
+  });
+
+  test("clears per-turn reasoning dedupe on session_busy completion", () => {
+    const { core, events } = createCore();
+    const turnTwo = "turn-2";
+
+    core.handle({
+      type: "session_busy",
+      sessionId,
+      busy: true,
+      turnId,
+      cause: "user_message",
+    });
+    core.handle({
+      type: "reasoning",
+      sessionId,
+      kind: "summary",
+      text: "Repeated thought.",
+    });
+    core.handle({
+      type: "session_busy",
+      sessionId,
+      busy: false,
+      turnId,
+      outcome: "completed",
+    });
+    core.handle({
+      type: "session_busy",
+      sessionId,
+      busy: true,
+      turnId: turnTwo,
+      cause: "user_message",
+    });
+    core.handle({
+      type: "reasoning",
+      sessionId,
+      kind: "summary",
+      text: "Repeated thought.",
+    });
+
+    const reasoningCompleted = projectedOfType(events, "item/completed")
+      .filter((event) => event.item.type === "reasoning");
+    const turnCompleted = projectedOfType(events, "turn/completed");
+
+    expect(reasoningCompleted).toHaveLength(2);
+    expect(turnCompleted).toEqual([{
+      type: "turn/completed",
+      turnId,
+      turn: {
+        id: turnId,
+        status: "completed",
+      },
+    }]);
+  });
+
+  test("supports reconnect bootstrap for finish-only assistant completions", () => {
+    const { core, events } = createCore({
+      initialActiveTurnId: turnId,
+      initialAgentText: "Hello",
+    });
+
+    core.handle({
+      type: "assistant_message",
+      sessionId,
+      text: "Hello world",
+    });
+
+    expect(projectedOfType(events, "item/started")).toHaveLength(0);
+    expect(projectedOfType(events, "item/completed")).toEqual([{
+      type: "item/completed",
+      turnId,
+      item: {
+        id: `agentMessage:${turnId}`,
+        type: "agentMessage",
+        text: "Hello world",
+      },
+    }]);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add canonical projected-event types and a shared `createProjectionCore()` state machine for JSON-RPC turn/item projection
- refactor the live event projector and journal projector into thin adapters over the shared core while preserving passthrough notifications, request wiring, reconnect bootstrap, and journal metadata
- add direct core coverage for ordering, buffering, dedupe, raw replay, per-turn cleanup, and reconnect bootstrap

## Testing
- `bun test test/jsonrpc.projectionCore.test.ts`
- `bun test test/jsonrpc.projectionCore.test.ts test/jsonrpc.projectors.test.ts test/jsonrpc.thread-read-projector.test.ts test/server.jsonrpc.flow.test.ts test/server.jsonrpc.test.ts test/harness.ws.e2e.test.ts`
- `bun run typecheck`
- `bun test`
- manual Electron walkthrough: sent `Read package.json and tell me the package name.`, confirmed live reasoning/tool activity, restarted the workspace server from Settings > Workspaces > Advanced, and verified the same thread replayed intact after reconnect
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-588ebfc3-464b-408b-818d-e0f8d5f466a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-588ebfc3-464b-408b-818d-e0f8d5f466a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

