### PR TITLE
Trim cowork internals from static prompts

### DIFF
--- a/docs/workspace-context.md
+++ b/docs/workspace-context.md
@@ -1,0 +1,66 @@
+# Workspace Context
+
+This document explains the workspace terms that are rendered into runtime prompts.
+
+The short version: the static prompt should only describe layering at a high level. Exact absolute paths belong to the runtime-supplied `## Active Workspace Context` section.
+
+## Core Terms
+
+| Term | Meaning |
+| --- | --- |
+| `workspaceRoot` | The directory that contains the project `.agent/` directory. This is the anchor for project-level config, memory, and MCP overrides. |
+| `workingDirectory` | The execution working directory for the current turn. The runtime prompt labels this as `Execution working directory`, and file tools plus shell defaults use it. |
+| `gitRoot` | The nearest ancestor of `workingDirectory` that contains `.git`, when one exists. It may be the same as `workspaceRoot`, above it, or unrelated when the execution directory is outside the workspace tree. |
+
+`workingDirectory` is intentionally not the same thing as `workspaceRoot`. A session can run inside a subdirectory of the workspace, or even outside the workspace root, while still keeping project-level `.agent/` data anchored at `workspaceRoot`.
+
+## Runtime Source Of Truth
+
+`## Active Workspace Context` is the source of truth for the exact absolute paths in the current turn. It renders:
+
+- workspace root
+- execution working directory
+- optional git root
+- working-directory relation to the workspace root
+- optional output directory
+- effective uploads directory
+- project `.agent/` override root
+
+If a contributor needs to know which absolute path the model will see, check this runtime section and the code that renders it, not the static prompt template.
+
+## AGENTS.md Versus .agent/AGENT.md
+
+These names are similar, but they serve different systems.
+
+- `AGENTS.md` and `AGENTS.override.md` are hierarchical project instructions. They are loaded from the repository hierarchy and rendered into `## Project Instructions`.
+- `.agent/AGENT.md` is project hot-cache memory. It is loaded by the memory system and is separate from hierarchical project instructions.
+- `AGENTS.override.md` wins over `AGENTS.md` within the same directory.
+- Project and user `AGENT.md` files participate in memory fallback, not in AGENTS hierarchy traversal.
+
+In practice, a runtime prompt can include both project instructions and hot-cache memory, but they come from different loaders and should not be described interchangeably.
+
+## Workspace Map Is Bounded Context
+
+`## Workspace Map` is a bounded startup snapshot for orientation. It helps the model see the workspace root, execution directory, and git root without reading the whole tree up front.
+
+It is not the filesystem source of truth:
+
+- it is intentionally bounded and may omit files or directories
+- it reflects startup-time context, not every later filesystem change
+- it should not be used to infer exact absolute paths
+
+When exact path semantics matter, trust `## Active Workspace Context` plus normal file reads/searches over the workspace map.
+
+## Practical Guidance
+
+- Use `workspaceRoot` when reasoning about project-level `.agent/` overrides.
+- Use `workingDirectory` when reasoning about where tool calls execute by default.
+- Use `gitRoot` when reasoning about repository scope and AGENTS hierarchy traversal.
+- Keep static prompt wording high-level so runtime context, not baked-in Cowork internals, provides the exact path details.
+
+## Related Sources
+
+- [`src/workspace/context.ts`](../src/workspace/context.ts)
+- [`src/prompt.ts`](../src/prompt.ts)
+- [`src/projectInstructions.ts`](../src/projectInstructions.ts)
+- [`docs/harness/config.md`](./harness/config.md)

--- a/prompts/system-models/claude-sonnet-4-6.md
+++ b/prompts/system-models/claude-sonnet-4-6.md
@@ -14,21 +14,9 @@ You are a highly capable local AI agent specializing in software engineering, fi
 - Knowledge cutoff: {{knowledgeCutoff}} (search the web for anything that may have changed after this date)
 
 <directory_structure>
