### PR TITLE
feat(desktop): persistent settings shell and test fixes

### DIFF
--- a/apps/desktop/src/components/ui/checkbox.tsx
+++ b/apps/desktop/src/components/ui/checkbox.tsx
@@ -17,11 +17,13 @@ function Checkbox({ className, checked, disabled, onCheckedChange, ...props }: C
       data-slot="checkbox"
       className={cn(
         "inline-flex items-center justify-center",
-        "[&_[data-slot=checkbox-control]]:size-4 [&_[data-slot=checkbox-control]]:shrink-0 [&_[data-slot=checkbox-control]]:rounded-[4px]",
-        "[&_[data-slot=checkbox-control]]:border [&_[data-slot=checkbox-control]]:border-border [&_[data-slot=checkbox-control]]:shadow-[var(--shadow-surface)]",
+        "[&_[data-slot=checkbox-control]]:size-[18px] [&_[data-slot=checkbox-control]]:shrink-0 [&_[data-slot=checkbox-control]]:rounded-[5px]",
+        "[&_[data-slot=checkbox-control]]:border [&_[data-slot=checkbox-control]]:border-border [&_[data-slot=checkbox-control]]:bg-foreground/[0.06]",
+        "[&_[data-slot=checkbox-control]]:shadow-[var(--shadow-surface)]",
         "[&_[data-slot=checkbox-control]]:transition-colors [&_[data-slot=checkbox-control]]:duration-150",
         "[&_[data-slot=checkbox-control]]:data-[selected=true]:border-primary [&_[data-slot=checkbox-control]]:data-[selected=true]:bg-primary",
-        "[&_[data-slot=checkbox-control]]:text-primary-foreground",
+        "[&_[data-slot=checkbox-control]]:data-[selected=false]:text-transparent",
+        "[&_[data-slot=checkbox-control]]:data-[selected=true]:text-primary-foreground",
         "[&_[data-slot=checkbox-control]]:outline-none [&_[data-slot=checkbox-control]]:focus-visible:ring-2 [&_[data-slot=checkbox-control]]:focus-visible:ring-primary",
         "[&_[data-slot=checkbox-indicator]]:flex [&_[data-slot=checkbox-indicator]]:items-center [&_[data-slot=checkbox-indicator]]:justify-center",
         "disabled:cursor-not-allowed disabled:opacity-50",

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -288,6 +288,11 @@ body {
   }
 }
 
+.settings-shell__page-header {
+  background: var(--surface-settings-main);
+  box-shadow: 0 1px 0 var(--border-subtle);
+}
+
 .settings-shell__content {
   min-height: 100%;
 }

--- a/apps/desktop/src/styles/platform/darwin.css
+++ b/apps/desktop/src/styles/platform/darwin.css
@@ -49,6 +49,11 @@
   margin-top: 0;
 }
 
+:root[data-platform="darwin"] .settings-shell__main {
+  position: relative;
+  z-index: 81;
+}
+
 :root[data-platform="darwin"] .settings-shell__drag-zone {
   position: absolute;
   top: 0;

--- a/apps/desktop/src/styles/platform/linux.css
+++ b/apps/desktop/src/styles/platform/linux.css
@@ -20,11 +20,20 @@
 }
 
 :root[data-platform="linux"] .settings-shell__nav {
-  padding-top: 2.75rem;
+  padding-top: 3rem;
 }
 
 :root[data-platform="linux"] .settings-shell__back-button {
   margin-top: 0;
+}
+
+:root[data-platform="linux"] .settings-shell__header-actions {
+  padding-right: 8.5rem;
+}
+
+:root[data-platform="linux"] .settings-shell__main {
+  position: relative;
+  z-index: 81;
 }
 
 :root[data-platform="linux"] .settings-shell__drag-zone {
@@ -32,7 +41,7 @@
   top: 0;
   left: 0;
   right: 0;
-  height: 2.75rem;
+  height: 3rem;
   z-index: 80;
   -webkit-app-region: drag;
 }

--- a/apps/desktop/src/styles/platform/win32.css
+++ b/apps/desktop/src/styles/platform/win32.css
@@ -154,6 +154,10 @@
   z-index: 81;
 }
 
+:root[data-platform="win32"] .settings-shell__header-actions {
+  padding-right: 8.5rem;
+}
+
 :root[data-platform="win32"] .settings-shell__drag-zone {
   position: absolute;
   top: 0;

--- a/apps/desktop/src/ui/settings/SettingsChromeContext.tsx
+++ b/apps/desktop/src/ui/settings/SettingsChromeContext.tsx
@@ -1,0 +1,44 @@
+import { createContext, useCallback, useContext, useMemo, type ReactNode } from "react";
+
+export type SettingsChromeState = {
+  /** Optional row on the right side of the sticky settings header (actions, secondary controls). */
+  headerActions?: ReactNode;
+};
+
+type SettingsChromeApi = {
+  setChrome: (patch: Partial<SettingsChromeState> | null) => void;
+};
+
+const SettingsChromeContext = createContext<SettingsChromeApi | null>(null);
+
+export function SettingsChromeProvider({
+  children,
+  onChromeChange,
+}: {
+  children: ReactNode;
+  onChromeChange: (chrome: SettingsChromeState) => void;
+}) {
+  const setChrome = useCallback(
+    (patch: Partial<SettingsChromeState> | null) => {
+      onChromeChange(patch ?? {});
+    },
+    [onChromeChange],
+  );
+
+  const value = useMemo(() => ({ setChrome }), [setChrome]);
+
+  return <SettingsChromeContext.Provider value={value}>{children}</SettingsChromeContext.Provider>;
+}
+
+export function useSettingsChrome(): SettingsChromeApi {
+  const ctx = useContext(SettingsChromeContext);
+  if (!ctx) {
+    throw new Error("useSettingsChrome must be used within SettingsChromeProvider");
+  }
+  return ctx;
+}
+
+/** Safe when the provider is absent (e.g. isolated tests rendering a page alone). */
+export function useOptionalSettingsChrome(): SettingsChromeApi | null {
+  return useContext(SettingsChromeContext);
+}

--- a/apps/desktop/src/ui/settings/SettingsShell.tsx
+++ b/apps/desktop/src/ui/settings/SettingsShell.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useState, type ReactNode } from "react";
 
-import { ArrowLeftIcon } from "lucide-react";
+import { ArrowLeftIcon, XIcon } from "lucide-react";
 
 import { useAppStore } from "../../app/store";
 import { Button } from "../../components/ui/button";
