### PR TITLE
fix: single-source spawn-agent prompt docs

### DIFF
--- a/prompts/system-models/claude-sonnet-4-6.md
+++ b/prompts/system-models/claude-sonnet-4-6.md
@@ -182,20 +182,7 @@ User: "Add user authentication and run tests"
 </example>
 </tool>
 
-<tool name="spawnAgent">
-Launch an independent sub-agent to handle a specific task in its own context with its own tools. Use this for parallelization (two or more independent tasks running simultaneously), context isolation (heavy analysis or reading that would bloat the main conversation), and verification (checking your own work after completing complex tasks). Sub-agents are one of the most powerful efficiency tools available — prefer parallel sub-agents over sequential work whenever tasks are independent.
-
-Rules:
-- Provide detailed, self-contained prompts. The sub-agent doesn't see the main conversation history — include all necessary context, file paths, and clear instructions.
-- Clearly tell the sub-agent whether to write code/files or just research and report back.
-- Sub-agent results are not visible to the user — summarize them in your response.
-- Sub-agents cannot spawn their own sub-agents (no recursive spawning).
-
-Available sub-agent types:
-- **explore**: Fast codebase exploration. Uses a cheap/fast model. Tools: read, glob, grep, bash. Read-only — does not modify files.
-- **research**: Web research and synthesis. Uses the main model. Tools: webSearch, webFetch, read. Returns sourced summaries.
-- **general**: Full-capability agent for delegated tasks. Uses all tools except spawnAgent.
-</tool>
+{{spawnAgentToolSection}}
 
 <tool name="notebookEdit">
 Edit Jupyter notebook (.ipynb) cells. Use this for modifying, inserting, or deleting cells in notebook files. Supports replace, insert, and delete operations. Do NOT manually edit .ipynb JSON with the edit or write tools — always use this dedicated tool for notebook modifications.

--- a/prompts/system-models/gemini-3-flash-preview.md
+++ b/prompts/system-models/gemini-3-flash-preview.md
@@ -176,23 +176,7 @@ User: "Add user authentication and run tests"
 
 ## Agent
 
-### spawnAgent
-
-Launch an independent sub-agent for a specific task.
-
-When to use:
-
-- **Parallelization**: Two or more independent tasks — spawn agents for each.
-- **Context isolation**: Heavy reading/research — spawn an agent to keep the main context clean.
-- **Verification**: After complex work, spawn an agent to check it.
-
-Rules: Provide detailed, self-contained prompts (the sub-agent has no main conversation history). State whether it should write files or just report back. Sub-agent results are not visible to the user — summarize them. No recursive spawning.
-
-Types:
-
-- **explore**: Fast codebase exploration. Cheap/fast model. Tools: read, glob, grep, bash. Read-only.
-- **research**: Web research. Main model. Tools: webSearch, webFetch, read.
-- **general**: Full capability. All tools except spawnAgent.
+{{spawnAgentMarkdownSection}}
 
 ### notebookEdit
 

--- a/prompts/system-models/gemini-3.1-pro-preview.md
+++ b/prompts/system-models/gemini-3.1-pro-preview.md
@@ -213,25 +213,7 @@ User: "Add user authentication and run tests"
 
 <agent>
 
-<spawnAgent>
-Launch a sub-agent to handle a specific task independently. The sub-agent runs in its own context with its own tools and returns a result.
-
-When to use:
-- **Parallelization**: When you have two or more independent tasks, spawn agents for each. They can work simultaneously.
-- **Context isolation**: When a subtask requires reading many files, extensive research, or heavy analysis, spawn an agent so the intermediate context doesn't bloat the main conversation.
-- **Verification**: After completing complex work, spawn an agent to verify the result (run tests, check for errors, validate output).
-
-Rules:
-- Provide detailed, self-contained prompts. The sub-agent doesn't see the main conversation history.
-- Clearly tell the sub-agent whether to write code/files or just research and report back.
-- Sub-agent results are not visible to the user — summarize them in your response.
-- Sub-agents cannot spawn their own sub-agents (no recursive spawning).
-
-Available sub-agent types:
-- **explore**: Fast codebase exploration. Uses a cheap/fast model. Tools: read, glob, grep, bash. Read-only — does not modify files.
-- **research**: Web research and synthesis. Uses the main model. Tools: webSearch, webFetch, read. Returns sourced summaries.
-- **general**: Full-capability agent for delegated tasks. Uses all tools except spawnAgent.
-</spawnAgent>
+{{spawnAgentXmlSection}}
 
 <notebookEdit>
 Edit Jupyter notebook (.ipynb) cells. Supports replace, insert, and delete operations.

