### PR TITLE
feat: add GPT-5.5 model support

### DIFF
--- a/config/models/codex-cli/gpt-5.5.json
+++ b/config/models/codex-cli/gpt-5.5.json
@@ -1,0 +1,14 @@
+{
+  "id": "gpt-5.5",
+  "provider": "codex-cli",
+  "displayName": "GPT-5.5 (Codex CLI)",
+  "knowledgeCutoff": "December 01, 2025",
+  "supportsImageInput": true,
+  "promptTemplate": "system-models/gpt-5.4.json",
+  "providerOptionsDefaults": {
+    "reasoningEffort": "high",
+    "reasoningSummary": "detailed",
+    "textVerbosity": "medium"
+  },
+  "isDefault": false
+}

--- a/config/models/openai/gpt-5.5.json
+++ b/config/models/openai/gpt-5.5.json
@@ -1,0 +1,14 @@
+{
+  "id": "gpt-5.5",
+  "provider": "openai",
+  "displayName": "GPT-5.5",
+  "knowledgeCutoff": "December 01, 2025",
+  "supportsImageInput": true,
+  "promptTemplate": "system-models/gpt-5.4.json",
+  "providerOptionsDefaults": {
+    "reasoningEffort": "high",
+    "reasoningSummary": "detailed",
+    "textVerbosity": "medium"
+  },
+  "isDefault": false
+}