@@ -231,11 +231,19 @@ export function SettingsShell() {
                     {meta.description}
                   </p>
                 </div>
-                {pageChrome.headerActions ? (
-                  <div className="flex shrink-0 flex-wrap items-center justify-end gap-2 sm:pt-0.5">
-                    {pageChrome.headerActions}
-                  </div>
-                ) : null}
+                <div className="settings-shell__header-actions flex shrink-0 flex-wrap items-center justify-end gap-2 sm:pt-0.5">
+                  {pageChrome.headerActions}
+                  <Button
+                    variant="ghost"
+                    size="icon-sm"
+                    type="button"
+                    className="text-muted-foreground hover:text-foreground"
+                    onClick={closeSettings}
+                    title="Close settings"
+                  >
+                    <XIcon data-icon />
+                  </Button>
+                </div>
               </div>
             </header>
 

--- a/apps/desktop/src/ui/settings/SettingsShell.tsx
+++ b/apps/desktop/src/ui/settings/SettingsShell.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { useCallback, useState, type ReactNode } from "react";
 
 import { ArrowLeftIcon } from "lucide-react";
 
@@ -16,11 +16,54 @@ import { UpdatesPage } from "./pages/UpdatesPage";
 import { DeveloperPage } from "./pages/DeveloperPage";
 import { MemoryPage } from "./pages/MemoryPage";
 import { RemoteAccessPage } from "./pages/RemoteAccessPage";
+import { SettingsChromeProvider, type SettingsChromeState } from "./SettingsChromeContext";
 
 type SettingsPageDefinition = {
   id: SettingsPageId;
   label: string;
   render: () => ReactNode;
+};
+
+const SETTINGS_PAGE_META: Record<
+  SettingsPageId,
+  { title: string; description: string }
+> = {
+  providers: {
+    title: "Providers",
+    description: "Connect models and see whether each provider is ready to use.",
+  },
+  mcp: {
+    title: "MCP servers",
+    description: "Add tools and services the agent can call from this workspace.",
+  },
+  workspaces: {
+    title: "Workspace",
+    description: "Defaults for models, tools, and behavior in this project.",
+  },
+  memory: {
+    title: "Memory",
+    description: "What Cowork remembers about you and this workspace.",
+  },
+  remoteAccess: {
+    title: "Remote access",
+    description: "Pair a phone to this workspace over the relay when the app is open.",
+  },
+  backup: {
+    title: "Backups",
+    description: "Recovery snapshots and restore points for chat sessions.",
+  },
+  usage: {
+    title: "Usage",
+    description: "Token usage and estimated cost across sessions.",
+  },
+  developer: {
+    title: "Developer",
+    description: "Debug visibility and advanced workspace options.",
+  },
+  updates: {
+    title: "Updates",
+    description: "App version and restart-based updates.",
+  },
 };
 
 export function getSettingsGroups(remoteAccessAvailable: boolean): Array<{
@@ -29,10 +72,10 @@ export function getSettingsGroups(remoteAccessAvailable: boolean): Array<{
 }> {
   return [
     {
-      label: "Models & Tools",
+      label: "Models & tools",
       pages: [
         { id: "providers", label: "Providers", render: () => <ProvidersPage /> },
-        { id: "mcp", label: "Integrations", render: () => <McpServersPage /> },
+        { id: "mcp", label: "MCP servers", render: () => <McpServersPage /> },
       ],
     },
     {
@@ -41,14 +84,14 @@ export function getSettingsGroups(remoteAccessAvailable: boolean): Array<{
         { id: "workspaces", label: "General", render: () => <WorkspacesPage /> },
         { id: "memory", label: "Memory", render: () => <MemoryPage /> },
         ...(remoteAccessAvailable
-          ? [{ id: "remoteAccess", label: "Remote Access", render: () => <RemoteAccessPage /> } satisfies SettingsPageDefinition]
+          ? [{ id: "remoteAccess", label: "Remote access", render: () => <RemoteAccessPage /> } satisfies SettingsPageDefinition]
           : []),
       ],
     },
     {
-      label: "Recovery & Data",
+      label: "Data",
       pages: [
-        { id: "backup", label: "Backup", render: () => <BackupPage /> },
+        { id: "backup", label: "Backups", render: () => <BackupPage /> },
         { id: "usage", label: "Usage", render: () => <UsagePage /> },
       ],
     },
@@ -80,51 +123,56 @@ function SettingsNavigation({
   const perWorkspaceSettings = useAppStore((s) => s.perWorkspaceSettings);
 
   return (
-    <aside className="settings-shell__nav app-left-sidebar-pane flex min-h-0 flex-col border-r border-border/60 bg-gradient-to-b from-muted/12 to-muted/[0.04] max-[960px]:border-r-0 max-[960px]:border-b max-[960px]:bg-gradient-to-r max-[960px]:from-muted/10 max-[960px]:to-transparent">
-      <div className="border-b border-border/70 px-3 py-3 flex flex-col gap-2">
+    <aside className="settings-shell__nav app-left-sidebar-pane flex min-h-0 min-w-0 flex-col border-r border-border/50 bg-muted/20 max-[960px]:border-r-0 max-[960px]:border-b">
+      <div className="shrink-0 border-b border-border/50 px-3 py-3">
         <Button
-          className="settings-shell__back-button sidebar-lift h-9 w-full justify-start rounded-lg border border-border/70 bg-foreground/[0.03] px-3 text-[13px] font-medium text-foreground/86 hover:bg-foreground/[0.05] hover:text-foreground"
+          className="settings-shell__back-button h-9 w-full justify-start rounded-md px-2.5 text-[13px] font-medium"
           variant="ghost"
           type="button"
           onClick={onBack}
         >
-          <ArrowLeftIcon className="h-4 w-4 mr-2" />
-          Back to app
+          <ArrowLeftIcon className="mr-2 h-4 w-4 shrink-0 opacity-70" />
+          Back
         </Button>
         {perWorkspaceSettings && currentWorkspace && (
-          <div className="mt-1 px-1 text-xs font-medium text-muted-foreground truncate">
+          <div className="mt-2 truncate px-1 text-[11px] text-muted-foreground" title={currentWorkspace.name}>
             {currentWorkspace.name}
           </div>
         )}
       </div>
 
-      <div className="flex-1 overflow-y-auto px-3 py-3.5 pb-4 flex flex-col gap-5 max-[960px]:flex-row max-[960px]:flex-wrap">
-        {settingsGroups.map((group) => (
-          <div key={group.label} className="flex flex-col gap-1">
-            <h4 className="mb-1.5 px-2 text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground/80">
-              {group.label}
-            </h4>
-            <div className="flex flex-col gap-0.5">
-              {group.pages.map((page) => (
-                <Button
-                  key={page.id}
-                  variant="ghost"
-                  className={cn(
-                    "settings-shell__nav-button sidebar-lift h-8 justify-start rounded-lg px-2.5 text-[13px] font-medium tracking-[-0.015em]",
-                    activePage === page.id
-                      ? "bg-foreground/[0.07] text-foreground shadow-sm ring-1 ring-border/45"
-                      : "text-muted-foreground hover:bg-foreground/[0.045] hover:text-foreground",
-                  )}
-                  type="button"
-                  onClick={() => onSelectPage(page.id)}
-                >
-                  {page.label}
-                </Button>
-              ))}
+      <nav
+        className="min-h-0 flex-1 overflow-y-auto px-2 py-3 pb-4"
+        aria-label="Settings sections"
+      >
+        <div className="flex flex-col gap-4 max-[960px]:flex-row max-[960px]:flex-wrap max-[960px]:gap-x-4 max-[960px]:gap-y-3">
+          {settingsGroups.map((group) => (
+            <div key={group.label} className="flex min-w-0 flex-col gap-0.5">
+              <div className="mb-1 px-2 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/90">
+                {group.label}
+              </div>
+              <div className="flex flex-col gap-0.5">
+                {group.pages.map((page) => (
+                  <Button
+                    key={page.id}
+                    variant="ghost"
+                    className={cn(
+                      "settings-shell__nav-button h-8 justify-start rounded-md px-2 text-[13px] font-normal",
+                      activePage === page.id
+                        ? "bg-foreground/[0.06] font-medium text-foreground"
+                        : "text-muted-foreground hover:bg-foreground/[0.04] hover:text-foreground",
+                    )}
+                    type="button"
+                    onClick={() => onSelectPage(page.id)}
+                  >
+                    {page.label}
+                  </Button>
+                ))}
+              </div>
             </div>
-          </div>
-        ))}
-      </div>
+          ))}
+        </div>
+      </nav>
     </aside>
   );
 }
@@ -138,10 +186,18 @@ export function SettingsShell() {
   const settingsGroups = getSettingsGroups(remoteAccessAvailable);
   const settingsPages = settingsGroups.flatMap((group) => group.pages);
   const activePage = settingsPages.find((page) => page.id === settingsPage) ?? settingsPages[0];
+  const meta = SETTINGS_PAGE_META[activePage.id];
+
+  const [pageChrome, setPageChromeState] = useState<SettingsChromeState>({});
+  const handleChromeChange = useCallback((next: SettingsChromeState) => {
+    setPageChromeState(next);
+  }, []);
+
+  const isBackupPage = activePage.id === "backup";
 
   return (
     <div
-      className="settings-shell relative grid h-full min-h-0 min-w-0 bg-transparent"
+      className="settings-shell relative grid h-full min-h-0 min-w-0 bg-background"
       style={{ gridTemplateColumns: `${sidebarWidth}px minmax(0, 1fr)` }}
     >
       <div className="settings-shell__drag-zone" aria-hidden="true" />
@@ -152,20 +208,64 @@ export function SettingsShell() {
         settingsGroups={settingsGroups}
       />
 
-      <main className="settings-shell__main app-main-content min-h-0 overflow-auto">
-        <div
-          className={cn(
-            "settings-shell__content w-full",
-            // Narrow: even padding. Wide: flush to the nav divider on the left; keep right/top/bottom inset.
-            activePage.id === "backup"
-              ? "h-full p-0"
-              : "max-[960px]:p-4 min-[961px]:pl-3 min-[961px]:py-5 min-[961px]:pr-5 lg:py-6 lg:pr-6",
-          )}
-        >
-          <div key={activePage.id} className="animate-in fade-in slide-in-from-bottom-2 duration-200 ease-out h-full">
-            {activePage.render()}
+      <main className="settings-shell__main app-main-content flex min-h-0 min-w-0 flex-col">
+        <SettingsChromeProvider onChromeChange={handleChromeChange}>
+          <div
+            className={cn(
+              "flex min-h-0 min-w-0 flex-1 flex-col",
+              isBackupPage ? "overflow-hidden" : "",
+            )}
+          >
+            <header
+              className={cn(
+                "settings-shell__page-header shrink-0 border-b border-border/50 bg-background/95 px-5 py-4 backdrop-blur-sm max-[960px]:px-4",
+                isBackupPage ? "" : "sticky top-0 z-10",
+              )}
+            >
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                <div className="min-w-0 space-y-1">
+                  <h1 className="text-xl font-semibold tracking-tight text-foreground">
+                    {meta.title}
+                  </h1>
+                  <p className="max-w-xl text-sm leading-relaxed text-muted-foreground">
+                    {meta.description}
+                  </p>
+                </div>
+                {pageChrome.headerActions ? (
+                  <div className="flex shrink-0 flex-wrap items-center justify-end gap-2 sm:pt-0.5">
+                    {pageChrome.headerActions}
+                  </div>
+                ) : null}
+              </div>
+            </header>
+
+            <div
+              className={cn(
+                "settings-shell__scroll min-h-0 min-w-0 flex-1",
+                isBackupPage ? "flex min-h-0 flex-col overflow-hidden" : "overflow-y-auto",
+              )}
+            >
+              <div
+                className={cn(
+                  "settings-shell__content w-full",
+                  isBackupPage
+                    ? "flex min-h-0 flex-1 flex-col p-0"
+                    : "max-[960px]:p-4 min-[961px]:px-5 min-[961px]:pb-6 min-[961px]:pt-4",
+                )}
+              >
+                <div
+                  key={activePage.id}
+                  className={cn(
+                    "animate-in fade-in duration-150",
+                    isBackupPage ? "flex min-h-0 flex-1 flex-col" : "",
+                  )}
+                >
+                  {activePage.render()}
+                </div>
+              </div>
+            </div>
           </div>
-        </div>
+        </SettingsChromeProvider>
       </main>
     </div>
   );

--- a/apps/desktop/src/ui/settings/SettingsShell.tsx
+++ b/apps/desktop/src/ui/settings/SettingsShell.tsx
@@ -142,31 +142,30 @@ function SettingsNavigation({
       </div>
 
       <nav
-        className="min-h-0 flex-1 overflow-y-auto px-2 py-3 pb-4"
+        className="min-h-0 flex-1 overflow-y-auto py-2 pb-4"
         aria-label="Settings sections"
       >
-        <div className="flex flex-col gap-4 max-[960px]:flex-row max-[960px]:flex-wrap max-[960px]:gap-x-4 max-[960px]:gap-y-3">
+        <div className="flex flex-col gap-3 max-[960px]:flex-row max-[960px]:flex-wrap max-[960px]:gap-x-4 max-[960px]:gap-y-3">
           {settingsGroups.map((group) => (
-            <div key={group.label} className="flex min-w-0 flex-col gap-0.5">
-              <div className="mb-1 px-2 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/90">
+            <div key={group.label} className="flex min-w-0 flex-col">
+              <div className="mb-0.5 px-4 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/80">
                 {group.label}
               </div>
-              <div className="flex flex-col gap-0.5">
+              <div className="flex flex-col">
                 {group.pages.map((page) => (
-                  <Button
+                  <button
                     key={page.id}
-                    variant="ghost"
                     className={cn(
-                      "settings-shell__nav-button h-8 justify-start rounded-md px-2 text-[13px] font-normal",
+                      "settings-shell__nav-button flex w-full items-center px-4 py-2 text-left text-[13px] transition-colors",
                       activePage === page.id
-                        ? "bg-foreground/[0.08] font-medium text-foreground ring-1 ring-border/40"
-                        : "text-muted-foreground hover:bg-foreground/[0.04] hover:text-foreground",
+                        ? "bg-foreground/[0.08] font-medium text-foreground"
+                        : "font-normal text-muted-foreground hover:bg-foreground/[0.05] hover:text-foreground",
                     )}
                     type="button"
                     onClick={() => onSelectPage(page.id)}
                   >
                     {page.label}
-                  </Button>
+                  </button>
                 ))}
               </div>
             </div>

--- a/apps/desktop/src/ui/settings/SettingsShell.tsx
+++ b/apps/desktop/src/ui/settings/SettingsShell.tsx
@@ -123,10 +123,10 @@ function SettingsNavigation({
   const perWorkspaceSettings = useAppStore((s) => s.perWorkspaceSettings);
 
   return (
-    <aside className="settings-shell__nav app-left-sidebar-pane flex min-h-0 min-w-0 flex-col border-r border-border/50 bg-muted/20 max-[960px]:border-r-0 max-[960px]:border-b">
+    <aside className="settings-shell__nav app-left-sidebar-pane flex min-h-0 min-w-0 flex-col border-r border-border/50 max-[960px]:border-r-0 max-[960px]:border-b">
       <div className="shrink-0 border-b border-border/50 px-3 py-3">
         <Button
-          className="settings-shell__back-button h-9 w-full justify-start rounded-md px-2.5 text-[13px] font-medium"
+          className="settings-shell__back-button h-9 w-full justify-start rounded-md border border-border/50 bg-foreground/[0.03] px-2.5 text-[13px] font-medium"
           variant="ghost"
           type="button"
           onClick={onBack}
@@ -159,7 +159,7 @@ function SettingsNavigation({
                     className={cn(
                       "settings-shell__nav-button h-8 justify-start rounded-md px-2 text-[13px] font-normal",
                       activePage === page.id
-                        ? "bg-foreground/[0.06] font-medium text-foreground"
+                        ? "bg-foreground/[0.08] font-medium text-foreground ring-1 ring-border/40"
                         : "text-muted-foreground hover:bg-foreground/[0.04] hover:text-foreground",
                     )}
                     type="button"
@@ -197,7 +197,7 @@ export function SettingsShell() {
 
   return (
     <div
-      className="settings-shell relative grid h-full min-h-0 min-w-0 bg-background"
+      className="settings-shell relative grid h-full min-h-0 min-w-0 bg-transparent"
       style={{ gridTemplateColumns: `${sidebarWidth}px minmax(0, 1fr)` }}
     >
       <div className="settings-shell__drag-zone" aria-hidden="true" />
@@ -218,7 +218,7 @@ export function SettingsShell() {
           >
             <header
               className={cn(
-                "settings-shell__page-header shrink-0 border-b border-border/50 bg-background/95 px-5 py-4 backdrop-blur-sm max-[960px]:px-4",
+                "settings-shell__page-header shrink-0 px-5 py-4 backdrop-blur-sm max-[960px]:px-4",
                 isBackupPage ? "" : "sticky top-0 z-10",
               )}
             >

--- a/apps/desktop/src/ui/settings/SettingsShell.tsx
+++ b/apps/desktop/src/ui/settings/SettingsShell.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useState, type ReactNode } from "react";
 
-import { ArrowLeftIcon, XIcon } from "lucide-react";
+import { ArrowLeftIcon } from "lucide-react";
 
 import { useAppStore } from "../../app/store";
 import { Button } from "../../components/ui/button";
@@ -231,19 +231,11 @@ export function SettingsShell() {
                     {meta.description}
                   </p>
                 </div>
-                <div className="settings-shell__header-actions flex shrink-0 flex-wrap items-center justify-end gap-2 sm:pt-0.5">
-                  {pageChrome.headerActions}
-                  <Button
-                    variant="ghost"
-                    size="icon-sm"
-                    type="button"
-                    className="text-muted-foreground hover:text-foreground"
-                    onClick={closeSettings}
-                    title="Close settings"
-                  >
-                    <XIcon data-icon />
-                  </Button>
-                </div>
+                {pageChrome.headerActions ? (
+                  <div className="settings-shell__header-actions flex shrink-0 flex-wrap items-center justify-end gap-2 sm:pt-0.5">
+                    {pageChrome.headerActions}
+                  </div>
+                ) : null}
               </div>
             </header>
 

--- a/apps/desktop/src/ui/settings/SettingsShell.tsx
+++ b/apps/desktop/src/ui/settings/SettingsShell.tsx
@@ -142,23 +142,23 @@ function SettingsNavigation({
       </div>
 
       <nav
-        className="min-h-0 flex-1 overflow-y-auto py-2 pb-4"
+        className="min-h-0 flex-1 overflow-y-auto px-2.5 py-2 pb-4"
         aria-label="Settings sections"
       >
         <div className="flex flex-col gap-3 max-[960px]:flex-row max-[960px]:flex-wrap max-[960px]:gap-x-4 max-[960px]:gap-y-3">
           {settingsGroups.map((group) => (
             <div key={group.label} className="flex min-w-0 flex-col">
-              <div className="mb-0.5 px-4 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/80">
+              <div className="mb-0.5 px-2 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/80">
                 {group.label}
               </div>
-              <div className="flex flex-col">
+              <div className="flex flex-col gap-0.5">
                 {group.pages.map((page) => (
                   <button
                     key={page.id}
                     className={cn(
-                      "settings-shell__nav-button flex w-full items-center px-4 py-2 text-left text-[13px] transition-colors",
+                      "settings-shell__nav-button flex w-full items-center rounded-lg px-3 py-2 text-left text-[13px] transition-colors",
                       activePage === page.id
-                        ? "bg-foreground/[0.08] font-medium text-foreground"
+                        ? "bg-foreground/[0.08] font-medium text-foreground ring-1 ring-border/40"
                         : "font-normal text-muted-foreground hover:bg-foreground/[0.05] hover:text-foreground",
                     )}
                     type="button"

--- a/apps/desktop/src/ui/settings/pages/BackupPage.tsx
+++ b/apps/desktop/src/ui/settings/pages/BackupPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useEffectEvent, useState } from "react";
+import { useEffect, useEffectEvent, useMemo, useState } from "react";
 
 import {
   AlertTriangleIcon,
@@ -35,6 +35,7 @@ import {
 import { confirmAction, revealPath } from "../../../lib/desktopCommands";
 import { cn } from "../../../lib/utils";
 import { workspaceBackupActionKey } from "../../../app/store.helpers/backupActionKey";
+import { useOptionalSettingsChrome } from "../SettingsChromeContext";
 
 type BackupPageProps = {
   workspace?: WorkspaceRecord | null;
@@ -575,23 +576,6 @@ export function BackupPage(props: BackupPageProps = {}) {
     requestSelectedDelta();
   }, [workspace?.id, runtime?.controlSessionId, activeTargetSessionId, selectedCheckpointId]);
 
-  if (!workspace) {
-    return (
-      <div className="space-y-5 px-6 py-6 max-[960px]:px-4 max-[960px]:py-4">
-        <div className="space-y-2">
-          <h1 className="text-3xl font-semibold tracking-tight text-foreground">Workspace Backups</h1>
-          <p className="text-sm text-muted-foreground">Manage backup history and restore points for your workspaces.</p>
-        </div>
-        <Card className="border-border/80 bg-card/85">
-          <CardContent className="p-8 text-center">
-            <ArchiveIcon className="h-12 w-12 mx-auto mb-4 text-muted-foreground/30" />
-            <p className="text-muted-foreground">Select a workspace first to manage its backup history.</p>
-          </CardContent>
-        </Card>
-      </div>
-    );
-  }
-
   const pendingActions = runtime?.workspaceBackupPendingActionKeys ?? {};
   const loading = runtime?.workspaceBackupsLoading ?? false;
   const error = runtime?.workspaceBackupsError ?? null;
@@ -607,7 +591,7 @@ export function BackupPage(props: BackupPageProps = {}) {
     && deltaPreview?.checkpointId === selectedCheckpointId
     ? deltaPreview
     : null;
-  const selectedThread = selectedEntry
+  const selectedThread = selectedEntry && workspace
     ? threads.find((thread) => (
         thread.workspaceId === workspace.id
           && threadRuntimeById[thread.id]?.sessionId === selectedEntry.targetSessionId
@@ -621,46 +605,75 @@ export function BackupPage(props: BackupPageProps = {}) {
   );
   const selectedBackupsEnabled = selectedThreadRuntime?.sessionConfig?.backupsEnabled ?? null;
 
+  const settingsChrome = useOptionalSettingsChrome();
+  const backupHeaderActions = useMemo(() => {
+    if (!workspace) return null;
+    return (
+      <div className="flex flex-wrap items-center justify-end gap-2">
+        <label className="flex max-w-full items-center gap-2 rounded-md border border-border/70 bg-background px-2.5 py-1.5 text-xs sm:text-sm">
+          <Checkbox
+            checked={selectedBackupsEnabled ?? false}
+            disabled={!canToggleSelectedEntry}
+            onCheckedChange={(checked) => {
+              if (!selectedEntry) return;
+              void setSessionBackupsEnabled?.(selectedEntry.targetSessionId, toBoolean(checked));
+            }}
+          />
+          <span className={canToggleSelectedEntry ? "text-foreground" : "text-muted-foreground"}>
+            Keep recovery snapshots for this session
+          </span>
+        </label>
+        {workspaceList.length > 1 && props.workspace === undefined && (
+          <Select value={workspace.id} onValueChange={(val) => { if (val !== workspace.id) void selectWorkspaceFromStore(val); }}>
+            <SelectTrigger className="h-9 w-[min(200px,100%)] border-border/70 bg-background text-sm">
+              <SelectValue placeholder="Select workspace" />
+            </SelectTrigger>
+            <SelectContent>
+              {workspaceList.map((ws) => (
+                <SelectItem key={ws.id} value={ws.id}>{ws.name}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        )}
+      </div>
+    );
+  }, [
+    workspace,
+    workspaceList.length,
+    props.workspace,
+    selectedBackupsEnabled,
+    canToggleSelectedEntry,
+    selectedEntry,
+    setSessionBackupsEnabled,
+    selectWorkspaceFromStore,
+  ]);
+
+  useEffect(() => {
+    if (!settingsChrome) return;
+    settingsChrome.setChrome(backupHeaderActions ? { headerActions: backupHeaderActions } : {});
+    return () => {
+      settingsChrome.setChrome(null);
+    };
+  }, [settingsChrome, backupHeaderActions]);
+
+  if (!workspace) {
+    return (
+      <div className="flex min-h-[220px] flex-col items-center justify-center px-4 py-10" data-backup-page="true">
+        <Card className="w-full max-w-md border-border/80 bg-card/85">
+          <CardContent className="p-8 text-center">
+            <ArchiveIcon className="mx-auto mb-4 h-12 w-12 text-muted-foreground/30" />
+            <p className="text-muted-foreground">Select a workspace first to manage its backup history.</p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
   return (
     <div
-      className="flex h-full min-h-0 flex-col gap-5 px-6 pt-6 max-[960px]:gap-4 max-[960px]:px-4 max-[960px]:pt-4"
+      className="flex h-full min-h-0 flex-col gap-0"
       data-backup-page="true"
     >
-      {/* Header */}
-      <div className="flex flex-col sm:flex-row sm:items-end justify-between gap-4 shrink-0">
-        <div className="space-y-1">
-          <h1 className="text-3xl font-semibold tracking-tight text-foreground">Workspace Backups</h1>
-          <p className="text-sm text-muted-foreground">Manage backup history and restore points for your workspaces.</p>
-        </div>
-        <div className="flex items-center gap-2">
-          <label className="flex items-center gap-2 rounded-lg border border-border/70 bg-background px-3 py-2 text-sm">
-            <Checkbox
-              checked={selectedBackupsEnabled ?? false}
-              disabled={!canToggleSelectedEntry}
-              onCheckedChange={(checked) => {
-                if (!selectedEntry) return;
-                void setSessionBackupsEnabled?.(selectedEntry.targetSessionId, toBoolean(checked));
-              }}
-            />
-            <span className={canToggleSelectedEntry ? "text-foreground" : "text-muted-foreground"}>
-              Keep recovery snapshots for this session
-            </span>
-          </label>
-          {workspaceList.length > 1 && props.workspace === undefined && (
-            <Select value={workspace.id} onValueChange={(val) => { if (val !== workspace.id) void selectWorkspaceFromStore(val); }}>
-              <SelectTrigger className="h-9 w-[200px] border-border/70 bg-background">
-                <SelectValue placeholder="Select workspace" />
-              </SelectTrigger>
-              <SelectContent>
-                {workspaceList.map((ws) => (
-                  <SelectItem key={ws.id} value={ws.id}>{ws.name}</SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          )}
-        </div>
-      </div>
-
       {error ? (
         <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive flex items-center gap-2 shrink-0">
           <AlertTriangleIcon className="h-4 w-4" />

--- a/apps/desktop/src/ui/settings/pages/BackupPage.tsx
+++ b/apps/desktop/src/ui/settings/pages/BackupPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useEffectEvent, useMemo, useState } from "react";
+import { useEffect, useEffectEvent, useState } from "react";
 
 import {
   AlertTriangleIcon,
@@ -606,10 +606,30 @@ export function BackupPage(props: BackupPageProps = {}) {
   const selectedBackupsEnabled = selectedThreadRuntime?.sessionConfig?.backupsEnabled ?? null;
 
   const settingsChrome = useOptionalSettingsChrome();
-  const backupHeaderActions = useMemo(() => {
-    if (!workspace) return null;
+  useEffect(() => {
+    if (!settingsChrome) return;
+    return () => { settingsChrome.setChrome(null); };
+  }, [settingsChrome]);
+
+  if (!workspace) {
     return (
-      <div className="flex flex-wrap items-center justify-end gap-2">
+      <div className="flex min-h-[220px] flex-col items-center justify-center px-4 py-10" data-backup-page="true">
+        <Card className="w-full max-w-md border-border/80 bg-card/85">
+          <CardContent className="p-8 text-center">
+            <ArchiveIcon className="mx-auto mb-4 h-12 w-12 text-muted-foreground/30" />
+            <p className="text-muted-foreground">Select a workspace first to manage its backup history.</p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="flex h-full min-h-0 flex-col gap-0"
+      data-backup-page="true"
+    >
+      <div className="flex shrink-0 flex-wrap items-center justify-end gap-2 px-5 py-2.5 max-[960px]:px-4">
         <label className="flex max-w-full items-center gap-2 rounded-md border border-border/70 bg-background px-2.5 py-1.5 text-xs sm:text-sm">
           <Checkbox
             checked={selectedBackupsEnabled ?? false}
@@ -636,44 +656,7 @@ export function BackupPage(props: BackupPageProps = {}) {
           </Select>
         )}
       </div>
-    );
-  }, [
-    workspace,
-    workspaceList.length,
-    props.workspace,
-    selectedBackupsEnabled,
-    canToggleSelectedEntry,
-    selectedEntry,
-    setSessionBackupsEnabled,
-    selectWorkspaceFromStore,
-  ]);
 
-  useEffect(() => {
-    if (!settingsChrome) return;
-    settingsChrome.setChrome(backupHeaderActions ? { headerActions: backupHeaderActions } : {});
-    return () => {
-      settingsChrome.setChrome(null);
-    };
-  }, [settingsChrome, backupHeaderActions]);
-
-  if (!workspace) {
-    return (
-      <div className="flex min-h-[220px] flex-col items-center justify-center px-4 py-10" data-backup-page="true">
-        <Card className="w-full max-w-md border-border/80 bg-card/85">
-          <CardContent className="p-8 text-center">
-            <ArchiveIcon className="mx-auto mb-4 h-12 w-12 text-muted-foreground/30" />
-            <p className="text-muted-foreground">Select a workspace first to manage its backup history.</p>
-          </CardContent>
-        </Card>
-      </div>
-    );
-  }
-
-  return (
-    <div
-      className="flex h-full min-h-0 flex-col gap-0"
-      data-backup-page="true"
-    >
       {error ? (
         <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive flex items-center gap-2 shrink-0">
           <AlertTriangleIcon className="h-4 w-4" />

--- a/apps/desktop/src/ui/settings/pages/BackupPage.tsx
+++ b/apps/desktop/src/ui/settings/pages/BackupPage.tsx
@@ -683,7 +683,7 @@ export function BackupPage(props: BackupPageProps = {}) {
 
       {/* Main Split-Pane Layout - Full Page */}
       <div
-        className="mx-[-1.5rem] flex min-h-0 flex-1 overflow-hidden border-y border-border/70 bg-transparent max-[960px]:mx-[-1rem]"
+        className="flex min-h-0 flex-1 overflow-hidden bg-transparent"
         data-backup-split="true"
       >
         <BackupSidebar

--- a/apps/desktop/src/ui/settings/pages/DeveloperPage.tsx
+++ b/apps/desktop/src/ui/settings/pages/DeveloperPage.tsx
@@ -89,11 +89,6 @@ export function DeveloperPage() {
 
   return (
     <div className="space-y-5">
-      <div className="space-y-2">
-        <h1 className="text-3xl font-semibold tracking-tight text-foreground">Developer</h1>
-        <p className="text-sm text-muted-foreground">Advanced settings and debugging tools.</p>
-      </div>
-
       <Card className="border-border/80 bg-card/85">
         <CardHeader>
           <CardTitle>File Explorer</CardTitle>

--- a/apps/desktop/src/ui/settings/pages/McpServersPage.tsx
+++ b/apps/desktop/src/ui/settings/pages/McpServersPage.tsx
@@ -120,13 +120,6 @@ export function McpServersPage() {
 
   return (
     <div className="space-y-5" ref={parent}>
-      <div className="space-y-2">
-        <h1 className="text-3xl font-semibold tracking-tight text-foreground">MCP servers</h1>
-        <p className="text-sm text-muted-foreground">Connect external tools and services Cowork can use in this workspace.</p>
-      </div>
-
-
-
       <div className="flex items-center justify-between">
         <h2 className="text-lg font-medium">Custom servers</h2>
         {workspace ? (

--- a/apps/desktop/src/ui/settings/pages/MemoryPage.tsx
+++ b/apps/desktop/src/ui/settings/pages/MemoryPage.tsx
@@ -190,13 +190,6 @@ export function MemoryPage() {
 
   return (
     <div className="space-y-5">
-      <div className="space-y-2">
-        <h1 className="text-3xl font-semibold tracking-tight text-foreground">Memory</h1>
-        <p className="text-sm text-muted-foreground">
-          Things Cowork remembers about you and this workspace.
-        </p>
-      </div>
-
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
           {workspaces.length > 1 && workspace ? (

--- a/apps/desktop/src/ui/settings/pages/ProvidersPage.tsx
+++ b/apps/desktop/src/ui/settings/pages/ProvidersPage.tsx
@@ -13,6 +13,7 @@ import { compareProviderNamesForSettings } from "../../../lib/providerOrdering";
 import type { ProviderName, ServerEvent } from "../../../lib/wsProtocol";
 import { PROVIDER_NAMES } from "../../../lib/wsProtocol";
 import { cn } from "../../../lib/utils";
+import { useOptionalSettingsChrome } from "../SettingsChromeContext";
 import {
   displayProviderName,
   fallbackAuthMethods,
@@ -359,6 +360,28 @@ export function ProvidersPage({ initialExpandedSectionId = null }: ProvidersPage
     if (!canConnectProvider) return;
     void refreshProviderStatus();
   }, [canConnectProvider, refreshProviderStatus]);
+
+  const settingsChrome = useOptionalSettingsChrome();
+  useEffect(() => {
+    if (!settingsChrome) return;
+    settingsChrome.setChrome({
+      headerActions: canConnectProvider ? (
+        <Button
+          variant="outline"
+          size="sm"
+          type="button"
+          className="shrink-0"
+          onClick={() => void refreshProviderStatus({ refreshBedrockDiscovery: true })}
+          disabled={providerStatusRefreshing}
+        >
+          {providerStatusRefreshing ? "Refreshing…" : "Refresh status"}
+        </Button>
+      ) : null,
+    });
+    return () => {
+      settingsChrome.setChrome(null);
+    };
+  }, [settingsChrome, canConnectProvider, providerStatusRefreshing, refreshProviderStatus]);
 
   useEffect(() => {
     if (!providerLastAuthResult?.ok) return;
@@ -1083,22 +1106,6 @@ export function ProvidersPage({ initialExpandedSectionId = null }: ProvidersPage
 
   return (
     <div className="space-y-5">
-      <div className="space-y-2">
-        <h1 className="text-3xl font-semibold tracking-tight text-foreground">Providers</h1>
-        <p className="text-sm text-muted-foreground">
-          Manage the providers Cowork can use in this app and check whether each one is ready.{" "}
-          <Button
-            variant="link"
-            className="h-auto px-0"
-            type="button"
-            onClick={() => void refreshProviderStatus({ refreshBedrockDiscovery: true })}
-            disabled={providerStatusRefreshing}
-          >
-            {providerStatusRefreshing ? "Refreshing..." : "Refresh status"}
-          </Button>
-        </p>
-      </div>
-
       {!canConnectProvider ? (
         <Card className="border-border/80 bg-card/85">
           <CardContent className="p-6 text-center text-sm text-muted-foreground">

--- a/apps/desktop/src/ui/settings/pages/ProvidersPage.tsx
+++ b/apps/desktop/src/ui/settings/pages/ProvidersPage.tsx
@@ -3,7 +3,7 @@ import { motion } from "framer-motion";
 
 import { useAppStore } from "../../../app/store";
 import { Badge } from "../../../components/ui/badge";
-import { Button } from "../../../components/ui/button";
+import { Button, buttonVariants } from "../../../components/ui/button";
 import { Card, CardContent } from "../../../components/ui/card";
 import { Checkbox } from "../../../components/ui/checkbox";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "../../../components/ui/collapsible";
@@ -366,16 +366,14 @@ export function ProvidersPage({ initialExpandedSectionId = null }: ProvidersPage
     if (!settingsChrome) return;
     settingsChrome.setChrome({
       headerActions: canConnectProvider ? (
-        <Button
-          variant="outline"
-          size="sm"
+        <button
           type="button"
-          className="shrink-0"
+          className={buttonVariants({ variant: "outline", size: "sm", className: "shrink-0" })}
           onClick={() => void refreshProviderStatus({ refreshBedrockDiscovery: true })}
           disabled={providerStatusRefreshing}
         >
           {providerStatusRefreshing ? "Refreshing…" : "Refresh status"}
-        </Button>
+        </button>
       ) : null,
     });
     return () => {

--- a/apps/desktop/src/ui/settings/pages/RemoteAccessPage.tsx
+++ b/apps/desktop/src/ui/settings/pages/RemoteAccessPage.tsx
@@ -95,14 +95,7 @@ export function RemoteAccessPage() {
   }
 
   return (
-    <div className="space-y-5">
-      <div className="space-y-2">
-        <h1 className="text-3xl font-semibold tracking-tight text-foreground">Remote Access</h1>
-        <p className="text-sm text-muted-foreground">
-          Pair one phone to the selected workspace using the remote relay and Cowork JSON-RPC.
-        </p>
-      </div>
-
+    <div className="space-y-5" data-remote-access-page="true">
       <Card className="border-border/80 bg-card/85">
         <CardHeader>
           <CardTitle>Workspace bridge</CardTitle>

--- a/apps/desktop/src/ui/settings/pages/UpdatesPage.tsx
+++ b/apps/desktop/src/ui/settings/pages/UpdatesPage.tsx
@@ -81,11 +81,6 @@ export function UpdatesPage(props: UpdatesPageProps = {}) {
 
   return (
     <div className="space-y-5" data-update-phase={updateState.phase}>
-      <div className="space-y-2">
-        <h1 className="text-3xl font-semibold tracking-tight text-foreground">Updates</h1>
-        <p className="text-sm text-muted-foreground">Desktop app versioning and restart-based update installs.</p>
-      </div>
-
       <Card className="border-border/80 bg-card/85">
         <CardHeader className="flex-row items-center justify-between space-y-0">
           <div>

--- a/apps/desktop/src/ui/settings/pages/UsagePage.tsx
+++ b/apps/desktop/src/ui/settings/pages/UsagePage.tsx
@@ -16,6 +16,7 @@ import {
   DialogTitle,
 } from "../../../components/ui/dialog";
 import { cn } from "../../../lib/utils";
+import { useOptionalSettingsChrome } from "../SettingsChromeContext";
 import { formatCost, formatTokenCount } from "../../../../../../src/session/pricing";
 import type { ModelUsageSummary } from "../../../../../../src/session/costTracker";
 
@@ -203,56 +204,58 @@ export function UsagePage(props: UsagePageProps = {}) {
 
   const hasUsage = aggregate && aggregate.totalSessions > 0;
 
-  return (
-    <div className="space-y-5" data-usage-page="true">
-      <div className="flex items-start justify-between gap-3 max-[960px]:flex-col">
-        <div className="space-y-2">
-          <h1 className="text-3xl font-semibold tracking-tight text-foreground">Usage</h1>
-          <p className="max-w-2xl text-sm text-muted-foreground">
-            Token usage and estimated costs across all sessions, broken down by provider and model.
+  const settingsChrome = useOptionalSettingsChrome();
+  const estimateNoticeDialog = (
+    <Dialog open={estimateNoticeOpen} onOpenChange={handleEstimateNoticeOpenChange}>
+      <DialogContent showClose className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Usage estimates</DialogTitle>
+          <DialogDescription>
+            These numbers are estimates based on provider-reported token usage and Cowork&apos;s local pricing catalog.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-3 text-sm text-muted-foreground">
+          <p>
+            Billing may vary. Providers can round differently, apply cached-token discounts differently, or change
+            prices independently of what is bundled in the app.
+          </p>
+          <p>
+            Be careful while using these estimates for spend decisions. Treat totals as protective guidance, not exact
+            invoices.
           </p>
         </div>
-
-        <div className="shrink-0">
-          <Button
-            type="button"
-            variant="outline"
-            className="gap-2"
-            onClick={() => handleEstimateNoticeOpenChange?.(true)}
-          >
-            <AlertTriangleIcon className="h-4 w-4" />
-            How estimates work
+        <DialogFooter>
+          <Button type="button" variant="secondary" onClick={() => handleEstimateNoticeOpenChange?.(false)}>
+            Got it
           </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
 
-          <Dialog open={estimateNoticeOpen} onOpenChange={handleEstimateNoticeOpenChange}>
-            <DialogContent showClose className="max-w-lg">
-              <DialogHeader>
-                <DialogTitle>Usage estimates</DialogTitle>
-                <DialogDescription>
-                  These numbers are estimates based on provider-reported token usage and Cowork&apos;s local pricing
-                  catalog.
-                </DialogDescription>
-              </DialogHeader>
-              <div className="space-y-3 text-sm text-muted-foreground">
-                <p>
-                  Billing may vary. Providers can round differently, apply cached-token discounts differently, or
-                  change prices independently of what is bundled in the app.
-                </p>
-                <p>
-                  Be careful while using these estimates for spend decisions. Treat totals as protective
-                  guidance, not exact invoices.
-                </p>
-              </div>
-              <DialogFooter>
-                <Button type="button" variant="secondary" onClick={() => handleEstimateNoticeOpenChange?.(false)}>
-                  Got it
-                </Button>
-              </DialogFooter>
-            </DialogContent>
-          </Dialog>
-        </div>
-      </div>
+  useEffect(() => {
+    if (!settingsChrome) return;
+    settingsChrome.setChrome({
+      headerActions: (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="gap-2"
+          onClick={() => handleEstimateNoticeOpenChange?.(true)}
+        >
+          <AlertTriangleIcon className="h-4 w-4" />
+          How estimates work
+        </Button>
+      ),
+    });
+    return () => {
+      settingsChrome.setChrome(null);
+    };
+  }, [settingsChrome, handleEstimateNoticeOpenChange]);
 
+  return (
+    <div className="space-y-5" data-usage-page="true">
       {/* ── Overview stats ──────────────────────────────────────────── */}
       <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
         <UsageStat
@@ -360,6 +363,22 @@ export function UsagePage(props: UsagePageProps = {}) {
           No usage data recorded yet. Usage will appear here as you use models across sessions.
         </div>
       )}
+
+      {!settingsChrome ? (
+        <div className="flex justify-end">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="gap-2"
+            onClick={() => handleEstimateNoticeOpenChange?.(true)}
+          >
+            <AlertTriangleIcon className="h-4 w-4" />
+            How estimates work
+          </Button>
+        </div>
+      ) : null}
+      {estimateNoticeDialog}
     </div>
   );
 }

--- a/apps/desktop/src/ui/settings/pages/UsagePage.tsx
+++ b/apps/desktop/src/ui/settings/pages/UsagePage.tsx
@@ -6,7 +6,7 @@ import { useAutoAnimate } from "@formkit/auto-animate/react";
 import { useAppStore } from "../../../app/store";
 import type { ThreadRuntime } from "../../../app/types";
 import { Badge } from "../../../components/ui/badge";
-import { Button } from "../../../components/ui/button";
+import { Button, buttonVariants } from "../../../components/ui/button";
 import {
   Dialog,
   DialogContent,
@@ -237,16 +237,14 @@ export function UsagePage(props: UsagePageProps = {}) {
     if (!settingsChrome) return;
     settingsChrome.setChrome({
       headerActions: (
-        <Button
+        <button
           type="button"
-          variant="outline"
-          size="sm"
-          className="gap-2"
+          className={buttonVariants({ variant: "outline", size: "sm", className: "gap-2" })}
           onClick={() => handleEstimateNoticeOpenChange?.(true)}
         >
-          <AlertTriangleIcon className="h-4 w-4" />
+          <AlertTriangleIcon className="h-4 w-4" data-icon />
           How estimates work
-        </Button>
+        </button>
       ),
     });
     return () => {

--- a/apps/desktop/src/ui/settings/pages/WorkspacesPage.tsx
+++ b/apps/desktop/src/ui/settings/pages/WorkspacesPage.tsx
@@ -1212,11 +1212,6 @@ export function WorkspacesPage() {
 
   return (
     <div className="space-y-5">
-      <div className="space-y-2">
-        <h1 className="text-3xl font-semibold tracking-tight text-foreground">Workspaces</h1>
-        <p className="text-sm text-muted-foreground">Set up how your AI works in this project.</p>
-      </div>
-
       {workspaces.length === 0 || !ws ? (
         <Card className="border-border/80 bg-card/85">
           <CardContent className="p-8 text-center">

--- a/apps/desktop/test/backup-page.test.ts
+++ b/apps/desktop/test/backup-page.test.ts
@@ -75,7 +75,7 @@ describe("desktop backup page", () => {
   test("renders an empty-state prompt when no workspace is selected", () => {
     const html = renderToStaticMarkup(createElement(BackupPage, { workspace: null, runtime: null }));
 
-    expect(html).toContain("Workspace Backups");
+    expect(html).toContain("data-backup-page");
     expect(html).toContain("Select a workspace first to manage its backup history.");
   });
 
@@ -164,9 +164,8 @@ describe("desktop backup page", () => {
       }),
     );
 
-    expect(html).toContain("Workspace Backups");
+    expect(html).toContain("data-backup-page");
     expect(html).toContain("Backup History");
-    expect(html).toContain("Manage backup history and restore points for your workspaces.");
     expect(html).toContain("Deleted session");
     expect(html).toContain("Broken backup");
     expect(html).toContain("cp-0001");

--- a/apps/desktop/test/remote-access-page.test.ts
+++ b/apps/desktop/test/remote-access-page.test.ts
@@ -192,8 +192,8 @@ describe("desktop remote access page", () => {
 
   test("renders pairing and trusted phone sections", () => {
     const html = renderToStaticMarkup(createElement(RemoteAccessPage));
-    expect(html).toContain("Remote Access");
-    expect(html).toContain("using the remote relay and Cowork JSON-RPC");
+    expect(html).toContain("data-remote-access-page");
+    expect(html).toContain("Cowork Mobile");
     expect(html).toContain("Workspace bridge");
     expect(html).toContain("Relay service:");
     expect(html).toContain("Pairing QR");

--- a/apps/desktop/test/usage-page.test.ts
+++ b/apps/desktop/test/usage-page.test.ts
@@ -173,7 +173,7 @@ describe("desktop usage page", () => {
       } as any),
     );
 
-    expect(html).toContain("Usage");
+    expect(html).toContain("data-usage-page");
     expect(html).toContain("By provider");
     expect(html).toContain("gpt-5.2");
     expect(html).toContain("gemini-3-flash-preview");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Introduces `SettingsChromeContext` so settings pages can register header actions (refresh, backup controls, usage estimate trigger) while `SettingsShell` owns the sticky title and description.
- Simplifies settings navigation styling and refactors individual pages to remove duplicate `h1`/description blocks; backup page keeps its split layout with non-sticky shell header where needed.
- **Usage page**: moves the "How estimates work" dialog into the page tree so SSR/unit tests see the button and dialog; when `SettingsChromeProvider` is present, only the compact trigger lives in the shell header (dialog still portals from the page).
- **Tests**: remote access assertions updated for shell-owned title (`data-remote-access-page`, copy that still exists on the page); usage aggregate test uses `data-usage-page` instead of the removed title string.

## How to test

```bash
cd /workspace && bun run typecheck
cd apps/desktop && bun test
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ff1a209f-6c1a-411f-b4cd-aefb5d49838d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ff1a209f-6c1a-411f-b4cd-aefb5d49838d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