--- a/prompts/system-models/gpt-5.2.md
+++ b/prompts/system-models/gpt-5.2.md
@@ -321,27 +321,7 @@ User: "Add user authentication and run tests"
 
 ## Agent
 
-### spawnAgent
-Launch a sub-agent to handle a specific task independently. The sub-agent runs in its own context with its own tools and returns a result.
-
-When to use:
-
-- **Parallelization**: When you have two or more independent tasks, spawn agents for each. They can work simultaneously.
-- **Context isolation**: When a subtask requires reading many files, extensive research, or heavy analysis, spawn an agent so the intermediate context doesn't bloat the main conversation.
-- **Verification**: After completing complex work, spawn an agent to verify the result (run tests, check for errors, validate output).
-
-Rules:
-
-- Provide detailed, self-contained prompts. The sub-agent doesn't see the main conversation history.
-- Clearly tell the sub-agent whether to write code/files or just research and report back.
-- Sub-agent results are not visible to the user — summarize them in your response.
-- Sub-agents cannot spawn their own sub-agents (no recursive spawning).
-
-Available sub-agent types:
-
-- **explore**: Fast codebase exploration. Uses a cheap/fast model. Tools: read, glob, grep, bash. Read-only — does not modify files.
-- **research**: Web research and synthesis. Uses the main model. Tools: webSearch, webFetch, read. Returns sourced summaries.
-- **general**: Full-capability agent for delegated tasks. Uses all tools except spawnAgent.
+{{spawnAgentMarkdownSection}}
 
 ### notebookEdit
 Edit Jupyter notebook (.ipynb) cells. Supports replace, insert, and delete operations.

--- a/prompts/system.md
+++ b/prompts/system.md
@@ -232,24 +232,7 @@ User: "Add user authentication and run tests"
 
 ## Agent
 
-### spawnAgent
-Launch a sub-agent to handle a specific task independently. The sub-agent runs in its own context with its own tools and returns a result.
-
-When to use:
-- **Parallelization**: When you have two or more independent tasks, spawn agents for each. They can work simultaneously.
-- **Context isolation**: When a subtask requires reading many files, extensive research, or heavy analysis, spawn an agent so the intermediate context doesn't bloat the main conversation.
-- **Verification**: After completing complex work, spawn an agent to verify the result (run tests, check for errors, validate output).
-
-Rules:
-- Provide detailed, self-contained prompts. The sub-agent doesn't see the main conversation history.
-- Clearly tell the sub-agent whether to write code/files or just research and report back.
-- Sub-agent results are not visible to the user — summarize them in your response.
-- Sub-agents cannot spawn their own sub-agents (no recursive spawning).
-
-Available sub-agent types:
-- **explore**: Fast codebase exploration. Uses a cheap/fast model. Tools: read, glob, grep, bash. Read-only — does not modify files.
-- **research**: Web research and synthesis. Uses the main model. Tools: webSearch, webFetch, read. Returns sourced summaries.
-- **general**: Full-capability agent for delegated tasks. Uses all tools except spawnAgent.
+{{spawnAgentMarkdownSection}}
 
 ### notebookEdit
 Edit Jupyter notebook (.ipynb) cells. Supports replace, insert, and delete operations.

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -8,7 +8,14 @@ import type { ResolvedModelMetadata } from "./models/metadataTypes";
 import { getChildAgentModelInfo, listChildAgentModelsWithInfo } from "./models/childAgentModelInfo";
 import { parseChildModelRef } from "./models/childModelRouting";
 import { MemoryStore } from "./memoryStore";
