### PR TITLE
fix: relax Fireworks tool schemas for tool calling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "latest"
 
       - name: Install dependencies
         run: bun install

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,7 +186,7 @@ Durable rules distilled from prior corrections. Apply before editing, not after.
 - **Workspace settings**: any new field must round-trip through `PersistenceService.sanitizeWorkspaces()` — partial sanitizer updates silently drop fields on save/load. Audit every new field, not just the headline one.
 - **Tool prompt guidance**: use actual callable tool IDs (`bash`, `glob`, `grep`); generic names like `shell`/`search` route the model into nonexistent calls.
 - **JSON-RPC projector**: item IDs must be occurrence-stable within a turn. Always forward `itemId` on `item/agentMessage/delta`. Close the current assistant item before reasoning/tool phases. Don't key assistant items only by `turnId`.
-- **New provider**: audit every provider-gated tool factory in `src/tools/*` and add a `createTools(...)` regression — missing branches crash PI tool mapping before the turn starts.
+- **New provider**: audit every provider-gated tool factory in `src/tools/` and add a `createTools(...)` regression — missing branches crash PI tool mapping before the turn starts.
 - **MCP tool schemas**: normalize tuple-style JSON Schema arrays (`items: [{...}, {...}]`) to provider-safe object/boolean nodes before registration; OpenAI-compatible runtimes reject otherwise.
 - **Settings toggles**: shared `Switch` for binary on/off; reserve `Checkbox` for checklist selection.
 - **Optimistic chat sends**: preserve `clientMessageId` through `turn/start`/`turn/steer` and the projected `item/userMessage` notifications, or duplicate user bubbles render.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,7 +156,7 @@ Durable rules distilled from prior corrections. Apply before editing, not after.
 - **Workspace settings**: any new field must round-trip through `PersistenceService.sanitizeWorkspaces()` — partial sanitizer updates silently drop fields on save/load. Audit every new field, not just the headline one.
 - **Tool prompt guidance**: use actual callable tool IDs (`bash`, `glob`, `grep`); generic names like `shell`/`search` route the model into nonexistent calls.
 - **JSON-RPC projector**: item IDs must be occurrence-stable within a turn. Always forward `itemId` on `item/agentMessage/delta`. Close the current assistant item before reasoning/tool phases. Don't key assistant items only by `turnId`.
-- **New provider**: audit every provider-gated tool factory in `src/tools/*` and add a `createTools(...)` regression — missing branches crash PI tool mapping before the turn starts.
+- **New provider**: audit every provider-gated tool factory in `src/tools/` and add a `createTools(...)` regression — missing branches crash PI tool mapping before the turn starts.
 - **MCP tool schemas**: normalize tuple-style JSON Schema arrays (`items: [{...}, {...}]`) to provider-safe object/boolean nodes before registration; OpenAI-compatible runtimes reject otherwise.
 - **Settings toggles**: shared `Switch` for binary on/off; reserve `Checkbox` for checklist selection.
 - **Optimistic chat sends**: preserve `clientMessageId` through `turn/start`/`turn/steer` and the projected `item/userMessage` notifications, or duplicate user bubbles render.

--- a/apps/desktop/test/workspace-startup.test.ts
+++ b/apps/desktop/test/workspace-startup.test.ts
@@ -26,6 +26,21 @@ async function flushAsyncWork(): Promise<void> {
   await Promise.resolve();
 }
 
+async function waitForCondition(
+  predicate: () => boolean,
+  opts: { timeoutMs?: number; intervalMs?: number } = {},
+): Promise<void> {
+  const timeoutMs = opts.timeoutMs ?? 1_000;
+  const intervalMs = opts.intervalMs ?? 0;
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline) {
+      throw new Error(`Timed out after ${timeoutMs}ms waiting for test condition`);
+    }
+    await Bun.sleep(intervalMs);
+  }
+}
+
 const startDeferreds: Deferred<{ url: string }>[] = [];
 const startCalls: Array<{ workspaceId: string; workspacePath: string; yolo: boolean }> = [];
 const stopCalls: string[] = [];