-Settings, memory, and MCP configs resolve in a three-tier hierarchy: **project → user → built-in**. Skills resolve in a four-tier hierarchy: **project → global (~/.cowork/skills) → user → built-in**. Project-level always wins.
+Configuration and memory can come from project, user, and built-in layers. Skills can also include shared/global layers in addition to project, user, and built-in sources.
 
-- **Project-level** (`.agent/` in the current working directory): Per-project overrides — project-specific skills, memory, config, and MCP servers.
-- **User-level** (`~/.agent/`): Personal defaults — skills, memory, config, and MCP servers.
-- **Global skills-level** (`~/.cowork/skills/`): Shared skills available across projects.
-- **Built-in** (shipped with the agent): Default skills (spreadsheet, slides, pdf, doc), default config, system prompt.
-
-Skills from all four skill tiers are merged (union). For config, MCP, and memory, project overrides user overrides built-in.
-
-Key paths:
-
-- Skills: `.agent/skills/`, `~/.cowork/skills/`, `~/.agent/skills/`, and built-in `skills/` are scanned in that order. For duplicate names, higher-priority tiers win.
-- Memory: `.agent/AGENT.md` (project hot cache) → `~/.agent/AGENT.md` (user hot cache). Deep storage in `.agent/memory/` and `~/.agent/memory/`.
-- MCP: `.agent/mcp-servers.json` merged with `~/.agent/mcp-servers.json`. Same-named servers: project wins.
-- Config: `.agent/config.json` merged over `~/.agent/config.json` over built-in defaults.
+Use the `## Active Workspace Context` section for the exact absolute paths supplied at runtime in this session.
 </directory_structure>
 
 <file_locations>
@@ -38,7 +26,7 @@ When referring to file locations in conversation, use natural language and don't
 
 If you don't have access to user files and the user asks to work with them, explain that you don't currently have access and offer to request it.
 
-Files the user uploads are available in the working directory ({{workingDirectory}}). Some file types (text, CSV, images, PDFs) may also be present directly in the conversation context as text or images. If the content is already in context, don't re-read it with the read tool unless you need to process it programmatically (e.g., convert an image, run analysis on a CSV).
+Files the user uploads are stored in the configured uploads directory, or `{{workingDirectory}}/User Uploads` when no uploads directory is configured. Some file types (text, CSV, images, PDFs) may also be present directly in the conversation context as text or images. If the content is already in context, don't re-read it with the read tool unless you need to process it programmatically (e.g., convert an image, run analysis on a CSV).
 </file_locations>
 </environment>
 
@@ -198,8 +186,7 @@ Load a skill to get specialized instructions before creating a specific type of 
 
 - Available skills are listed at the end of this prompt. Use the exact skill name as shown there (e.g., {{skillNames}}).
 - Multiple skills can be loaded for a single task.
-- Skills are discovered from four directory tiers (project → global → user → built-in) and merged. Global skills live in `~/.cowork/skills/`. If names collide, higher-priority tiers win.
-- User-created skills can be placed in `~/.cowork/skills/{name}/SKILL.md` (shared across projects), `~/.agent/skills/{name}/SKILL.md` (user-level), or `.agent/skills/{name}/SKILL.md` (project-only).
+- Skills can come from merged project, shared/global, user, and built-in layers. Treat the appended available-skills list as the source of truth for what can be loaded in this session.
 
 Examples of when to load a skill:
 {{skillExamples}}

--- a/prompts/system-models/gemini-3-flash-preview.md
+++ b/prompts/system-models/gemini-3-flash-preview.md
@@ -14,21 +14,9 @@ You are a direct, action-oriented AI assistant running locally on the user's com
 
 ## Directory Structure
 
-Settings, memory, and MCP configs resolve in a three-tier hierarchy: **project → user → built-in**. Skills resolve in a four-tier hierarchy: **project → global (~/.cowork/skills) → user → built-in**. Project-level always wins.
+Configuration and memory can come from project, user, and built-in layers. Skills can also include shared/global layers in addition to project, user, and built-in sources.
 
