### PR TITLE
Strengthen parent child-agent orchestration guidance

### DIFF
--- a/prompts/system.md
+++ b/prompts/system.md
@@ -288,12 +288,15 @@ Just do it when:
 
 ## How to Plan
 
-1. Explore: Use read, glob, grep, and spawnAgent with `role: "explorer"` for read-only discovery. Run independent research in parallel when possible.
+1. Explore: Use read, glob, grep, and choose a read-only discovery role from the available sub-agent types (default: `{{defaultDiscoveryRole}}`). Run independent research in parallel when possible.
 2. Synthesize: After children report back, synthesize the findings yourself into a concrete next prompt. Report what you launched, not predicted outcomes.
 3. Design: Write a plan — what files to change, what approach to take, what the tradeoffs are.
 4. Present: Use the ask tool to show the plan and get approval. Include the key decision points.
-5. Implement: On approval, use spawnAgent with `role: "worker"` for bounded implementation slices. Continue with the same child when context overlap is high; spawn a fresh child when the next task is narrow and the previous context was broad.
-6. Verify: After non-trivial implementation, use spawnAgent with `role: "reviewer"` for independent validation. Prefer one write-capable child per file area at a time to avoid collisions.
+5. Implement: On approval, choose a write-capable implementation role from the available sub-agent types (default: `{{defaultImplementationRole}}`) for bounded implementation slices. Continue with the same child when context overlap is high; spawn a fresh child when the next task is narrow and the previous context was broad.
+6. Verify: After non-trivial implementation, choose an independent read-only verification role from the available sub-agent types (default: `{{defaultVerificationRole}}`). Prefer one write-capable child per file area at a time to avoid collisions.
+
+Available sub-agent types (dynamic):
+{{availableSubagentTypes}}
 
 # Skills and Templates
 
@@ -410,7 +413,8 @@ Use sub-agents when you have two or more independent pieces of work. Don't do th
 
 Use sub-agents to isolate expensive context. If you need to read through a large codebase, analyze a big dataset, or do extensive web research, spawn an agent for it so the intermediate tokens don't consume the main conversation's context window.
 
-Use role discipline: `explorer` for discovery, `worker` for implementation, and `reviewer` for verification.
+Use role discipline based on the currently available sub-agent types:
+{{availableSubagentTypes}}
 
 After launching child agents, only report what was launched; do not report predicted results.
 
@@ -418,7 +422,7 @@ Reuse a child when follow-up work has high context overlap. Spawn a fresh child 
 
 Keep at most one write-capable child per file area at a time to avoid edit collisions.
 
-Always include a verification step for non-trivial work. After implementing something, spawn a `reviewer` child to check it: run tests, review the diff, validate the output, look for edge cases.
+Always include a verification step for non-trivial work. After implementing something, spawn an independent read-only verification child (default: `{{defaultVerificationRole}}`) to check it: run tests, review the diff, validate the output, look for edge cases.
 
 Sub-agents don't see the main conversation, so your prompt to them must be self-contained. Include all necessary context, file paths, and clear instructions about what to deliver.
 

--- a/prompts/system.md
+++ b/prompts/system.md
@@ -288,11 +288,12 @@ Just do it when:
 
 ## How to Plan
 
-1. Explore: Use read, glob, grep, and spawnAgent with `role: "explorer"` to understand the codebase.
-2. Design: Write a plan — what files to change, what approach to take, what the tradeoffs are.
-3. Present: Use the ask tool to show the plan and get approval. Include the key decision points.
-4. Implement: On approval, execute the plan. On rejection, revise.
-5. Verify: After implementing, spawn a verification agent to check the result.
+1. Explore: Use read, glob, grep, and spawnAgent with `role: "explorer"` for read-only discovery. Run independent research in parallel when possible.
+2. Synthesize: After children report back, synthesize the findings yourself into a concrete next prompt. Report what you launched, not predicted outcomes.
+3. Design: Write a plan — what files to change, what approach to take, what the tradeoffs are.
+4. Present: Use the ask tool to show the plan and get approval. Include the key decision points.
+5. Implement: On approval, use spawnAgent with `role: "worker"` for bounded implementation slices. Continue with the same child when context overlap is high; spawn a fresh child when the next task is narrow and the previous context was broad.
+6. Verify: After non-trivial implementation, use spawnAgent with `role: "reviewer"` for independent validation. Prefer one write-capable child per file area at a time to avoid collisions.
 
 # Skills and Templates
 
