### PR TITLE
fix: address PR attachment edge cases and CI dependency

### DIFF
--- a/apps/desktop/src/app/store.helpers/jsonRpcSocket.ts
+++ b/apps/desktop/src/app/store.helpers/jsonRpcSocket.ts
@@ -335,7 +335,10 @@ export async function startJsonRpcTurn(
   clientMessageId?: string,
   attachments?: FileAttachmentInput[],
 ): Promise<any> {
-  const input: Array<Record<string, unknown>> = [{ type: "text", text }];
+  const input: Array<Record<string, unknown>> = [];
+  if (text.trim().length > 0) {
+    input.push({ type: "text", text });
+  }
   if (attachments && attachments.length > 0) {
     for (const a of attachments) {
       input.push({ type: "file", filename: a.filename, contentBase64: a.contentBase64, mimeType: a.mimeType });
@@ -358,7 +361,10 @@ export async function steerJsonRpcTurn(
   clientMessageId?: string,
   attachments?: FileAttachmentInput[],
 ): Promise<any> {
-  const input: Array<Record<string, unknown>> = [{ type: "text", text }];
+  const input: Array<Record<string, unknown>> = [];
+  if (text.trim().length > 0) {
+    input.push({ type: "text", text });
+  }
   if (attachments && attachments.length > 0) {
     for (const a of attachments) {
       input.push({ type: "file", filename: a.filename, contentBase64: a.contentBase64, mimeType: a.mimeType });

--- a/apps/desktop/src/app/store.helpers/runtimeState.ts
+++ b/apps/desktop/src/app/store.helpers/runtimeState.ts
@@ -119,6 +119,7 @@ export function drainPendingThreadMessages(threadId: string): string[] {
   const existing = RUNTIME.pendingThreadMessages.get(threadId);
   if (!existing || existing.length === 0) return [];
   RUNTIME.pendingThreadMessages.delete(threadId);
+  RUNTIME.pendingThreadAttachments.delete(threadId);
   return existing;
 }
 

--- a/apps/desktop/test/jsonrpc-single-connection.test.ts
+++ b/apps/desktop/test/jsonrpc-single-connection.test.ts
@@ -545,6 +545,64 @@ describe("desktop JSON-RPC single connection path", () => {
     expect(jsonRpcRequests.map((entry) => entry.method)).toContain("turn/steer");
   });
 
+  test("omits empty text parts for attachment-only turn/start requests", async () => {
+    seedActiveThreadState();
+
+    await useAppStore.getState().sendMessage("", "reject", [{
+      filename: "diagram.png",
+      contentBase64: "ZmFrZS1wbmc=",
+      mimeType: "image/png",
+    }]);
+    await flushAsyncWork();
+
+    expect(jsonRpcRequests.findLast((entry) => entry.method === "turn/start")?.params).toMatchObject({
+      threadId: "jsonrpc-thread-1",
+      input: [{
+        type: "file",
+        filename: "diagram.png",
+        contentBase64: "ZmFrZS1wbmc=",
+        mimeType: "image/png",
+      }],
+      clientMessageId: expect.any(String),
+    });
+  });
+
+  test("omits empty text parts for attachment-only turn/steer requests", async () => {
+    seedActiveThreadState();
+    useAppStore.setState({
+      threadRuntimeById: {
+        ...useAppStore.getState().threadRuntimeById,
+        "jsonrpc-thread-1": {
+          ...defaultThreadRuntime(),
+          wsUrl: "ws://jsonrpc-workspace",
+          connected: true,
+          sessionId: "jsonrpc-thread-1",
+          busy: true,
+          activeTurnId: "turn-1",
+        },
+      },
+    } as any);
+
+    await useAppStore.getState().sendMessage("", "steer", [{
+      filename: "trace.txt",
+      contentBase64: "dHJhY2U=",
+      mimeType: "text/plain",
+    }]);
+    await flushAsyncWork();
+
+    expect(jsonRpcRequests.findLast((entry) => entry.method === "turn/steer")?.params).toMatchObject({
+      threadId: "jsonrpc-thread-1",
+      turnId: "turn-1",
+      input: [{
+        type: "file",
+        filename: "trace.txt",
+        contentBase64: "dHJhY2U=",
+        mimeType: "text/plain",
+      }],
+      clientMessageId: expect.any(String),
+    });
+  });
+
   test("routes provider, memory, and backup control requests over the shared JsonRpcSocket", async () => {
     await useAppStore.getState().selectWorkspace("ws-jsonrpc");
     await useAppStore.getState().requestProviderCatalog();

--- a/apps/desktop/test/runtimeState.test.ts
+++ b/apps/desktop/test/runtimeState.test.ts
@@ -2,7 +2,9 @@ import { beforeEach, describe, expect, test } from "bun:test";
 
 const {
   RUNTIME,
+  drainPendingThreadMessages,
   queuePendingThreadMessage,
+  shiftPendingThreadAttachments,
   shiftPendingThreadMessage,
   prependPendingThreadMessage,
 } = await import("../src/app/store.helpers/runtimeState");
@@ -10,6 +12,7 @@ const {
 describe("runtimeState pending thread message queue", () => {
   beforeEach(() => {
     RUNTIME.pendingThreadMessages.clear();
+    RUNTIME.pendingThreadAttachments.clear();
   });
 
   test("prepends a failed flush back to the front without changing FIFO order", () => {
@@ -23,5 +26,16 @@ describe("runtimeState pending thread message queue", () => {
     expect(shiftPendingThreadMessage("thread-1")).toBe("first");
     expect(shiftPendingThreadMessage("thread-1")).toBe("second");
     expect(shiftPendingThreadMessage("thread-1")).toBeUndefined();
+  });
+
+  test("draining queued messages also clears the aligned attachment queue", () => {
+    queuePendingThreadMessage("thread-1", "first", [{
+      filename: "notes.txt",
+      contentBase64: "Zmlyc3Q=",
+      mimeType: "text/plain",
+    }]);
+
+    expect(drainPendingThreadMessages("thread-1")).toEqual(["first"]);
+    expect(shiftPendingThreadAttachments("thread-1")).toBeUndefined();
   });
 });

--- a/bun.lock
+++ b/bun.lock
@@ -19,6 +19,7 @@
         "react": "^19.2.4",
         "turndown": "^7.2.2",
         "zod": "^4.3.6",
+        "zustand": "^5.0.12",
       },
       "devDependencies": {
         "@types/jsdom": "^27.0.0",
@@ -867,6 +868,8 @@
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
+
+    "zustand": ["zustand@5.0.12", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g=="],
 
     "@asamuzakjp/css-color/lru-cache": ["lru-cache@11.2.6", "", {}, "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ=="],
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "partial-json": "^0.1.7",
     "react": "^19.2.4",
     "turndown": "^7.2.2",
-    "zod": "^4.3.6"
+    "zod": "^4.3.6",
+    "zustand": "^5.0.12"
   },
   "devDependencies": {
     "@types/jsdom": "^27.0.0",

--- a/src/server/session/SessionAdminManager.ts
+++ b/src/server/session/SessionAdminManager.ts
@@ -9,6 +9,7 @@ import {
   listPersistedSessionSnapshots,
   type PersistedSessionSummary,
 } from "../sessionStore";
+import { decodeValidatedBase64 } from "./base64";
 import type { SessionContext } from "./SessionContext";
 
 function snapshotToTopLevelSessionSummary(liveSnapshot: SessionSnapshot | null): PersistedSessionSummary | null {
@@ -485,7 +486,7 @@ export class SessionAdminManager {
     }
 
     try {
-      const decoded = Buffer.from(contentBase64, "base64");
+      const { bytes: decoded } = decodeValidatedBase64(contentBase64, "Invalid file content.");
       if (this.context.state.config.uploadsDirectory) {
         await fs.mkdir(uploadsDir, { recursive: true });
       }

--- a/src/server/session/SessionAdminManager.ts
+++ b/src/server/session/SessionAdminManager.ts
@@ -493,6 +493,14 @@ export class SessionAdminManager {
       await fs.writeFile(filePath, decoded);
       this.context.emit({ type: "file_uploaded", sessionId: this.context.id, filename: safeName, path: filePath });
     } catch (err) {
+      if (
+        typeof err === "object"
+        && err !== null
+        && (err as { code?: unknown }).code === "validation_failed"
+      ) {
+        this.context.emitError("validation_failed", "session", err instanceof Error ? err.message : String(err));
+        return;
+      }
       this.context.emitError("internal_error", "session", `Failed to upload file: ${String(err)}`);
     }
   }

--- a/src/server/session/TurnExecutionManager.ts
+++ b/src/server/session/TurnExecutionManager.ts
@@ -20,6 +20,7 @@ import {
 } from "../../types";
 import { supportsImageInput } from "../../models/registry";
 import type { FileAttachment } from "../jsonrpc/routes/shared";
+import { decodeValidatedBase64 } from "./base64";
 import type { HistoryManager } from "./HistoryManager";
 import type { InteractionManager } from "./InteractionManager";
 import type { SessionBackupController } from "./SessionBackupController";
@@ -283,6 +284,22 @@ export class TurnExecutionManager {
     return this.context.state.currentTurnOutcome === "error" ? "errored" : "completed";
   }
 
+  private normalizeAttachments(
+    attachments?: FileAttachment[],
+    invalidMessage = "Invalid attachment content.",
+  ): FileAttachment[] | undefined {
+    if (!attachments || attachments.length === 0) {
+      return undefined;
+    }
+
+    return attachments.map((attachment) => {
+      const { normalizedBase64 } = decodeValidatedBase64(attachment.contentBase64, invalidMessage);
+      return normalizedBase64 === attachment.contentBase64
+        ? attachment
+        : { ...attachment, contentBase64: normalizedBase64 };
+    });
+  }
+
   async sendSteerMessage(text: string, expectedTurnId: string, clientMessageId?: string, attachments?: FileAttachment[]) {
     if (!this.context.state.running) {
       this.context.emitError("validation_failed", "session", "No active turn to steer.");
@@ -305,7 +322,15 @@ export class TurnExecutionManager {
       return;
     }
 
-    if (text.trim().length === 0 && (!attachments || attachments.length === 0)) {
+    let normalizedAttachments: FileAttachment[] | undefined;
+    try {
+      normalizedAttachments = this.normalizeAttachments(attachments);
+    } catch (err) {
+      this.context.emitError("validation_failed", "session", this.context.formatError(err));
+      return;
+    }
+
+    if (text.trim().length === 0 && (!normalizedAttachments || normalizedAttachments.length === 0)) {
       this.context.emitError("validation_failed", "session", "Steer input must be non-empty.");
       return;
     }
@@ -313,7 +338,7 @@ export class TurnExecutionManager {
     this.context.state.pendingSteers.push({
       text,
       ...(clientMessageId ? { clientMessageId } : {}),
-      ...(attachments && attachments.length > 0 ? { attachments } : {}),
+      ...(normalizedAttachments && normalizedAttachments.length > 0 ? { attachments: normalizedAttachments } : {}),
       acceptedAt: new Date().toISOString(),
     });
     this.context.emit({
@@ -373,6 +398,14 @@ export class TurnExecutionManager {
         "session",
         "Session hard-stop budget has been exceeded. Raise or clear the stop threshold before sending another message."
       );
+      return;
+    }
+
+    let normalizedAttachments: FileAttachment[] | undefined;
+    try {
+      normalizedAttachments = this.normalizeAttachments(attachments);
+    } catch (err) {
+      this.context.emitError("validation_failed", "session", this.context.formatError(err));
       return;
     }
 
@@ -600,7 +633,7 @@ export class TurnExecutionManager {
         model: this.context.state.config.model,
       });
 
-      const userMessageContent = await this.buildUserMessageContent(text, attachments);
+      const userMessageContent = await this.buildUserMessageContent(text, normalizedAttachments);
       this.deps.historyManager.appendMessagesToHistory([{ role: "user", content: userMessageContent }]);
       this.deps.metadataManager.maybeGenerateTitleFromQuery(text);
       this.context.queuePersistSessionSnapshot("session.user_message");
@@ -844,7 +877,10 @@ export class TurnExecutionManager {
         // File doesn't exist, use as-is
       }
 
-      const decoded = Buffer.from(attachment.contentBase64, "base64");
+      const { bytes: decoded, normalizedBase64 } = decodeValidatedBase64(
+        attachment.contentBase64,
+        "Invalid attachment content.",
+      );
       await fs.writeFile(diskPath, decoded);
 
       contentParts.push({
@@ -862,13 +898,13 @@ export class TurnExecutionManager {
       if (isImage && modelSupportsImages) {
         contentParts.push({
           type: "image",
-          data: attachment.contentBase64,
+          data: normalizedBase64,
           mimeType: attachment.mimeType,
         });
       } else if (isGeminiMultimodal && isGoogleProvider) {
         contentParts.push({
           type: "image",
-          data: attachment.contentBase64,
+          data: normalizedBase64,
           mimeType: attachment.mimeType,
         });
       }

--- a/src/server/session/base64.ts
+++ b/src/server/session/base64.ts
@@ -1,0 +1,40 @@
+type DecodedBase64 = {
+  bytes: Buffer;
+  normalizedBase64: string;
+};
+
+function invalidBase64Error(message: string): Error {
+  return Object.assign(new Error(message), {
+    code: "validation_failed",
+    source: "session",
+  });
+}
+
+export function decodeValidatedBase64(
+  contentBase64: string,
+  invalidMessage: string,
+): DecodedBase64 {
+  const normalized = contentBase64
+    .replace(/\s+/g, "")
+    .replace(/-/g, "+")
+    .replace(/_/g, "/");
+  if (!normalized) {
+    throw invalidBase64Error(invalidMessage);
+  }
+
+  const remainder = normalized.length % 4;
+  if (remainder === 1) {
+    throw invalidBase64Error(invalidMessage);
+  }
+
+  const padded = remainder === 0
+    ? normalized
+    : `${normalized}${"=".repeat(4 - remainder)}`;
+  const bytes = Buffer.from(padded, "base64");
+  const normalizedBase64 = bytes.toString("base64");
+  if (!normalizedBase64 || normalizedBase64 !== padded) {
+    throw invalidBase64Error(invalidMessage);
+  }
+
+  return { bytes, normalizedBase64 };
+}

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -564,3 +564,9 @@
 - The root cause was a file-level `mock.module("../src/ui/skills/SkillDetailDialog", ...)` in `apps/desktop/test/skills-catalog-page.test.ts`. On Bun/Linux CI that mock can leak into the adjacent skill dialog test file, causing `SkillDetailDialog` to stay mocked as `null`.
 - `apps/desktop/test/skills-catalog-page.test.ts` no longer mocks `SkillDetailDialog`. Those catalog-page tests only assert loading and empty states while the dialog remains closed, so the extra mock was unnecessary and destabilized CI.
 - Verification passed with `bun test apps/desktop/test/skills-catalog-page.test.ts apps/desktop/test/skill-detail-dialog.test.ts --rerun-each 25`, `bun test apps/desktop/test/skill-detail-dialog.test.ts apps/desktop/test/protocol-v2-events.test.ts apps/desktop/test/thread-reconnect.test.ts apps/desktop/test/jsonrpc-single-connection.test.ts apps/desktop/test/bootstrap-cache.test.ts`, `bun run typecheck`, and `bun test`.
+
+## PR Build Fixes Review Sweep
+
+- [ ] Reconcile the remaining open PR review comments against the current branch and fix only the issues that are still accurate.
+- [ ] Restore CI/root test compatibility for mobile store imports and tighten the remaining attachment transport/runtime edge cases.
+- [ ] Re-run the focused JSON-RPC, session, mobile-store, and desktop queue verification slices plus repo `typecheck`, then update the PR.

--- a/test/mobile.transport.relay-role.test.ts
+++ b/test/mobile.transport.relay-role.test.ts
@@ -1,12 +1,26 @@
 import { describe, expect, mock, test } from "bun:test";
+import { EventEmitter as NodeEventEmitter } from "node:events";
 
 mock.module("expo-modules-core", () => ({
-  EventEmitter: class EventEmitter {
-    addListener() {
-      return { remove() {} };
+  EventEmitter: class EventEmitter<TEventsMap extends Record<string, (...args: any[]) => void>> {
+    private readonly emitter = new NodeEventEmitter();
+
+    addListener<EventName extends keyof TEventsMap>(eventName: EventName, listener: TEventsMap[EventName]) {
+      this.emitter.on(String(eventName), listener as (...args: any[]) => void);
+      return {
+        remove: () => {
+          this.emitter.off(String(eventName), listener as (...args: any[]) => void);
+        },
+      };
     }
 
-    removeAllListeners() {}
+    removeAllListeners(eventName: keyof TEventsMap) {
+      this.emitter.removeAllListeners(String(eventName));
+    }
+
+    emit<EventName extends keyof TEventsMap>(eventName: EventName, ...args: Parameters<TEventsMap[EventName]>) {
+      this.emitter.emit(String(eventName), ...args);
+    }
   },
   requireOptionalNativeModule: () => null,
 }));

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -2753,6 +2753,23 @@ describe("AgentSession", () => {
       expect(busyFalseIdxAfter).toBeGreaterThan(busyTrueIdx);
     });
 
+    test("rejects malformed attachment payloads before the turn starts", async () => {
+      const { session, events } = makeSession();
+
+      await session.sendUserMessage("go", "user-1", undefined, [{
+        filename: "broken.txt",
+        contentBase64: "%%%not-base64%%%",
+        mimeType: "text/plain",
+      }]);
+
+      expect(mockRunTurn).not.toHaveBeenCalled();
+      expect(events.find((event) => event.type === "user_message")).toBeUndefined();
+      expect(events.find((event) => event.type === "session_busy")).toBeUndefined();
+      const errorEvt = events.find((event) => event.type === "error") as Extract<ServerEvent, { type: "error" }> | undefined;
+      expect(errorEvt?.code).toBe("validation_failed");
+      expect(errorEvt?.message).toBe("Invalid attachment content.");
+    });
+
     test("accepts steer_message for the active turn without emitting another busy=true", async () => {
       const { session, events } = makeSession();
 
@@ -2857,6 +2874,58 @@ describe("AgentSession", () => {
           && (e as any).text === "mention the queue behavior"
           && (e as any).clientMessageId === "steer-commit"),
       ).toBe(true);
+
+      resolveRunTurn();
+      await turnPromise;
+    });
+
+    test("commits attachment-only steer content when prepareStep drains it", async () => {
+      const { session } = makeSession();
+      let capturedPrepareStep: ((step: { stepNumber: number; messages: any[] }) => Promise<any>) | undefined;
+      let resolveRunTurn!: () => void;
+
+      mockRunTurn.mockImplementation(async (params: any) => {
+        capturedPrepareStep = params.prepareStep;
+        await new Promise<void>((resolve) => {
+          resolveRunTurn = resolve;
+        });
+        return {
+          text: "done",
+          reasoningText: undefined,
+          responseMessages: [{ role: "assistant", content: "done" }],
+        };
+      });
+
+      const turnPromise = session.sendUserMessage("go");
+      await new Promise((r) => setTimeout(r, 10));
+
+      const activeTurnId = session.activeTurnId;
+      expect(activeTurnId).toBeTruthy();
+      await session.sendSteerMessage("", activeTurnId!, "steer-attachment", [{
+        filename: "diagram.png",
+        contentBase64: Buffer.from("png-bytes").toString("base64"),
+        mimeType: "image/png",
+      }]);
+
+      const prepareResult = await capturedPrepareStep?.({
+        stepNumber: 2,
+        messages: [{ role: "user", content: "go" }],
+      });
+      expect(prepareResult?.messages).toHaveLength(2);
+      expect(prepareResult?.messages?.[1]).toMatchObject({
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: expect.stringContaining("diagram.png"),
+          },
+          {
+            type: "image",
+            data: Buffer.from("png-bytes").toString("base64"),
+            mimeType: "image/png",
+          },
+        ],
+      });
 
       resolveRunTurn();
       await turnPromise;
@@ -4239,6 +4308,21 @@ describe("AgentSession", () => {
       expect(thirdCall.messages[2]).toEqual({ role: "user", content: "msg2" });
       expect(thirdCall.messages[3]).toEqual(responseMsg2);
       expect(thirdCall.messages[4]).toEqual({ role: "user", content: "msg3" });
+    });
+  });
+
+  describe("uploadFile", () => {
+    test("rejects malformed base64 payloads as validation errors", async () => {
+      const { session, events } = makeSession();
+
+      await session.uploadFile("notes.txt", "%%%not-base64%%%");
+
+      expect(events.find((event) => event.type === "file_uploaded")).toBeUndefined();
+      const errorEvt = events.find((event) => event.type === "error") as Extract<ServerEvent, { type: "error" }> | undefined;
+      expect(errorEvt).toBeDefined();
+      expect(errorEvt?.code).toBe("validation_failed");
+      expect(errorEvt?.source).toBe("session");
+      expect(errorEvt?.message).toBe("Invalid file content.");
     });
   });
 

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -2917,7 +2917,7 @@ describe("AgentSession", () => {
         content: [
           {
             type: "text",
-            text: expect.stringContaining("diagram.png"),
+            text: expect.stringContaining("/User Uploads/"),
           },
           {
             type: "image",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add strict attachment base64 validation for session uploads and turn/steer attachments
- omit empty text parts for attachment-only desktop JSON-RPC turn requests
- add the missing root `zustand` dependency needed by CI's mobile store tests
- add focused regressions for attachment-only steer/start behavior, queue cleanup, and upload validation
- stabilize the mobile transport relay-role test mock so the full Bun lane no longer pollutes shared transport state across files

## Testing
- `~/.bun/bin/bun test apps/desktop/test/runtimeState.test.ts apps/desktop/test/jsonrpc-single-connection.test.ts`
- `~/.bun/bin/bun test test/session.test.ts --test-name-pattern "attachment|uploadFile|steer_message|sendUserMessage"`
- `~/.bun/bin/bun test test/mobile.control-store.test.ts test/mobile.thread-store.test.ts`
- `~/.bun/bin/bun test test/mobile.transport.relay-role.test.ts test/mobile.transport-integration.test.ts`
- `~/.bun/bin/bun run typecheck`
- `~/.bun/bin/bun test --max-concurrency 4`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dfee86d5-2ffd-4811-9699-2eabf19aa4c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dfee86d5-2ffd-4811-9699-2eabf19aa4c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