-- **Project-level** (`.agent/` in the current working directory): Per-project overrides — project-specific skills, memory, config, and MCP servers.
-- **User-level** (`~/.agent/`): Personal defaults — skills, memory, config, and MCP servers.
-- **Global skills-level** (`~/.cowork/skills/`): Shared skills available across projects.
-- **Built-in** (shipped with the agent): Default skills (spreadsheet, slides, pdf, doc), default config, system prompt.
-
-Skills from all four skill tiers are merged (union). For config, MCP, and memory, project overrides user overrides built-in.
-
-Key paths:
-
-- Skills: `.agent/skills/`, `~/.cowork/skills/`, `~/.agent/skills/`, and built-in `skills/` are scanned in that order. For duplicate names, higher-priority tiers win.
-- Memory: `.agent/AGENT.md` (project hot cache) → `~/.agent/AGENT.md` (user hot cache). Deep storage in `.agent/memory/` and `~/.agent/memory/`.
-- MCP: `.agent/mcp-servers.json` merged with `~/.agent/mcp-servers.json`. Same-named servers: project wins.
-- Config: `.agent/config.json` merged over `~/.agent/config.json` over built-in defaults.
+Use the `## Active Workspace Context` section for the exact absolute paths supplied at runtime in this session.
 
 # Core Behavior
 
@@ -221,11 +209,9 @@ Skills are markdown files (SKILL.md) with domain-specific best practices for pro
 Examples of when to load a skill:
 {{skillExamples}}
 
-Multiple skills may be relevant for a single task. Skills are discovered from four tiers (project → global → user → built-in) and merged. If names collide, higher-priority tiers win.
+Multiple skills may be relevant for a single task. Skills can come from merged project, shared/global, user, and built-in layers.
 
-Available skills are listed at the end of this prompt. Use the `skill` tool to load them by name.
-
-User-created skills: `~/.cowork/skills/{name}/SKILL.md` (shared), `~/.agent/skills/{name}/SKILL.md` (user-level), or `.agent/skills/{name}/SKILL.md` (project-only).
+Available skills are listed at the end of this prompt. Treat that list as the source of truth for this session and use the `skill` tool to load skills by the exact names shown there.
 
 # Best Practices
 
@@ -281,7 +267,7 @@ Use natural language for file locations in conversation and don't expose interna
 
 ## User-Uploaded Files
 
-Available in the working directory ({{workingDirectory}}). If content is already in context, don't re-read unless you need programmatic processing.
+Stored in the configured uploads directory, or `{{workingDirectory}}/User Uploads` when no uploads directory is configured. If content is already in context, don't re-read unless you need programmatic processing.
 
 ## Creating Outputs
 

--- a/prompts/system-models/gemini-3.1-pro-preview.md
+++ b/prompts/system-models/gemini-3.1-pro-preview.md
@@ -18,20 +18,9 @@ This model's reasoning is optimized for temperature 1.0. Do not adjust temperatu
 - Knowledge cutoff: {{knowledgeCutoff}} (search the web for anything that may have changed after this date)
 
 <directory_structure>
-Settings, memory, and MCP configs resolve in a three-tier hierarchy: **project → user → built-in**. Skills resolve in a four-tier hierarchy: **project → global (~/.cowork/skills) → user → built-in**. Project-level always wins.
+Configuration and memory can come from project, user, and built-in layers. Skills can also include shared/global layers in addition to project, user, and built-in sources.
 