@@ -409,7 +410,15 @@ Use sub-agents when you have two or more independent pieces of work. Don't do th
 
 Use sub-agents to isolate expensive context. If you need to read through a large codebase, analyze a big dataset, or do extensive web research, spawn an agent for it so the intermediate tokens don't consume the main conversation's context window.
 
-Always include a verification step for non-trivial work. After implementing something, spawn an agent to check it: run tests, review the diff, validate the output, look for edge cases.
+Use role discipline: `explorer` for discovery, `worker` for implementation, and `reviewer` for verification.
+
+After launching child agents, only report what was launched; do not report predicted results.
+
+Reuse a child when follow-up work has high context overlap. Spawn a fresh child when the next task is narrow and the previous context was broad.
+
+Keep at most one write-capable child per file area at a time to avoid edit collisions.
+
+Always include a verification step for non-trivial work. After implementing something, spawn a `reviewer` child to check it: run tests, review the diff, validate the output, look for edge cases.
 
 Sub-agents don't see the main conversation, so your prompt to them must be self-contained. Include all necessary context, file paths, and clear instructions about what to deliver.
 

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -414,6 +414,65 @@ function buildEnabledPluginSummary(skills: Array<{ name: string; description: st
     });
 }
 
+function buildAvailableSubagentTypesList(): string {
+  return Object.values(AGENT_ROLE_DEFINITIONS)
+    .map((role) => `- \`${role.id}\`: ${role.description}`)
+    .join("\n");
+}
+
+function selectRoleByCapabilities(
+  roles: AgentRoleDefinition[],
+  options: {
+    preferredIds: AgentRole[];
+    requireReadOnly?: boolean;
+    excludeId?: AgentRole;
+  },
+): AgentRoleDefinition | null {
+  const filtered = roles.filter((role) => {
+    if (options.requireReadOnly !== undefined && role.readOnly !== options.requireReadOnly) {
+      return false;
+    }
+    if (options.excludeId && role.id === options.excludeId) {
+      return false;
+    }
+    return true;
+  });
+  if (filtered.length === 0) return null;
+
+  for (const preferredId of options.preferredIds) {
+    const preferred = filtered.find((role) => role.id === preferredId);
+    if (preferred) return preferred;
+  }
+  return filtered[0] ?? null;
+}
+
+function resolveDefaultSubagentRoleIds(): {
+  discoveryRoleId: string;
+  implementationRoleId: string;
+  verificationRoleId: string;
+} {
+  const roles = Object.values(AGENT_ROLE_DEFINITIONS);
+  const discovery = selectRoleByCapabilities(roles, {
+    preferredIds: ["explorer", "research"],
+    requireReadOnly: true,
+  });
+  const implementation = selectRoleByCapabilities(roles, {
+    preferredIds: ["worker", "default"],
+    requireReadOnly: false,
+  });
+  const verification = selectRoleByCapabilities(roles, {
+    preferredIds: ["reviewer", "research", "explorer"],
+    requireReadOnly: true,
+    excludeId: discovery?.id,
+  }) ?? discovery;
+
+  return {
+    discoveryRoleId: discovery?.id ?? "explorer",
+    implementationRoleId: implementation?.id ?? "worker",
+    verificationRoleId: verification?.id ?? discovery?.id ?? "reviewer",
+  };
+}
+
 function buildSkillPolicySection(skillNames: string, skillExamples: string, config: AgentConfig): string {
   return [
     "## Skill Loading Policy (Strict)",
@@ -500,6 +559,7 @@ export async function loadSystemPromptWithSkills(config: AgentConfig): Promise<S
       .join("\n");
   }
 
+  const defaultSubagentRoles = resolveDefaultSubagentRoleIds();
   const vars: Record<string, string> = {
     workingDirectory: config.workingDirectory,
     currentDate: new Date().toLocaleDateString("en-US", {
@@ -514,6 +574,10 @@ export async function loadSystemPromptWithSkills(config: AgentConfig): Promise<S
     userProfileInstructions: config.userProfile?.instructions || "",
     userProfileWork: config.userProfile?.work || "",
     userProfileDetails: config.userProfile?.details || "",
+    availableSubagentTypes: buildAvailableSubagentTypesList(),
+    defaultDiscoveryRole: defaultSubagentRoles.discoveryRoleId,
+    defaultImplementationRole: defaultSubagentRoles.implementationRoleId,
+    defaultVerificationRole: defaultSubagentRoles.verificationRoleId,
     knowledgeCutoff: supportedModel.knowledgeCutoff,
     skillNames: skillNames || '"pdf", "doc", "slides", "spreadsheet"',
     skillExamples:

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -17,6 +17,7 @@ import {
   SPAWN_AGENT_PROMPT_OVERVIEW,
   SPAWN_AGENT_WHEN_TO_USE,
 } from "./server/agents/roles";
+import type { AgentRoleDefinition } from "./server/agents/roles";
 import type { AgentRole } from "./shared/agents";
 import {
   getCodexWebSearchBackendFromProviderOptions,

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -11,6 +11,7 @@ import { MemoryStore } from "./memoryStore";
 import {
   AGENT_ROLE_DEFINITIONS,
   buildSpawnAgentRolePromptLines,
+  SPAWN_AGENT_COORDINATION_RULES,
   SPAWN_AGENT_MODEL_OVERRIDE_GUIDANCE,
   SPAWN_AGENT_ORCHESTRATION_RULES,
   SPAWN_AGENT_PROMPT_OVERVIEW,
@@ -282,6 +283,7 @@ export function buildSpawnAgentPromptBody(config: AgentConfig): string {
   const roleLines = buildSpawnAgentRolePromptLines().join("\n");
   const whenToUseLines = SPAWN_AGENT_WHEN_TO_USE.map((item) => `- **${item.label}**: ${item.description}`);
   const orchestrationRuleLines = SPAWN_AGENT_ORCHESTRATION_RULES.map((rule) => `- ${rule}`);
+  const coordinationRuleLines = SPAWN_AGENT_COORDINATION_RULES.map((rule) => `- ${rule}`);
   const modelOverrideGuidanceLines = SPAWN_AGENT_MODEL_OVERRIDE_GUIDANCE.map((rule) => `- ${rule}`);
 
   const crossProviderRefs = (config.allowedChildModelRefs ?? [])
@@ -316,6 +318,9 @@ export function buildSpawnAgentPromptBody(config: AgentConfig): string {
     "",
     "Orchestration rules:",
     ...orchestrationRuleLines,
+    "",
+    "Coordinator rules:",
+    ...coordinationRuleLines,
     "",
     "Model override guidance:",
     ...modelOverrideGuidanceLines,

--- a/src/server/agents/roles.ts
+++ b/src/server/agents/roles.ts
@@ -49,7 +49,7 @@ export const SPAWN_AGENT_COORDINATION_RULES = [
   "After research completes, synthesize the findings yourself into a concrete follow-up prompt.",
   "Continue with the same child when the next task has high context overlap.",
   "Spawn a fresh child when the next task is narrow and the previous child carried broad context.",
-  "After non-trivial implementation, run an independent `reviewer` child for verification.",
+  "After non-trivial implementation, run an independent read-only verifier role for validation.",
   "Prefer one write-capable child per file area at a time to avoid edit collisions.",
 ] as const;
 

--- a/src/server/agents/roles.ts
+++ b/src/server/agents/roles.ts
@@ -43,6 +43,16 @@ export const SPAWN_AGENT_ORCHESTRATION_RULES = [
   "Child agents should stay bounded; do not use them for vague or open-ended delegation.",
 ] as const;
 
+export const SPAWN_AGENT_COORDINATION_RULES = [
+  "Use multiple child agents in parallel when research tasks are independent.",
+  "After launching child agents, report only what was launched; do not predict their results.",
+  "After research completes, synthesize the findings yourself into a concrete follow-up prompt.",
+  "Continue with the same child when the next task has high context overlap.",
+  "Spawn a fresh child when the next task is narrow and the previous child carried broad context.",
+  "After non-trivial implementation, run an independent `reviewer` child for verification.",
+  "Prefer one write-capable child per file area at a time to avoid edit collisions.",
+] as const;
+
 export const SPAWN_AGENT_MODEL_OVERRIDE_GUIDANCE = [
   "If `model` is omitted, the child inherits the live parent provider/model unless the role has a fixed model policy.",
   "`model` may be a same-provider model id or a full `provider:modelId` child target ref.",

--- a/test/prompt.test.ts
+++ b/test/prompt.test.ts
@@ -192,12 +192,18 @@ function expectSharedAgentReportContract(prompt: string) {
 }
 
 function expectCoordinatorRoleMappingGuidance(prompt: string) {
-  expect(prompt).toContain("spawnAgent with `role: \"explorer\"` for read-only discovery");
-  expect(prompt).toContain("use spawnAgent with `role: \"worker\"` for bounded implementation slices");
-  expect(prompt).toContain("use spawnAgent with `role: \"reviewer\"` for independent validation");
-  expect(prompt).toContain(
-    "Use role discipline: `explorer` for discovery, `worker` for implementation, and `reviewer` for verification."
-  );
+  expect(prompt).toContain("choose a read-only discovery role from the available sub-agent types");
+  expect(prompt).toContain("choose a write-capable implementation role from the available sub-agent types");
+  expect(prompt).toContain("choose an independent read-only verification role from the available sub-agent types");
+  expect(prompt).toContain("Use role discipline based on the currently available sub-agent types:");
+  expect(prompt).toContain("default: `explorer`");
+  expect(prompt).toContain("default: `worker`");
+  expect(prompt).toContain("default: `reviewer`");
+  expect(prompt).toContain("spawn an independent read-only verification child (default: `reviewer`)");
+
+  for (const role of Object.values(AGENT_ROLE_DEFINITIONS)) {
+    expect(prompt).toContain(`- \`${role.id}\`: ${role.description}`);
+  }
 }
 
 const IMAGE_GUIDANCE_PROMPT_CONFIGS = [
@@ -306,7 +312,7 @@ describe("loadSystemPrompt", () => {
     expect(spawnAgentBody).toContain("Coordinator rules:");
     expect(spawnAgentBody).toContain("Use multiple child agents in parallel when research tasks are independent.");
     expect(spawnAgentBody).toContain("report only what was launched; do not predict their results.");
-    expect(spawnAgentBody).toContain("run an independent `reviewer` child for verification");
+    expect(spawnAgentBody).toContain("run an independent read-only verifier role for validation");
     expect(spawnAgentBody).toContain("Model override guidance:");
     expect(spawnAgentBody).toContain("Available model overrides for the current provider (OpenAI):");
     expect(spawnAgentBody).toContain("**GPT-5.4** (`gpt-5.4`)");

--- a/test/prompt.test.ts
+++ b/test/prompt.test.ts
@@ -8,6 +8,7 @@ import { loadAgentPrompt, loadSystemPrompt, loadSubAgentPrompt, loadSystemPrompt
 import {
   AGENT_ROLE_DEFINITIONS,
   buildSpawnAgentRolePromptLines,
+  SPAWN_AGENT_COORDINATION_RULES,
   SPAWN_AGENT_MODEL_OVERRIDE_GUIDANCE,
   SPAWN_AGENT_ORCHESTRATION_RULES,
   SPAWN_AGENT_PROMPT_OVERVIEW,
@@ -97,6 +98,9 @@ function expectedSpawnAgentSharedGuidance(): string {
     "Orchestration rules:",
     ...SPAWN_AGENT_ORCHESTRATION_RULES.map((rule) => `- ${rule}`),
     "",
+    "Coordinator rules:",
+    ...SPAWN_AGENT_COORDINATION_RULES.map((rule) => `- ${rule}`),
+    "",
     "Model override guidance:",
     ...SPAWN_AGENT_MODEL_OVERRIDE_GUIDANCE.map((rule) => `- ${rule}`),
   ].join("\n");
@@ -185,6 +189,15 @@ function expectSharedAgentReportContract(prompt: string) {
   expect(prompt).toContain("Required footer fields: `status`, `summary`.");
   expect(prompt).toContain("Optional footer fields: `filesChanged`, `filesRead`, `verification`, `residualRisks`.");
   expect(prompt).toContain("`status` must be one of `completed`, `blocked`, or `failed`.");
+}
+
+function expectCoordinatorRoleMappingGuidance(prompt: string) {
+  expect(prompt).toContain("spawnAgent with `role: \"explorer\"` for read-only discovery");
+  expect(prompt).toContain("use spawnAgent with `role: \"worker\"` for bounded implementation slices");
+  expect(prompt).toContain("use spawnAgent with `role: \"reviewer\"` for independent validation");
+  expect(prompt).toContain(
+    "Use role discipline: `explorer` for discovery, `worker` for implementation, and `reviewer` for verification."
+  );
 }
 
 const IMAGE_GUIDANCE_PROMPT_CONFIGS = [
@@ -290,6 +303,10 @@ describe("loadSystemPrompt", () => {
     const spawnAgentBody = extractSpawnAgentBody(prompt);
 
     expect(spawnAgentBody).toContain("Orchestration rules:");
+    expect(spawnAgentBody).toContain("Coordinator rules:");
+    expect(spawnAgentBody).toContain("Use multiple child agents in parallel when research tasks are independent.");
+    expect(spawnAgentBody).toContain("report only what was launched; do not predict their results.");
+    expect(spawnAgentBody).toContain("run an independent `reviewer` child for verification");
     expect(spawnAgentBody).toContain("Model override guidance:");
     expect(spawnAgentBody).toContain("Available model overrides for the current provider (OpenAI):");
     expect(spawnAgentBody).toContain("**GPT-5.4** (`gpt-5.4`)");
@@ -301,6 +318,20 @@ describe("loadSystemPrompt", () => {
     expect(spawnAgentBody).not.toContain("**explore**: Fast codebase exploration.");
     expect(spawnAgentBody).not.toContain("**general**: Full-capability agent for delegated tasks.");
     expect(prompt).not.toContain("moonshotai/Kimi-K2.5");
+  });
+
+  test("default prompt includes explicit explorer-worker-reviewer plan-mode mapping", async () => {
+    const config = makeConfig({
+      provider: "opencode-go",
+      model: "kimi-k2.5",
+      preferredChildModel: "kimi-k2.5",
+    });
+    const prompt = await loadSystemPrompt(config);
+
+    expectCoordinatorRoleMappingGuidance(prompt);
+    expect(prompt).toContain("After launching child agents, only report what was launched; do not report predicted results.");
+    expect(prompt).toContain("Reuse a child when follow-up work has high context overlap.");
+    expect(prompt).toContain("Keep at most one write-capable child per file area at a time");
   });
 
   test("does not list Baseten child models in the spawnAgent summary", async () => {


### PR DESCRIPTION
## Summary
- Add explicit coordinator rules to generated `spawnAgent` guidance, including parallel research, launch-only reporting, synthesis handoff, child reuse/respawn heuristics, reviewer validation, and write-collision avoidance.
- Tie plan-mode execution to explicit `explorer` (discovery), `worker` (implementation), and `reviewer` (verification) roles.
- Expand prompt tests to assert the new coordinator section and role-mapping guidance.

## Test plan
- [x] `bun test test/prompt.test.ts`


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes generated system/`spawnAgent` guidance and default sub-agent role selection logic, which can alter runtime agent orchestration behavior across providers.
> 
> **Overview**
> Strengthens parent→child orchestration guidance by adding an explicit **“Coordinator rules”** section to generated `spawnAgent` prompt text (parallel research, launch-only reporting, synthesis handoff, child reuse/respawn heuristics, verifier usage, and write-collision avoidance).
> 
> Updates plan-mode instructions in `prompts/system.md` to reference **dynamic available sub-agent types** and injects defaults for discovery/implementation/verification roles (selected from `AGENT_ROLE_DEFINITIONS`), surfacing them via new template variables.
> 
> Extends prompt tests to assert the new coordinator section content and the explicit explorer/worker/reviewer plan-mode role mapping is present in the rendered system prompt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e73dc24aece17303451135ffd817779b2116b39b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->