-import { AGENT_ROLE_DEFINITIONS } from "./server/agents/roles";
+import {
+  AGENT_ROLE_DEFINITIONS,
+  buildSpawnAgentRolePromptLines,
+  SPAWN_AGENT_MODEL_OVERRIDE_GUIDANCE,
+  SPAWN_AGENT_ORCHESTRATION_RULES,
+  SPAWN_AGENT_PROMPT_OVERVIEW,
+  SPAWN_AGENT_WHEN_TO_USE,
+} from "./server/agents/roles";
 import type { AgentRole } from "./shared/agents";
 import {
   getCodexWebSearchBackendFromProviderOptions,
@@ -264,13 +271,18 @@ const PROVIDER_DISPLAY_NAMES: Record<ProviderName, string> = {
   "codex-cli": "Codex CLI",
 };
 
-function buildSpawnAgentPromptBody(config: AgentConfig): string {
+const SPAWN_AGENT_MARKDOWN_SECTION_PLACEHOLDER = "{{spawnAgentMarkdownSection}}";
+const SPAWN_AGENT_TOOL_SECTION_PLACEHOLDER = "{{spawnAgentToolSection}}";
+const SPAWN_AGENT_XML_SECTION_PLACEHOLDER = "{{spawnAgentXmlSection}}";
+const SPAWN_AGENT_PROMPT_BODY_PLACEHOLDER = "{{spawnAgentPromptBody}}";
+
+export function buildSpawnAgentPromptBody(config: AgentConfig): string {
   const providerLabel = PROVIDER_DISPLAY_NAMES[config.provider] ?? config.provider;
   const currentModel = getResolvedModelMetadataSync(config.provider, config.model, "model");
-
-  const roleLines = Object.values(AGENT_ROLE_DEFINITIONS)
-    .map((role) => `- **${role.id}**: ${role.description}`)
-    .join("\n");
+  const roleLines = buildSpawnAgentRolePromptLines().join("\n");
+  const whenToUseLines = SPAWN_AGENT_WHEN_TO_USE.map((item) => `- **${item.label}**: ${item.description}`);
+  const orchestrationRuleLines = SPAWN_AGENT_ORCHESTRATION_RULES.map((rule) => `- ${rule}`);
+  const modelOverrideGuidanceLines = SPAWN_AGENT_MODEL_OVERRIDE_GUIDANCE.map((rule) => `- ${rule}`);
 
   const crossProviderRefs = (config.allowedChildModelRefs ?? [])
     .map((ref) => {
@@ -297,21 +309,16 @@ function buildSpawnAgentPromptBody(config: AgentConfig): string {
           .join("\n");
 
   return [
-    "Launch a collaborative child agent for a well-scoped task. It returns a durable child handle to use with follow-up agent tools; it does not return the child agent's final answer text directly.",
+    SPAWN_AGENT_PROMPT_OVERVIEW,
     "",
     "When to use:",
-    "- **Parallelization**: Independent work that can proceed concurrently.",
-    "- **Context isolation**: Large codebase reads, heavy research, or deep analysis that would bloat the parent context.",
-    "- **Verification**: Focused review, testing, or validation after implementation.",
+    ...whenToUseLines,
     "",
-    "Rules:",
-    "- Provide detailed, self-contained prompts with the exact files, ownership, and expected output.",
-    "- If `model` is omitted, the child inherits the live parent provider/model.",
-    "- `model` may be a same-provider model id or a full `provider:modelId` child target ref.",
-    "- `preferredChildModelRef` is only a workspace/UI suggestion; it does not override the spawn request automatically.",
-    "- If a cross-provider target is disallowed for this workspace or its provider is disconnected, the child falls back to the live parent provider/model.",
-    "- Child-agent results are not visible to the user unless you summarize them.",
-    "- Child agents should stay bounded; do not use them for vague or open-ended delegation.",
+    "Orchestration rules:",
+    ...orchestrationRuleLines,
+    "",
+    "Model override guidance:",
+    ...modelOverrideGuidanceLines,
     "",
     "Available child-agent roles:",
     roleLines,
@@ -326,11 +333,36 @@ function buildSpawnAgentPromptBody(config: AgentConfig): string {
   ].join("\n");
 }
 
-function renderSpawnAgentSpecificPrompt(prompt: string, config: AgentConfig): string {
+function buildSpawnAgentPromptSections(config: AgentConfig): {
+  body: string;
+  markdownSection: string;
+  toolSection: string;
+  xmlSection: string;
+} {
   const body = buildSpawnAgentPromptBody(config);
-  const markdownSection = `### spawnAgent\n${body}`;
-  const toolSection = `<tool name="spawnAgent">\n${body}\n</tool>`;
-  const xmlSection = `<spawnAgent>\n${body}\n</spawnAgent>`;
+  return {
+    body,
+    markdownSection: `### spawnAgent\n${body}`,
+    toolSection: `<tool name="spawnAgent">\n${body}\n</tool>`,
+    xmlSection: `<spawnAgent>\n${body}\n</spawnAgent>`,
+  };
+}
+
+function renderSpawnAgentSpecificPrompt(prompt: string, config: AgentConfig): string {
+  const { body, markdownSection, toolSection, xmlSection } = buildSpawnAgentPromptSections(config);
+
+  if (prompt.includes(SPAWN_AGENT_MARKDOWN_SECTION_PLACEHOLDER)) {
+    return prompt.replaceAll(SPAWN_AGENT_MARKDOWN_SECTION_PLACEHOLDER, markdownSection);
+  }
+  if (prompt.includes(SPAWN_AGENT_TOOL_SECTION_PLACEHOLDER)) {
+    return prompt.replaceAll(SPAWN_AGENT_TOOL_SECTION_PLACEHOLDER, toolSection);
+  }
+  if (prompt.includes(SPAWN_AGENT_XML_SECTION_PLACEHOLDER)) {
+    return prompt.replaceAll(SPAWN_AGENT_XML_SECTION_PLACEHOLDER, xmlSection);
+  }
+  if (prompt.includes(SPAWN_AGENT_PROMPT_BODY_PLACEHOLDER)) {
+    return prompt.replaceAll(SPAWN_AGENT_PROMPT_BODY_PLACEHOLDER, body);
+  }
 
   if (prompt.includes('<tool name="spawnAgent">')) {
     return prompt.replace(/<tool name="spawnAgent">[\s\S]*?<\/tool>/i, toolSection);

--- a/src/server/agents/roles.ts
+++ b/src/server/agents/roles.ts
@@ -16,6 +16,37 @@ export type AgentRoleDefinition = {
   };
 };
 
+export const SPAWN_AGENT_PROMPT_OVERVIEW =
+  "Launch a collaborative child agent for a well-scoped task. It returns a durable child handle to use with follow-up agent tools; it does not return the child agent's final answer text directly.";
+
+export const SPAWN_AGENT_WHEN_TO_USE = [
+  {
+    label: "Parallelization",
+    description: "Independent work that can proceed concurrently.",
+  },
+  {
+    label: "Context isolation",
+    description: "Large codebase reads, heavy research, or deep analysis that would bloat the parent context.",
+  },
+  {
+    label: "Verification",
+    description: "Focused review, testing, or validation after implementation.",
+  },
+] as const;
+
+export const SPAWN_AGENT_ORCHESTRATION_RULES = [
+  "Provide detailed, self-contained prompts with the exact files, ownership, and expected output.",
+  "Child-agent results are not visible to the user unless you summarize them.",
+  "Child agents should stay bounded; do not use them for vague or open-ended delegation.",
+] as const;
+
+export const SPAWN_AGENT_MODEL_OVERRIDE_GUIDANCE = [
+  "If `model` is omitted, the child inherits the live parent provider/model unless the role has a fixed model policy.",
+  "`model` may be a same-provider model id or a full `provider:modelId` child target ref.",
+  "`preferredChildModelRef` is only a workspace/UI suggestion; it does not override the spawn request automatically.",
+  "If a cross-provider target is disallowed for this workspace or its provider is disconnected, the child falls back to the live parent provider/model.",
+] as const;
+
 export const AGENT_ROLE_DEFINITIONS: Record<AgentRole, AgentRoleDefinition> = {
   default: {
     id: "default",
@@ -76,4 +107,33 @@ export const AGENT_ROLE_DEFINITIONS: Record<AgentRole, AgentRoleDefinition> = {
 
 export function getAgentRoleDefinition(role: AgentRole): AgentRoleDefinition {
   return AGENT_ROLE_DEFINITIONS[role];
+}
+
+function formatRoleCapabilities(role: AgentRoleDefinition): string[] {
+  const capabilities = [
+    role.description,
+    `Default mode: ${role.defaultMode}.`,
+    role.readOnly ? "Read-only." : "Write-capable.",
+    role.canAskUser ? "Can ask the user directly." : "Cannot ask the user directly.",
+    role.canSpawnChildren
+      ? `Can spawn child agents up to depth ${role.maxDepth}.`
+      : `Cannot spawn child agents; max depth ${role.maxDepth}.`,
+  ];
+
+  if (role.modelPolicy?.fixedModel) {
+    capabilities.push(`Fixed model: \`${role.modelPolicy.fixedModel}\`.`);
+  }
+  if (role.modelPolicy?.fixedReasoningEffort) {
+    capabilities.push(`Fixed reasoning effort: \`${role.modelPolicy.fixedReasoningEffort}\`.`);
+  }
+
+  return capabilities;
+}
+
+export function buildSpawnAgentRolePromptLine(role: AgentRoleDefinition): string {
+  return `- **${role.id}**: ${formatRoleCapabilities(role).join(" ")}`;
+}
+
+export function buildSpawnAgentRolePromptLines(): string[] {
+  return Object.values(AGENT_ROLE_DEFINITIONS).map((role) => buildSpawnAgentRolePromptLine(role));
 }

--- a/test/prompt.test.ts
+++ b/test/prompt.test.ts
@@ -5,6 +5,14 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { loadSystemPrompt, loadSubAgentPrompt, loadSystemPromptWithSkills } from "../src/prompt";
+import {
+  AGENT_ROLE_DEFINITIONS,
+  buildSpawnAgentRolePromptLines,
+  SPAWN_AGENT_MODEL_OVERRIDE_GUIDANCE,
+  SPAWN_AGENT_ORCHESTRATION_RULES,
+  SPAWN_AGENT_PROMPT_OVERVIEW,
+  SPAWN_AGENT_WHEN_TO_USE,
+} from "../src/server/agents/roles";
 import type { AgentConfig } from "../src/types";
 
 function repoRoot(): string {
@@ -53,6 +61,58 @@ function makeConfig(overrides: Partial<AgentConfig> = {}): AgentConfig {
 async function writeFile(p: string, content: string) {
   await fs.mkdir(path.dirname(p), { recursive: true });
   await fs.writeFile(p, content, "utf-8");
+}
+
+function extractSpawnAgentBody(prompt: string): string {
+  const patterns = [
+    /<tool name="spawnAgent">\n([\s\S]*?)\n<\/tool>/,
+    /<spawnAgent>\n([\s\S]*?)\n<\/spawnAgent>/,
+    /### spawnAgent\n([\s\S]*?)(?=\n### notebookEdit\b)/,
+  ];
+
+  for (const pattern of patterns) {
+    const match = prompt.match(pattern);
+    if (match?.[1]) {
+      return match[1];
+    }
+  }
+
+  throw new Error("spawnAgent section not found");
+}
+
+function expectedSpawnAgentRoleCatalog(): string {
+  return [
+    "Available child-agent roles:",
+    ...buildSpawnAgentRolePromptLines(),
+  ].join("\n");
+}
+
+function expectedSpawnAgentSharedGuidance(): string {
+  return [
+    SPAWN_AGENT_PROMPT_OVERVIEW,
+    "",
+    "When to use:",
+    ...SPAWN_AGENT_WHEN_TO_USE.map((item) => `- **${item.label}**: ${item.description}`),
+    "",
+    "Orchestration rules:",
+    ...SPAWN_AGENT_ORCHESTRATION_RULES.map((rule) => `- ${rule}`),
+    "",
+    "Model override guidance:",
+    ...SPAWN_AGENT_MODEL_OVERRIDE_GUIDANCE.map((rule) => `- ${rule}`),
+  ].join("\n");
+}
+
+function extractSpawnAgentRoleCatalog(prompt: string): string {
+  const body = extractSpawnAgentBody(prompt);
+  const match = body.match(
+    /Available child-agent roles:\n([\s\S]*?)(?=\n\n(?:Available allowed child target refs for this workspace:|Available model overrides for the current provider \(|$))/
+  );
+
+  if (!match?.[1]) {
+    throw new Error("spawnAgent role catalog not found");
+  }
+
+  return `Available child-agent roles:\n${match[1].trimEnd()}`;
 }
 
 async function withMockedFetch<T>(
@@ -194,25 +254,44 @@ describe("loadSystemPrompt", () => {
     expect(prompt).toContain("Any LM Studio LLM key discovered at runtime is allowed.");
   });
 
-  test("renders dynamic spawnAgent roles and current-provider model guidance", async () => {
+  test("renders spawnAgent role catalog from AGENT_ROLE_DEFINITIONS across prompt formats", async () => {
+    const expectedRoleCatalog = expectedSpawnAgentRoleCatalog();
+    const expectedSharedGuidance = `${expectedSpawnAgentSharedGuidance()}\n\n${expectedRoleCatalog}`;
+    const promptConfigs = [
+      makeConfig({ provider: "openai", model: "gpt-5.4", preferredChildModel: "gpt-5.4" }),
+      makeConfig({ provider: "google", model: "gemini-3.1-pro-preview", preferredChildModel: "gemini-3.1-pro-preview" }),
+      makeConfig({ provider: "anthropic", model: "claude-sonnet-4-6", preferredChildModel: "claude-sonnet-4-6" }),
+    ];
+
+    expect(buildSpawnAgentRolePromptLines()).toHaveLength(Object.keys(AGENT_ROLE_DEFINITIONS).length);
+
+    for (const config of promptConfigs) {
+      const prompt = await loadSystemPrompt(config);
+      const spawnAgentBody = extractSpawnAgentBody(prompt);
+
+      expect(spawnAgentBody.startsWith(expectedSharedGuidance)).toBe(true);
+      expect(extractSpawnAgentRoleCatalog(prompt)).toBe(expectedRoleCatalog);
+      expect(spawnAgentBody).not.toContain("**explore**:");
+      expect(spawnAgentBody).not.toContain("**general**:");
+    }
+  });
+
+  test("renders dynamic spawnAgent model guidance for the current provider", async () => {
     const config = makeConfig({ provider: "openai", model: "gpt-5.4", preferredChildModel: "gpt-5.4" });
     const prompt = await loadSystemPrompt(config);
+    const spawnAgentBody = extractSpawnAgentBody(prompt);
 
-    expect(prompt).toContain("Available child-agent roles:");
-    expect(prompt).toContain("**default**");
-    expect(prompt).toContain("**explorer**");
-    expect(prompt).toContain("**research**");
-    expect(prompt).toContain("**worker**");
-    expect(prompt).toContain("**reviewer**");
-    expect(prompt).toContain("Available model overrides for the current provider (OpenAI):");
-    expect(prompt).toContain("**GPT-5.4** (`gpt-5.4`)");
-    expect(prompt).toContain("**GPT-5.4 Mini** (`gpt-5.4-mini`)");
-    expect(prompt).toContain("**GPT-5 Mini** (`gpt-5-mini`)");
-    expect(prompt).toContain("`preferredChildModelRef` is only a workspace/UI suggestion");
+    expect(spawnAgentBody).toContain("Orchestration rules:");
+    expect(spawnAgentBody).toContain("Model override guidance:");
+    expect(spawnAgentBody).toContain("Available model overrides for the current provider (OpenAI):");
+    expect(spawnAgentBody).toContain("**GPT-5.4** (`gpt-5.4`)");
+    expect(spawnAgentBody).toContain("**GPT-5.4 Mini** (`gpt-5.4-mini`)");
+    expect(spawnAgentBody).toContain("**GPT-5 Mini** (`gpt-5-mini`)");
+    expect(spawnAgentBody).toContain("`preferredChildModelRef` is only a workspace/UI suggestion");
     expect(prompt).toContain("spawnAgent with `role: \"explorer\"`");
     expect(prompt).not.toContain("spawnAgent (explore type)");
-    expect(prompt).not.toContain("**explore**: Fast codebase exploration.");
-    expect(prompt).not.toContain("**general**: Full-capability agent for delegated tasks.");
+    expect(spawnAgentBody).not.toContain("**explore**: Fast codebase exploration.");
+    expect(spawnAgentBody).not.toContain("**general**: Full-capability agent for delegated tasks.");
     expect(prompt).not.toContain("moonshotai/Kimi-K2.5");
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- single-source the rendered `spawnAgent` prompt section from the runtime role registry module
- replace embedded spawn-agent prose in shipped prompt templates with runtime placeholders only
- add prompt coverage that asserts the rendered role catalog matches the registered agent roles across prompt formats

## Testing
- `bun test test/prompt.test.ts`
- `bun run typecheck`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b81b219b-0b95-4c35-85d2-9ed2c939c4a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b81b219b-0b95-4c35-85d2-9ed2c939c4a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