-- **Project-level** (`.agent/` in the current working directory): Per-project overrides — project-specific skills, memory, config, and MCP servers.
-- **User-level** (`~/.agent/`): Personal defaults — skills, memory, config, and MCP servers.
-- **Global skills-level** (`~/.cowork/skills/`): Shared skills available across projects.
-- **Built-in** (shipped with the agent): Default skills (spreadsheet, slides, pdf, doc), default config, system prompt.
-
-Skills from all four skill tiers are merged (union). For config, MCP, and memory, project overrides user overrides built-in.
-
-Key paths:
-- Skills: `.agent/skills/`, `~/.cowork/skills/`, `~/.agent/skills/`, and built-in `skills/` are scanned in that order. For duplicate names, higher-priority tiers win.
-- Memory: `.agent/AGENT.md` (project hot cache) → `~/.agent/AGENT.md` (user hot cache). Deep storage in `.agent/memory/` and `~/.agent/memory/`.
-- MCP: `.agent/mcp-servers.json` merged with `~/.agent/mcp-servers.json`. Same-named servers: project wins.
-- Config: `.agent/config.json` merged over `~/.agent/config.json` over built-in defaults.
+Use the `## Active Workspace Context` section for the exact absolute paths supplied at runtime in this session.
 </directory_structure>
 </environment>
 
@@ -372,11 +361,9 @@ Multiple skills may be relevant. Don't limit yourself to just one. For instance,
 </loading_skills>
 
 <skill_locations>
-Skills are discovered from four directory tiers (project → global → user → built-in) and merged. Global skills live in `~/.cowork/skills/`. If names collide, higher-priority tiers win.
+Skills can come from merged project, shared/global, user, and built-in layers.
 
-Available skills are listed at the end of this prompt (appended at startup). Use the `skill` tool to load them by name before starting work.
-
-User-created skills can be placed in `~/.cowork/skills/{name}/SKILL.md` (shared across projects), `~/.agent/skills/{name}/SKILL.md` (user-level), or `.agent/skills/{name}/SKILL.md` (project-only).
+The appended skills catalog is the source of truth for what can be loaded in this session. Use the `skill` tool to load skills by the exact names listed there.
 </skill_locations>
 
 </skills_and_templates>
@@ -484,7 +471,7 @@ If you don't have access to user files and the user asks to work with them, expl
 </file_locations>
 
 <uploaded_files>
-Files the user uploads are available in the working directory ({{workingDirectory}}). Some file types (text, CSV, images, PDFs) may also be present directly in the conversation context as text or images.
+Files the user uploads are stored in the configured uploads directory, or `{{workingDirectory}}/User Uploads` when no uploads directory is configured. Some file types (text, CSV, images, PDFs) may also be present directly in the conversation context as text or images.
 
 If the content is already in context, don't re-read it with the read tool unless you need to process it programmatically (e.g., convert an image, run analysis on a CSV). For instance: if the user uploads an image of text and asks you to transcribe it, just transcribe from what you see — no need to use the read tool.
 </uploaded_files>

--- a/prompts/system-models/gpt-5.2.md
+++ b/prompts/system-models/gpt-5.2.md
@@ -24,21 +24,9 @@ You follow instructions more literally than previous GPT models. This is a stren
 
 ## Directory Structure
 
-Settings, memory, and MCP configs resolve in a three-tier hierarchy: **project → user → built-in**. Skills resolve in a four-tier hierarchy: **project → global (~/.cowork/skills) → user → built-in**. Project-level always wins.
+Configuration and memory can come from project, user, and built-in layers. Skills can also include shared/global layers in addition to project, user, and built-in sources.
 
-- **Project-level** (`.agent/` in the current working directory): Per-project overrides — project-specific skills, memory, config, and MCP servers.
-- **User-level** (`~/.agent/`): Personal defaults — skills, memory, config, and MCP servers.
-- **Global skills-level** (`~/.cowork/skills/`): Shared skills available across projects.
-- **Built-in** (shipped with the agent): Default skills (spreadsheet, slides, pdf, doc), default config, system prompt.
-
-Skills from all four skill tiers are merged (union). For config, MCP, and memory, project overrides user overrides built-in.
-
-Key paths:
-
-- Skills: `.agent/skills/`, `~/.cowork/skills/`, `~/.agent/skills/`, and built-in `skills/` are scanned in that order. For duplicate names, higher-priority tiers win.
-- Memory: `.agent/AGENT.md` (project hot cache) → `~/.agent/AGENT.md` (user hot cache). Deep storage in `.agent/memory/` and `~/.agent/memory/`.
-- MCP: `.agent/mcp-servers.json` merged with `~/.agent/mcp-servers.json`. Same-named servers: project wins.
-- Config: `.agent/config.json` merged over `~/.agent/config.json` over built-in defaults.
+Use the `## Active Workspace Context` section for the exact absolute paths supplied at runtime in this session.
 
 ## File Locations
 
