### PR TITLE
fix: align desktop feature flag fallback defaults

### DIFF
--- a/apps/desktop/src/lib/desktopCommands.ts
+++ b/apps/desktop/src/lib/desktopCommands.ts
@@ -3,6 +3,7 @@ import type {
   DesktopFeatureFlagOverrides,
   DesktopFeatureFlags,
 } from "../../../../src/shared/featureFlags";
+import { resolveFeatureFlags } from "../../../../src/shared/featureFlags";
 import type { HydratedTranscriptSnapshot, PersistedState, TranscriptEvent } from "../app/types";
 import type {
   ConfirmActionInput,
@@ -30,14 +31,7 @@ function requireDesktopApi(): DesktopApi {
 }
 
 function getDefaultDesktopFeatureFlags(): DesktopFeatureFlags {
-  return {
-    menuBar: true,
-    remoteAccess: false,
-    workspacePicker: false,
-    workspaceLifecycle: false,
-    a2ui: false,
-    openAiNativeConnectors: false,
-  };
+  return resolveFeatureFlags({ isPackaged: false });
 }
 
 export function getDesktopFeatureFlags(

--- a/apps/desktop/test/desktop-feature-flags.test.ts
+++ b/apps/desktop/test/desktop-feature-flags.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, test } from "bun:test";
+
+import { resolveFeatureFlags } from "../../../src/shared/featureFlags";
+import { getDesktopFeatureFlags } from "../src/lib/desktopCommands";
+
+describe("desktop feature flag bridge fallback", () => {
+  test("matches canonical defaults when the desktop bridge is unavailable", () => {
+    expect(getDesktopFeatureFlags()).toEqual(resolveFeatureFlags({ isPackaged: false }));
+  });
+});

--- a/apps/desktop/test/desktop-feature-flags.test.ts
+++ b/apps/desktop/test/desktop-feature-flags.test.ts
@@ -1,10 +1,36 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import { resolveFeatureFlags } from "../../../src/shared/featureFlags";
-import { getDesktopFeatureFlags } from "../src/lib/desktopCommands";
 
 describe("desktop feature flag bridge fallback", () => {
-  test("matches canonical defaults when the desktop bridge is unavailable", () => {
+  let originalCoworkDescriptor: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    if (typeof window !== "undefined") {
+      originalCoworkDescriptor = Object.getOwnPropertyDescriptor(window, "cowork");
+      Object.defineProperty(window, "cowork", {
+        configurable: true,
+        value: undefined,
+        writable: true,
+      });
+    }
+  });
+
+  afterEach(() => {
+    if (typeof window !== "undefined") {
+      if (originalCoworkDescriptor) {
+        Object.defineProperty(window, "cowork", originalCoworkDescriptor);
+      } else {
+        delete window.cowork;
+      }
+    }
+  });
+
+  test("matches canonical defaults when the desktop bridge is unavailable", async () => {
+    const { getDesktopFeatureFlags } = await import(
+      "../src/lib/desktopCommands.ts?desktop-feature-flags-test"
+    );
+
     expect(getDesktopFeatureFlags()).toEqual(resolveFeatureFlags({ isPackaged: false }));
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Fix the desktop renderer fallback feature flags to use the canonical shared defaults instead of a duplicated stale object.
- Add an isolated regression test for the no-bridge fallback path.

## Testing
- `bun test apps/desktop/test/desktop-feature-flags.test.ts` reproduced the mismatch before the fix and passes after the fix.
- `bun test --max-concurrency 1`
- `bun run typecheck`
- `bun run docs:check`

## Notes
- Recent PR scan also surfaced lower-confidence/documentation-oriented candidates, but this was the smallest high-confidence runtime bug with a direct reproduction.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-617812c0-bbde-48f5-bf95-03c014f1472c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-617812c0-bbde-48f5-bf95-03c014f1472c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