@@ -167,6 +182,7 @@ describe("workspace startup flow", () => {
 
     useAppStore.setState({
       ready: true,
+      bootstrapPending: false,
       startupError: null,
       view: "settings",
       settingsPage: "workspaces",
@@ -174,12 +190,16 @@ describe("workspace startup flow", () => {
       workspaces: [],
       threads: [],
       selectedWorkspaceId: null,
+      pluginManagementWorkspaceId: null,
+      pluginManagementMode: "auto",
       selectedThreadId: null,
       workspaceRuntimeById: {},
       threadRuntimeById: {},
       latestTodosByThreadId: {},
       workspaceExplorerById: {},
+      workspaceExplorerRefreshById: {},
       promptModal: null,
+      filePreview: null,
       notifications: [],
       providerStatusByName: {},
       providerStatusLastUpdatedAt: null,
@@ -195,6 +215,18 @@ describe("workspace startup flow", () => {
       injectContext: false,
       developerMode: false,
       showHiddenFiles: false,
+      perWorkspaceSettings: false,
+      desktopFeatureFlags: {
+        remoteAccess: false,
+        workspacePicker: true,
+        workspaceLifecycle: true,
+        a2ui: false,
+      },
+      desktopFeatureFlagOverrides: {},
+      updateState: MOCK_UPDATE_STATE,
+      onboardingVisible: false,
+      onboardingStep: "welcome",
+      onboardingState: { status: "pending", completedAt: null, dismissedAt: null },
       sidebarCollapsed: false,
       contextSidebarCollapsed: false,
       contextSidebarWidth: 300,
@@ -211,7 +243,7 @@ describe("workspace startup flow", () => {
     pickedWorkspaceDirectory = "/tmp/new-workspace";
 
     const addPromise = useAppStore.getState().addWorkspace();
-    await flushAsyncWork();
+    await waitForCondition(() => savedStates.length === 1 && startCalls.length === 1);
 
     expect(savedStates).toHaveLength(1);
     expect(startCalls).toHaveLength(1);
@@ -248,7 +280,7 @@ describe("workspace startup flow", () => {
     expect(startCalls).toHaveLength(1);
 
     const restart = useAppStore.getState().restartWorkspaceServer(workspaceId);
-    await flushAsyncWork();
+    await waitForCondition(() => stopCalls.length === 1 && startCalls.length === 2);
 
     expect(stopCalls).toEqual([workspaceId]);
     expect(startCalls).toHaveLength(2);

--- a/src/runtime/piRuntime.ts
+++ b/src/runtime/piRuntime.ts
@@ -745,6 +745,7 @@ export function toolMapToPiTools(
   tools: RuntimeRunTurnParams["tools"],
   provider?: ProviderName,
 ): Array<Record<string, unknown>> {
+  const schemaBudgetState = { totalBytes: 0 };
   return Object.entries(tools).flatMap(([name, def]) => {
     const toolRecord = asRecord(def);
     if (!toolRecord) return [];
@@ -752,7 +753,7 @@ export function toolMapToPiTools(
     return [{
       name,
       description: asNonEmptyString(toolRecord.description) ?? name,
-      parameters: toPiJsonSchema(toolRecord.inputSchema, provider),
+      parameters: toPiJsonSchema(toolRecord.inputSchema, provider, schemaBudgetState),
     }];
   });
 }

--- a/src/runtime/piRuntimeOptions.ts
+++ b/src/runtime/piRuntimeOptions.ts
@@ -271,6 +271,13 @@ const FIREWORKS_UNSUPPORTED_SCHEMA_KEYS = new Set([
   "pattern",
 ]);
 
+const FIREWORKS_TOOL_SCHEMA_MAX_BYTES = 4096;
+const FIREWORKS_TOTAL_TOOL_SCHEMA_MAX_BYTES = 12288;
+
+type ToolSchemaBudgetState = {
+  totalBytes: number;
+};
+
 function normalizeSchemaArray(value: unknown): ToolJsonSchema[] {
   if (!Array.isArray(value)) return [];
   return value
@@ -460,22 +467,85 @@ function sanitizeProviderToolJsonSchema(
   return sanitized;
 }
 
-export function toPiJsonSchema(inputSchema: unknown, provider?: ProviderName): Record<string, unknown> {
+export function toPiJsonSchema(
+  inputSchema: unknown,
+  provider?: ProviderName,
+  state?: ToolSchemaBudgetState,
+): Record<string, unknown> {
   if (isZodSchema(inputSchema)) {
     const schema = z.toJSONSchema(inputSchema);
     const normalized = normalizeToolJsonSchema(schema);
     const sanitized = sanitizeProviderToolJsonSchema(normalized, provider);
     const record = asRecord(sanitized);
     if (record) {
-      return record;
+      return applyProviderToolSchemaBudget(provider, record, state);
     }
   }
 
   const normalized = normalizeToolJsonSchema(inputSchema);
   const sanitized = sanitizeProviderToolJsonSchema(normalized, provider);
   const record = asRecord(sanitized);
-  if (record) return record;
+  if (record) return applyProviderToolSchemaBudget(provider, record, state);
   return { type: "object", properties: {}, additionalProperties: true };
+}
+
+function relaxedToolJsonSchema(): Record<string, unknown> {
+  return { type: "object", properties: {}, additionalProperties: true };
+}
+
+function estimateSchemaBytes(schema: Record<string, unknown>): number | undefined {
+  try {
+    return Buffer.byteLength(JSON.stringify(schema), "utf8");
+  } catch {
+    return undefined;
+  }
+}
+
+function shapePreservingShallowObjectSchema(schema: Record<string, unknown>): Record<string, unknown> {
+  if (schema.type !== "object") return relaxedToolJsonSchema();
+
+  const properties = asRecord(schema.properties);
+  if (!properties) return relaxedToolJsonSchema();
+
+  const shallowProperties = Object.fromEntries(
+    Object.keys(properties).map((key) => [key, {}]),
+  );
+  const required = Array.isArray(schema.required)
+    ? schema.required.filter((entry): entry is string => typeof entry === "string")
+    : undefined;
+
+  return {
+    type: "object",
+    properties: shallowProperties,
+    ...(required && required.length > 0 ? { required } : {}),
+    additionalProperties: true,
+  };
+}
+
+export function applyProviderToolSchemaBudget(
+  provider: ProviderName | undefined,
+  schema: Record<string, unknown>,
+  state?: ToolSchemaBudgetState,
+): Record<string, unknown> {
+  if (provider !== "fireworks") return schema;
+
+  const schemaBytes = estimateSchemaBytes(schema);
+  const totalBytes = state?.totalBytes ?? 0;
+  if (
+    schemaBytes !== undefined &&
+    schemaBytes <= FIREWORKS_TOOL_SCHEMA_MAX_BYTES &&
+    totalBytes + schemaBytes <= FIREWORKS_TOTAL_TOOL_SCHEMA_MAX_BYTES
+  ) {
+    if (state) state.totalBytes += schemaBytes;
+    return schema;
+  }
+
+  const fallback = shapePreservingShallowObjectSchema(schema);
+  const fallbackBytes = estimateSchemaBytes(fallback);
+  if (state && fallbackBytes !== undefined) {
+    state.totalBytes += fallbackBytes;
+  }
+  return fallback;
 }
 
 export function toolCallFromPartial(event: any): {

--- a/src/runtime/piRuntimeOptions.ts
+++ b/src/runtime/piRuntimeOptions.ts
@@ -501,6 +501,17 @@ function estimateSchemaBytes(schema: Record<string, unknown>): number | undefine
   }
 }
 
+function fitsFireworksSchemaBudget(
+  schemaBytes: number | undefined,
+  totalBytes: number,
+): schemaBytes is number {
+  return (
+    schemaBytes !== undefined
+    && schemaBytes <= FIREWORKS_TOOL_SCHEMA_MAX_BYTES
+    && totalBytes + schemaBytes <= FIREWORKS_TOTAL_TOOL_SCHEMA_MAX_BYTES
+  );
+}
+
 function shapePreservingShallowObjectSchema(schema: Record<string, unknown>): Record<string, unknown> {
   if (schema.type !== "object") return relaxedToolJsonSchema();
 
@@ -529,23 +540,26 @@ export function applyProviderToolSchemaBudget(
 ): Record<string, unknown> {
   if (provider !== "fireworks") return schema;
 
-  const schemaBytes = estimateSchemaBytes(schema);
   const totalBytes = state?.totalBytes ?? 0;
-  if (
-    schemaBytes !== undefined &&
-    schemaBytes <= FIREWORKS_TOOL_SCHEMA_MAX_BYTES &&
-    totalBytes + schemaBytes <= FIREWORKS_TOTAL_TOOL_SCHEMA_MAX_BYTES
-  ) {
-    if (state) state.totalBytes += schemaBytes;
-    return schema;
+  const candidates = [
+    schema,
+    shapePreservingShallowObjectSchema(schema),
+    relaxedToolJsonSchema(),
+  ];
+
+  for (const candidate of candidates) {
+    const candidateBytes = estimateSchemaBytes(candidate);
+    if (!fitsFireworksSchemaBudget(candidateBytes, totalBytes)) continue;
+    if (state) state.totalBytes += candidateBytes;
+    return candidate;
   }
 
-  const fallback = shapePreservingShallowObjectSchema(schema);
-  const fallbackBytes = estimateSchemaBytes(fallback);
-  if (state && fallbackBytes !== undefined) {
-    state.totalBytes += fallbackBytes;
+  const relaxed = relaxedToolJsonSchema();
+  const relaxedBytes = estimateSchemaBytes(relaxed);
+  if (state && relaxedBytes !== undefined) {
+    state.totalBytes += relaxedBytes;
   }
-  return fallback;
+  return relaxed;
 }
 
 export function toolCallFromPartial(event: any): {

--- a/test/ci.workflow.test.ts
+++ b/test/ci.workflow.test.ts
@@ -6,6 +6,12 @@ const workflowPath = new URL("../.github/workflows/ci.yml", import.meta.url);
 const workflow = readFileSync(workflowPath, "utf8");
 
 describe("main CI workflow", () => {
+  test("installs the latest Bun release explicitly", () => {
+    expect(workflow).toContain("- name: Setup Bun");
+    expect(workflow).toContain("uses: oven-sh/setup-bun@v2");
+    expect(workflow).toContain('bun-version: "latest"');
+  });
+
   test("keeps the core reliability guardrails in the main checks job", () => {
     expect(workflow).toContain("- name: Docs consistency check");
     expect(workflow).toContain("run: bun run docs:check");

--- a/test/runtime.pi-options.test.ts
+++ b/test/runtime.pi-options.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { z } from "zod";
 
 import * as __internal from "../src/runtime/piRuntimeOptions";
+import { __internal as piRuntimeInternal } from "../src/runtime/piRuntime";
 import type { RuntimeRunTurnParams } from "../src/runtime/types";
 import type { AgentConfig, ModelMessage } from "../src/types";
 
@@ -343,5 +344,113 @@ describe("pi runtime provider option mapping", () => {
       { type: "string" },
       { type: "number" },
     ]);
+  });
+
+  test("keeps small Fireworks tool schemas intact when they fit the provider budget", () => {
+    const tools = {
+      readFile: {
+        description: "simple tool",
+        inputSchema: z.object({
+          filePath: z.string(),
+          limit: z.number().optional(),
+        }),
+      },
+    };
+
+    const fireworksTools = piRuntimeInternal.toolMapToPiTools(tools as any, "fireworks") as any[];
+    expect(fireworksTools[0]?.parameters).toMatchObject({
+      type: "object",
+      properties: {
+        filePath: { type: "string" },
+        limit: { type: "number" },
+      },
+      required: ["filePath"],
+    });
+    expect(fireworksTools[0]?.parameters.additionalProperties).toBe(false);
+  });
+
+  test("degrades oversized Fireworks tool schemas to a shallow object shape", () => {
+    const tools = {
+      giantTool: {
+        description: "tool with a very large enum schema",
+        inputSchema: {
+          type: "object",
+          properties: {
+            choice: {
+              type: "string",
+              enum: Array.from({ length: 160 }, (_, index) => `option-${index}-${"x".repeat(12)}`),
+            },
+          },
+          required: ["choice"],
+          additionalProperties: false,
+        },
+      },
+    };
+
+    const fireworksTools = piRuntimeInternal.toolMapToPiTools(tools as any, "fireworks") as any[];
+    expect(fireworksTools[0]?.parameters).toEqual({
+      type: "object",
+      properties: {
+        choice: {},
+      },
+      required: ["choice"],
+      additionalProperties: true,
+    });
+  });
+
+  test("degrades Fireworks tool schemas once the cumulative schema budget is exhausted", () => {
+    const sharedSchema = {
+      type: "object",
+      properties: {
+        choice: {
+          type: "string",
+          enum: Array.from({ length: 150 }, (_, index) => `option-${index}-${"x".repeat(12)}`),
+        },
+      },
+      required: ["choice"],
+      additionalProperties: false,
+    };
+    const tools = {
+      firstTool: { description: "first", inputSchema: sharedSchema },
+      secondTool: { description: "second", inputSchema: sharedSchema },
+      thirdTool: { description: "third", inputSchema: sharedSchema },
+      fourthTool: { description: "fourth", inputSchema: sharedSchema },
+    };
+
+    const fireworksTools = piRuntimeInternal.toolMapToPiTools(tools as any, "fireworks") as any[];
+    expect(fireworksTools[0]?.parameters.properties.choice.enum).toHaveLength(150);
+    expect(fireworksTools[1]?.parameters.properties.choice.enum).toHaveLength(150);
+    expect(fireworksTools[2]?.parameters.properties.choice.enum).toHaveLength(150);
+    expect(fireworksTools[3]?.parameters).toEqual({
+      type: "object",
+      properties: {
+        choice: {},
+      },
+      required: ["choice"],
+      additionalProperties: true,
+    });
+  });
+
+  test("keeps oversized tool schemas for non-Fireworks providers", () => {
+    const hugeEnum = Array.from({ length: 4000 }, (_, index) => `option-${index}`);
+    const tools = {
+      giantTool: {
+        description: "tool with a very large enum schema",
+        inputSchema: {
+          type: "object",
+          properties: {
+            choice: {
+              type: "string",
+              enum: hugeEnum,
+            },
+          },
+          required: ["choice"],
+          additionalProperties: false,
+        },
+      },
+    };
+
+    const openAiTools = piRuntimeInternal.toolMapToPiTools(tools as any, "openai") as any[];
+    expect(openAiTools[0]?.parameters.properties.choice.enum).toHaveLength(4000);
   });
 });

--- a/test/runtime.pi-options.test.ts
+++ b/test/runtime.pi-options.test.ts
@@ -398,6 +398,38 @@ describe("pi runtime provider option mapping", () => {
     });
   });
 
+  test("degrades to the fully relaxed schema when the shallow Fireworks fallback still exceeds budget", () => {
+    const propertyEntries = Array.from({ length: 100 }, (_, index) => {
+      const key = `property-${index}-${"x".repeat(48)}`;
+      return [
+        key,
+        {
+          type: "string",
+          enum: Array.from({ length: 24 }, (__unused, enumIndex) => `value-${enumIndex}-${"y".repeat(24)}`),
+        },
+      ] as const;
+    });
+    const giantSchema = {
+      type: "object",
+      properties: Object.fromEntries(propertyEntries),
+      required: propertyEntries.map(([key]) => key),
+      additionalProperties: false,
+    };
+    const tools = {
+      giantTool: {
+        description: "tool with many long property names",
+        inputSchema: giantSchema,
+      },
+    };
+
+    const fireworksTools = piRuntimeInternal.toolMapToPiTools(tools as any, "fireworks") as any[];
+    expect(fireworksTools[0]?.parameters).toEqual({
+      type: "object",
+      properties: {},
+      additionalProperties: true,
+    });
+  });
+
   test("degrades Fireworks tool schemas once the cumulative schema budget is exhausted", () => {
     const sharedSchema = {
       type: "object",

--- a/test/runtime.pi-runtime.test.ts
+++ b/test/runtime.pi-runtime.test.ts
@@ -875,6 +875,92 @@ describe("pi runtime regressions", () => {
     });
   });
 
+  test("Fireworks runtime sends budgeted tool schemas to piStreamImpl", async () => {
+    const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-runtime-fireworks-tools-"));
+    const streamCalls: Array<Record<string, unknown>> = [];
+    const runtime = createPiRuntime({
+      piStreamImpl: ((model: unknown, input: Record<string, unknown>) => {
+        streamCalls.push({
+          model,
+          tools: input.tools,
+        });
+        return {
+          async *[Symbol.asyncIterator]() {
+            return;
+          },
+          async result() {
+            return {
+              role: "assistant",
+              content: [{ type: "text", text: "done" }],
+              usage: { input: 1, output: 1, totalTokens: 2 },
+              stopReason: "stop",
+            };
+          },
+        };
+      }) as any,
+    });
+    const config = makeConfig(homeDir, {
+      provider: "fireworks",
+      model: "accounts/fireworks/models/glm-5",
+      preferredChildModel: "accounts/fireworks/models/glm-5",
+    });
+
+    await runtime.runTurn(makeParams(config, {
+      tools: {
+        readFile: {
+          description: "simple tool",
+          inputSchema: z.object({
+            filePath: z.string(),
+            limit: z.number().optional(),
+          }),
+          execute: async () => "unused",
+        },
+        giantTool: {
+          description: "tool with a very large enum schema",
+          inputSchema: {
+            type: "object",
+            properties: {
+              choice: {
+                type: "string",
+                enum: Array.from({ length: 160 }, (_, index) => `option-${index}-${"x".repeat(12)}`),
+              },
+            },
+            required: ["choice"],
+            additionalProperties: false,
+          },
+          execute: async () => "unused",
+        },
+      },
+    }));
+
+    const sentTools = streamCalls[0]?.tools as Array<Record<string, any>>;
+    expect(sentTools).toHaveLength(2);
+    expect(sentTools[0]).toMatchObject({
+      name: "readFile",
+      parameters: {
+        type: "object",
+        properties: {
+          filePath: { type: "string" },
+          limit: { type: "number" },
+        },
+        required: ["filePath"],
+      },
+    });
+    expect(sentTools[0]?.parameters.additionalProperties).toBe(false);
+    expect(sentTools[1]).toEqual({
+      name: "giantTool",
+      description: "tool with a very large enum schema",
+      parameters: {
+        type: "object",
+        properties: {
+          choice: {},
+        },
+        required: ["choice"],
+        additionalProperties: true,
+      },
+    });
+  });
+
   test("telemetry parsing keeps supported metadata and drops invalid values", () => {
     const parsed = piRuntimeInternal.parseTelemetrySettings({
       isEnabled: true,

--- a/test/runtime.pi-runtime.test.ts
+++ b/test/runtime.pi-runtime.test.ts
@@ -961,6 +961,75 @@ describe("pi runtime regressions", () => {
     });
   });
 
+  test("Fireworks runtime falls back to the fully relaxed schema when shallow fallback still exceeds budget", async () => {
+    const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-runtime-fireworks-relaxed-tools-"));
+    const propertyEntries = Array.from({ length: 100 }, (_, index) => {
+      const key = `property-${index}-${"x".repeat(48)}`;
+      return [
+        key,
+        {
+          type: "string",
+          enum: Array.from({ length: 24 }, (__unused, enumIndex) => `value-${enumIndex}-${"y".repeat(24)}`),
+        },
+      ] as const;
+    });
+
+    const streamCalls: Array<Record<string, unknown>> = [];
+    const runtime = createPiRuntime({
+      piStreamImpl: ((model: unknown, input: Record<string, unknown>) => {
+        streamCalls.push({
+          model,
+          tools: input.tools,
+        });
+        return {
+          async *[Symbol.asyncIterator]() {
+            return;
+          },
+          async result() {
+            return {
+              role: "assistant",
+              content: [{ type: "text", text: "done" }],
+              usage: { input: 1, output: 1, totalTokens: 2 },
+              stopReason: "stop",
+            };
+          },
+        };
+      }) as any,
+    });
+    const config = makeConfig(homeDir, {
+      provider: "fireworks",
+      model: "accounts/fireworks/models/glm-5",
+      preferredChildModel: "accounts/fireworks/models/glm-5",
+    });
+
+    await runtime.runTurn(makeParams(config, {
+      tools: {
+        giantTool: {
+          description: "tool with many long property names",
+          inputSchema: {
+            type: "object",
+            properties: Object.fromEntries(propertyEntries),
+            required: propertyEntries.map(([key]) => key),
+            additionalProperties: false,
+          },
+          execute: async () => "unused",
+        },
+      },
+    }));
+
+    const sentTools = streamCalls[0]?.tools as Array<Record<string, any>>;
+    expect(sentTools).toHaveLength(1);
+    expect(sentTools[0]).toEqual({
+      name: "giantTool",
+      description: "tool with many long property names",
+      parameters: {
+        type: "object",
+        properties: {},
+        additionalProperties: true,
+      },
+    });
+  });
+
   test("telemetry parsing keeps supported metadata and drops invalid values", () => {
     const parsed = piRuntimeInternal.parseTelemetrySettings({
       isEnabled: true,


### PR DESCRIPTION
## Summary
- rebase the branch onto current `main`
- keep Fireworks-specific schema sanitization while adding a budgeted fallback for oversized tool schemas
- preserve full Fireworks tool schemas when they fit the provider limits and degrade only oversized or over-budget schemas to a shallow object shape
- add regression coverage for small-schema, oversized-schema, cumulative-budget, and runtime payload behavior
- fix repo-root path references so `bun run docs:check` passes again

## Why
Fireworks was rejecting some tool-calling requests with `400 Error initializing response_format.grammar` when tool schemas expanded into very large grammars. The branch now keeps normal Fireworks-compatible schemas when they fit the provider budget, while degrading only the schemas that would exceed the per-tool or cumulative limits.

## How To Test
- `bun test ./test/runtime.pi-options.test.ts ./test/runtime.pi-runtime.test.ts`
- `bun test --max-concurrency 1`
- `bun run typecheck`
- `bun run docs:check`

## Test Results
- `bun test ./test/runtime.pi-options.test.ts ./test/runtime.pi-runtime.test.ts` passed
- `bun test --max-concurrency 1` passed
- `bun run typecheck` passed
- `bun run docs:check` passed