@@ -50,7 +38,7 @@ If you don't have access to user files and the user asks to work with them, expl
 
 ## User-Uploaded Files
 
-Files the user uploads are available in the working directory ({{workingDirectory}}). Some file types (text, CSV, images, PDFs) may also be present directly in the conversation context as text or images.
+Files the user uploads are stored in the configured uploads directory, or `{{workingDirectory}}/User Uploads` when no uploads directory is configured. Some file types (text, CSV, images, PDFs) may also be present directly in the conversation context as text or images.
 
 If the content is already in context, don't re-read it with the read tool unless you need to process it programmatically (e.g., convert an image, run analysis on a CSV). For instance: if the user uploads an image of text and asks you to transcribe it, just transcribe from what you see — no need to use the read tool.
 </environment>
@@ -512,11 +500,9 @@ Multiple skills may be relevant. Don't limit yourself to just one. For instance,
 
 ## Skill Locations
 
-Skills are discovered from four directory tiers (project → global → user → built-in) and merged. Global skills live in `~/.cowork/skills/`. If names collide, higher-priority tiers win.
+Skills can come from merged project, shared/global, user, and built-in layers.
 
-Available skills are listed at the end of this prompt (appended at startup). Use the `skill` tool to load them by name before starting work.
-
-User-created skills can be placed in `~/.cowork/skills/{name}/SKILL.md` (shared across projects), `~/.agent/skills/{name}/SKILL.md` (user-level), or `.agent/skills/{name}/SKILL.md` (project-only).
+The appended skills catalog is the source of truth for what can be loaded in this session. Use the `skill` tool to load skills by the exact names listed there.
 
 # Communication — Best Practices
 

--- a/prompts/system.md
+++ b/prompts/system.md
@@ -14,20 +14,9 @@ You are an AI assistant running locally on the user's computer. You have direct 
 
 ## Directory Structure
 
-Settings, memory, and MCP configs resolve in a three-tier hierarchy: **project → user → built-in**. Skills resolve in a four-tier hierarchy: **project → global (~/.cowork/skills) → user → built-in**. Project-level always wins.
+Configuration and memory can come from project, user, and built-in layers. Skills can also include shared/global layers in addition to project, user, and built-in sources.
 
-- **Project-level** (`.agent/` in the current working directory): Per-project overrides — project-specific skills, memory, config, and MCP servers.
-- **Global skills-level** (`~/.cowork/skills/`): Shared skills available across projects.
-- **User-level** (`~/.agent/`): Your global defaults — personal skills, contacts, preferences, API keys, global MCP servers.
-- **Built-in** (shipped with the agent): Default skills (spreadsheet, slides, pdf, doc), default config, system prompt.
-
-Skills from all four tiers are merged (union). For config, MCP, and memory, project overrides user overrides built-in.
-
-Key paths:
-- Skills: `.agent/skills/`, `~/.cowork/skills/`, `~/.agent/skills/`, and built-in `skills/` are all scanned in that order. For duplicate names, higher-priority tiers win.
-- Memory: `.agent/AGENT.md` (project hot cache) → `~/.agent/AGENT.md` (user hot cache). Deep storage in `.agent/memory/` and `~/.agent/memory/`.
-- MCP: `.agent/mcp-servers.json` merged with `~/.agent/mcp-servers.json`. Same-named servers: project wins.
-- Config: `.agent/config.json` merged over `~/.agent/config.json` over built-in defaults.
+Use the `## Active Workspace Context` section for the exact absolute paths supplied at runtime in this session.
 
 # Core Behavior
 
@@ -313,11 +302,9 @@ Multiple skills may be relevant. Don't limit yourself to just one. For instance,
 
 ## Skill Locations
 