--- a/src/models/childAgentModelInfo.ts
+++ b/src/models/childAgentModelInfo.ts
@@ -71,12 +71,14 @@ const freeExperimental = {
 } as const;
 
 const CHILD_AGENT_MODEL_INFO_BY_KEY: Readonly<Record<string, ChildAgentModelInfo>> = {
+  [key("openai", "gpt-5.5")]: frontierCoding,
   [key("openai", "gpt-5.4")]: frontierCoding,
   [key("openai", "gpt-5.4-mini")]: frontierCoding,
   [key("openai", "gpt-5.2")]: balancedGeneral,
   [key("openai", "gpt-5.2-pro")]: deepReasoning,
   [key("openai", "gpt-5-mini")]: fastGeneral,
 
+  [key("codex-cli", "gpt-5.5")]: frontierCoding,
   [key("codex-cli", "gpt-5.4")]: frontierCoding,
   [key("codex-cli", "gpt-5.4-mini")]: frontierCoding,
 

--- a/src/models/registry.ts
+++ b/src/models/registry.ts
@@ -10,6 +10,7 @@ import basetenZaiOrgGlm5 from "../../config/models/baseten/zai-org-glm-5.json";
 import bedrockAmazonNovaLiteV10 from "../../config/models/bedrock/amazon.nova-lite-v1-0.json";
 import bedrockAmazonNovaMicroV10 from "../../config/models/bedrock/amazon.nova-micro-v1-0.json";
 import bedrockAnthropicClaude35Haiku20241022V10 from "../../config/models/bedrock/anthropic.claude-3-5-haiku-20241022-v1-0.json";
+import codexCliGpt55 from "../../config/models/codex-cli/gpt-5.5.json";
 import codexCliGpt54 from "../../config/models/codex-cli/gpt-5.4.json";
 import codexCliGpt54Mini from "../../config/models/codex-cli/gpt-5.4-mini.json";
 import fireworksGlm5 from "../../config/models/fireworks/accounts-fireworks-models-glm-5.json";
@@ -23,6 +24,7 @@ import googleGemini3FlashPreview from "../../config/models/google/gemini-3-flash
 import nvidiaNemotron3Super120bA12b from "../../config/models/nvidia/nvidia-nemotron-3-super-120b-a12b.json";
 import openaiGpt52 from "../../config/models/openai/gpt-5.2.json";
 import openaiGpt52Pro from "../../config/models/openai/gpt-5.2-pro.json";
+import openaiGpt55 from "../../config/models/openai/gpt-5.5.json";
 import openaiGpt54 from "../../config/models/openai/gpt-5.4.json";
 import openaiGpt54Mini from "../../config/models/openai/gpt-5.4-mini.json";
 import openaiGpt5Mini from "../../config/models/openai/gpt-5-mini.json";
@@ -85,6 +87,7 @@ const RAW_MODEL_REGISTRY_ENTRIES = [
   basetenMoonshotAiKimiK25,
   basetenNvidiaNemotron120bA12b,
   basetenZaiOrgGlm5,
+  codexCliGpt55,
   codexCliGpt54,
   codexCliGpt54Mini,
   fireworksGlm5,
@@ -98,6 +101,7 @@ const RAW_MODEL_REGISTRY_ENTRIES = [
   openaiGpt5Mini,
   openaiGpt52Pro,
   openaiGpt52,
+  openaiGpt55,
   openaiGpt54,
   openaiGpt54Mini,
   nvidiaNemotron3Super120bA12b,

--- a/src/runtime/openaiResponsesModel.ts
+++ b/src/runtime/openaiResponsesModel.ts
@@ -25,11 +25,13 @@ const SUPPORTED_OPENAI_RESPONSES_MODEL_LIMITS: Record<string, SupportedResponses
   "gpt-5.2-pro": { contextWindow: 400_000, maxTokens: 128_000 },
   "gpt-5.4": { contextWindow: 400_000, maxTokens: 128_000 },
   "gpt-5.4-mini": { contextWindow: 400_000, maxTokens: 128_000 },
+  "gpt-5.5": { contextWindow: 1_050_000, maxTokens: 128_000 },
 };
 
 const SUPPORTED_CODEX_BACKEND_MODEL_LIMITS: Record<string, SupportedResponsesModelLimits> = {
   "gpt-5.4": { contextWindow: 272_000, maxTokens: 128_000 },
   "gpt-5.4-mini": { contextWindow: 272_000, maxTokens: 128_000 },
+  "gpt-5.5": { contextWindow: 400_000, maxTokens: 128_000 },
 };
 
 type ResolvedOpenAiResponsesModel = {

--- a/src/session/pricing.ts
+++ b/src/session/pricing.ts
@@ -134,6 +134,11 @@ const BASE_PRICING_TABLE: Record<string, ModelPricing> = {
   },
 
   // ── OpenAI ───────────────────────────────────────────────────────────
+  "openai:gpt-5.5": {
+    inputPerMillion: 5,
+    outputPerMillion: 30,
+    cachedInputPerMillion: 0.5,
+  },
   "openai:gpt-5.4": {
     inputPerMillion: 2.5,
     outputPerMillion: 15,
@@ -161,6 +166,11 @@ const BASE_PRICING_TABLE: Record<string, ModelPricing> = {
   },
 
   // ── Codex CLI (same pricing as OpenAI) ───────────────────────────────
+  "codex-cli:gpt-5.5": {
+    inputPerMillion: 5,
+    outputPerMillion: 30,
+    cachedInputPerMillion: 0.5,
+  },
   "codex-cli:gpt-5.4": {
     inputPerMillion: 2.5,
     outputPerMillion: 15,

--- a/test/runtime.pi-runtime.test.ts
+++ b/test/runtime.pi-runtime.test.ts
@@ -238,6 +238,21 @@ describe("pi runtime regressions", () => {
     expect(resolved.model.maxTokens).toBe(128000);
   });
 
+  test("openai responses model resolution keeps supported token limits for gpt-5.5", async () => {
+    const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-runtime-openai-gpt55-"));
+    const config = makeConfig(homeDir, {
+      provider: "openai",
+      model: "gpt-5.5",
+      preferredChildModel: "gpt-5.5",
+    });
+
+    const resolved = await resolveOpenAiResponsesModel(makeParams(config));
+
+    expect(resolved.model.api).toBe("openai-responses");
+    expect(resolved.model.contextWindow).toBe(1050000);
+    expect(resolved.model.maxTokens).toBe(128000);
+  });
+
   test("openai responses model resolution keeps supported token limits for gpt-5.4-mini", async () => {
     const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-runtime-openai-gpt54mini-"));
     const config = makeConfig(homeDir, {
@@ -607,6 +622,35 @@ describe("pi runtime regressions", () => {
     expect(resolved.apiKey).toBe("sk-codex");
     expect(resolved.model.api).toBe("openai-responses");
     expect(resolved.model.baseUrl).toBe("https://api.openai.com/v1");
+    expect(resolved.model.contextWindow).toBe(400000);
+    expect(resolved.model.maxTokens).toBe(128000);
+  });
+
+  test("codex runtime model resolution keeps codex backend token limits for gpt-5.5", async () => {
+    const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-runtime-codex-gpt55-"));
+    const paths = getAiCoworkerPaths({ homedir: homeDir });
+    const workspaceDir = path.join(homeDir, "workspace");
+    await fs.mkdir(workspaceDir, { recursive: true });
+
+    await writeCodexAuthMaterial(paths, {
+      accessToken: "tok_live",
+      refreshToken: "refresh_live",
+      expiresAtMs: Date.now() + 10 * 60_000,
+      issuer: "https://auth.example.invalid",
+      clientId: "client-id",
+    });
+
+    const config = makeConfig(homeDir, {
+      provider: "codex-cli",
+      model: "gpt-5.5",
+      preferredChildModel: "gpt-5.5",
+      userAgentDir: path.join(workspaceDir, ".agent"),
+    });
+
+    const resolved = await resolveOpenAiResponsesModel(makeParams(config));
+
+    expect(resolved.model.api).toBe("openai-codex-responses");
+    expect(resolved.model.baseUrl).toBe(CODEX_BACKEND_BASE_URL);
     expect(resolved.model.contextWindow).toBe(400000);
     expect(resolved.model.maxTokens).toBe(128000);
   });

--- a/test/session/pricing.test.ts
+++ b/test/session/pricing.test.ts
@@ -33,6 +33,14 @@ describe("pricing", () => {
       expect(pricing!.cachedInputPerMillion).toBe(0.075);
     });
 
+    it("resolves exact match for openai gpt-5.5 pricing", () => {
+      const pricing = resolveModelPricing("openai", "gpt-5.5");
+      expect(pricing).not.toBeNull();
+      expect(pricing!.inputPerMillion).toBe(5);
+      expect(pricing!.outputPerMillion).toBe(30);
+      expect(pricing!.cachedInputPerMillion).toBe(0.5);
+    });
+
     it("resolves exact match for google model", () => {
       const pricing = resolveModelPricing("google", "gemini-3-flash-preview");
       expect(pricing).not.toBeNull();
@@ -148,6 +156,14 @@ describe("pricing", () => {
       expect(pricing!.inputPerMillion).toBe(2.5);
       expect(pricing!.outputPerMillion).toBe(15);
       expect(pricing!.cachedInputPerMillion).toBe(0.25);
+    });
+
+    it("resolves exact match for codex-cli gpt-5.5 pricing", () => {
+      const pricing = resolveModelPricing("codex-cli", "gpt-5.5");
+      expect(pricing).not.toBeNull();
+      expect(pricing!.inputPerMillion).toBe(5);
+      expect(pricing!.outputPerMillion).toBe(30);
+      expect(pricing!.cachedInputPerMillion).toBe(0.5);
     });
 
     it("resolves exact match for codex-cli gpt-5.4-mini pricing", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add GPT-5.5 registry entries for OpenAI and Codex CLI.
- Add GPT-5.5 runtime limits with OpenAI API at 1,050,000 context and Codex backend at 400,000 context.
- Add GPT-5.5 pricing entries and regression coverage for pricing and runtime model resolution.

## Testing
- `bun test test/models.registry.test.ts test/session/pricing.test.ts test/runtime.pi-runtime.test.ts` passed.
- `bun run typecheck` passed.
- `bun run docs:check` passed.
- `bun test --max-concurrency 1` ran 3427 tests: 3420 passed, 3 skipped, and 4 existing desktop IPC tests failed only in the full-suite order due Electron module mocking; `bun test apps/desktop/test/ipc-files.test.ts` passed in isolation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2f11ccf3-3a31-41ae-9c4a-9c9b082589ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2f11ccf3-3a31-41ae-9c4a-9c9b082589ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