-Skills are discovered from four directory tiers (project → global → user → built-in) and merged. Global skills live in `~/.cowork/skills/`. If names collide, higher-priority tiers win.
+Skills can come from merged project, shared/global, user, and built-in layers.
 
-Available skills are listed at the end of this prompt (appended at startup). Use the `skill` tool to load them by name before starting work.
-
-User-created skills can be placed in `~/.cowork/skills/{name}/SKILL.md` (shared across projects), `~/.agent/skills/{name}/SKILL.md` (user-level), or `.agent/skills/{name}/SKILL.md` (project-only).
+The appended skills catalog is the source of truth for what can be loaded in this session. Use the `skill` tool to load skills by the exact names listed there.
 
 # Detailed Guidelines
 
@@ -542,7 +529,7 @@ If you don't have access to user files and the user asks to work with them, expl
 
 ## User-Uploaded Files
 
-Files the user uploads are available in the working directory ({{workingDirectory}}). Some file types (text, CSV, images, PDFs) may also be present directly in the conversation context as text or images.
+Files the user uploads are stored in the configured uploads directory, or `{{workingDirectory}}/User Uploads` when no uploads directory is configured. Some file types (text, CSV, images, PDFs) may also be present directly in the conversation context as text or images.
 
 If the content is already in context, don't re-read it with the read tool unless you need to process it programmatically (e.g., convert an image, run analysis on a CSV). For instance: if the user uploads an image of text and asks you to transcribe it, just transcribe from what you see — no need to use the read tool.
 

--- a/test/prompt.test.ts
+++ b/test/prompt.test.ts
@@ -247,10 +247,11 @@ describe("loadSystemPrompt", () => {
     expect(prompt).not.toContain("/my/custom/output/dir");
   });
 
-  test("uploadsDirectory no longer appears in prompt (uploads go to workingDirectory)", async () => {
+  test("static prompt keeps uploads guidance generic instead of interpolating uploadsDirectory", async () => {
     const config = makeConfig({ uploadsDirectory: "/my/custom/uploads/dir" });
     const prompt = await loadSystemPrompt(config);
-    // uploadsDirectory is no longer referenced in the prompt template
+    expect(prompt).toContain("configured uploads directory");
+    expect(prompt).toContain("/test/working/User Uploads");
     expect(prompt).not.toContain("{{uploadsDirectory}}");
     expect(prompt).not.toContain("/my/custom/uploads/dir");
   });


### PR DESCRIPTION
## Summary
- trim the static system prompts so they stop spending tokens on Cowork-specific directory layout details
- point models at the runtime `## Active Workspace Context` section for exact absolute paths and align upload wording with actual uploads-directory behavior
- add contributor docs for `workspaceRoot`, `workingDirectory`, `gitRoot`, `AGENTS.md` vs `.agent/AGENT.md`, and rename the prompt test that encoded the old uploads assumption

## Test plan
- [x] `bun test test/prompt.test.ts`
- [x] `bun test test/agent.test.ts --filter buildTurnSystemPrompt`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Edits are limited to prompt/docs text and a corresponding unit test; no runtime logic changes, so risk is low aside from potential prompt-behavior regressions if wording changes affect model behavior.
> 
> **Overview**
> Static system prompt templates are simplified to remove detailed Cowork-specific directory/override path descriptions, and instead direct models to rely on the runtime `## Active Workspace Context` for exact absolute paths.
> 
> Upload guidance in prompts is updated to reflect that uploads live in the configured uploads directory (or `{{workingDirectory}}/User Uploads` by default) without interpolating a configured `uploadsDirectory` into the static prompt.
> 
> Adds new contributor documentation in `docs/workspace-context.md` defining `workspaceRoot`/`workingDirectory`/`gitRoot` and clarifying `AGENTS.md` vs `.agent/AGENT.md`, and updates the prompt test expectation accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7d1991f4d59c22f6cb944e1f385dd3c5a775ea9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->