### PR TITLE
fix: update PI runtime dependency

### DIFF
--- a/apps/desktop/test/ipc-files.test.ts
+++ b/apps/desktop/test/ipc-files.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 
 import { DESKTOP_IPC_CHANNELS } from "../src/lib/desktopApi";
+import { createElectronMock } from "./helpers/mockElectron";
 
 const showSaveDialogMock = mock(async () => ({
   canceled: true,
@@ -15,7 +16,7 @@ let filesModuleImportNonce = 0;
 
 async function loadRegisterFilesIpc() {
   mock.restore();
-  mock.module("electron", () => ({
+  mock.module("electron", () => createElectronMock({
     app: {
       getPath(name: string) {
         return getDownloadsPathMock(name);

--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,7 @@
         "@aws-sdk/client-bedrock-runtime": "^3.1037.0",
         "@google/genai": "^1.50.1",
         "@langfuse/otel": "^4.6.1",
-        "@mariozechner/pi-ai": "^0.67.68",
+        "@mariozechner/pi-ai": "^0.70.2",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@mozilla/readability": "^0.6.0",
         "@opentelemetry/api": "^1.9.1",
@@ -416,7 +416,7 @@
 
     "@malept/flatpak-bundler": ["@malept/flatpak-bundler@0.4.0", "", { "dependencies": { "debug": "^4.1.1", "fs-extra": "^9.0.0", "lodash": "^4.17.15", "tmp-promise": "^3.0.2" } }, "sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q=="],
 
-    "@mariozechner/pi-ai": ["@mariozechner/pi-ai@0.67.68", "", { "dependencies": { "@anthropic-ai/sdk": "^0.90.0", "@aws-sdk/client-bedrock-runtime": "^3.1030.0", "@google/genai": "^1.40.0", "@mistralai/mistralai": "^2.2.0", "@sinclair/typebox": "^0.34.41", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "chalk": "^5.6.2", "openai": "6.26.0", "partial-json": "^0.1.7", "proxy-agent": "^6.5.0", "undici": "^7.19.1", "zod-to-json-schema": "^3.24.6" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-DWWQmcb3IV3mbGXmzYBScfKA6kA52n/stY029eiBikrIxVT7DGLG6n7KSvTA2R4qBSgi1iFL3nGHtwxmtIn6Lg=="],
+    "@mariozechner/pi-ai": ["@mariozechner/pi-ai@0.70.2", "", { "dependencies": { "@anthropic-ai/sdk": "^0.90.0", "@aws-sdk/client-bedrock-runtime": "^3.1030.0", "@google/genai": "^1.40.0", "@mistralai/mistralai": "^2.2.0", "chalk": "^5.6.2", "openai": "6.26.0", "partial-json": "^0.1.7", "proxy-agent": "^6.5.0", "typebox": "^1.1.24", "undici": "^7.19.1", "zod-to-json-schema": "^3.24.6" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-+30LRPjXsXF+oI96DvGWMbdPGeqoLJvadh6UPev7wx2DzhC9FEqXkQcoMZ0usbCm7E9pl8ua8a9s/pQ5ikaUbg=="],
 
     "@mermaid-js/parser": ["@mermaid-js/parser@1.1.0", "", { "dependencies": { "langium": "^4.0.0" } }, "sha512-gxK9ZX2+Fex5zu8LhRQoMeMPEHbc73UKZ0FQ54YrQtUxE1VVhMwzeNtKRPAu5aXks4FasbMe4xB4bWrmq6Jlxw=="],
 
@@ -643,8 +643,6 @@
     "@shikijs/types": ["@shikijs/types@3.23.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ=="],
 
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
-
-    "@sinclair/typebox": ["@sinclair/typebox@0.34.48", "", {}, "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA=="],
 
     "@sindresorhus/is": ["@sindresorhus/is@4.6.0", "", {}, "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw=="],
 
@@ -2358,6 +2356,8 @@
 
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
+    "typebox": ["typebox@1.1.34", "", {}, "sha512-V0fM5W5DTXlEMDxqtX1dQ25HR1RQ11DPUVrIup4sJi1yQtIyI30SHfxBy/HjXKL1CtUqc5or2igA/wa/v4hMKQ=="],
+
     "typed-query-selector": ["typed-query-selector@2.12.1", "", {}, "sha512-uzR+FzI8qrUEIu96oaeBJmd9E7CFEiQ3goA5qCVgc4s5llSubcfGHq9yUstZx/k4s9dXHVKsE35YWoFyvEqEHA=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
@@ -2599,8 +2599,6 @@
     "@isaacs/fs-minipass/minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
     "@malept/flatpak-bundler/fs-extra": ["fs-extra@9.1.0", "", { "dependencies": { "at-least-node": "^1.0.0", "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ=="],
-
-    "@mariozechner/pi-ai/@aws-sdk/client-bedrock-runtime": ["@aws-sdk/client-bedrock-runtime@3.1035.0", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.4", "@aws-sdk/credential-provider-node": "^3.972.35", "@aws-sdk/eventstream-handler-node": "^3.972.14", "@aws-sdk/middleware-eventstream": "^3.972.10", "@aws-sdk/middleware-host-header": "^3.972.10", "@aws-sdk/middleware-logger": "^3.972.10", "@aws-sdk/middleware-recursion-detection": "^3.972.11", "@aws-sdk/middleware-user-agent": "^3.972.34", "@aws-sdk/middleware-websocket": "^3.972.16", "@aws-sdk/region-config-resolver": "^3.972.13", "@aws-sdk/token-providers": "3.1035.0", "@aws-sdk/types": "^3.973.8", "@aws-sdk/util-endpoints": "^3.996.8", "@aws-sdk/util-user-agent-browser": "^3.972.10", "@aws-sdk/util-user-agent-node": "^3.973.20", "@smithy/config-resolver": "^4.4.17", "@smithy/core": "^3.23.16", "@smithy/eventstream-serde-browser": "^4.2.14", "@smithy/eventstream-serde-config-resolver": "^4.3.14", "@smithy/eventstream-serde-node": "^4.2.14", "@smithy/fetch-http-handler": "^5.3.17", "@smithy/hash-node": "^4.2.14", "@smithy/invalid-dependency": "^4.2.14", "@smithy/middleware-content-length": "^4.2.14", "@smithy/middleware-endpoint": "^4.4.31", "@smithy/middleware-retry": "^4.5.4", "@smithy/middleware-serde": "^4.2.19", "@smithy/middleware-stack": "^4.2.14", "@smithy/node-config-provider": "^4.3.14", "@smithy/node-http-handler": "^4.6.0", "@smithy/protocol-http": "^5.3.14", "@smithy/smithy-client": "^4.12.12", "@smithy/types": "^4.14.1", "@smithy/url-parser": "^4.2.14", "@smithy/util-base64": "^4.3.2", "@smithy/util-body-length-browser": "^4.2.2", "@smithy/util-body-length-node": "^4.2.3", "@smithy/util-defaults-mode-browser": "^4.3.48", "@smithy/util-defaults-mode-node": "^4.2.53", "@smithy/util-endpoints": "^3.4.2", "@smithy/util-middleware": "^4.2.14", "@smithy/util-retry": "^4.3.3", "@smithy/util-stream": "^4.5.24", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-XELIQk+znh53J2Bj0EmOftgcKRLw3tvI/P4WHLgSbSBWPh+wg0SvHu+bgIlzMHARbOC9auA0lsH+Eb9JwF1yjA=="],
 
     "@npmcli/agent/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
@@ -2875,8 +2873,6 @@
     "@isaacs/cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
-
-    "@mariozechner/pi-ai/@aws-sdk/client-bedrock-runtime/@smithy/util-stream": ["@smithy/util-stream@4.5.24", "", { "dependencies": { "@smithy/fetch-http-handler": "^5.3.17", "@smithy/node-http-handler": "^4.6.0", "@smithy/types": "^4.14.1", "@smithy/util-base64": "^4.3.2", "@smithy/util-buffer-from": "^4.2.2", "@smithy/util-hex-encoding": "^4.2.2", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-na5vv2mBSDzXewLEEoWGI7LQQkfpmFEomBsmOpzLFjqGctm0iMwXY5lAwesY9pIaErkccW0qzEOUcYP+WKneXg=="],
 
     "@opentelemetry/otlp-transformer/protobufjs/@types/node": ["@types/node@25.2.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ=="],
 

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@aws-sdk/client-bedrock-runtime": "^3.1037.0",
     "@google/genai": "^1.50.1",
     "@langfuse/otel": "^4.6.1",
-    "@mariozechner/pi-ai": "^0.67.68",
+    "@mariozechner/pi-ai": "^0.70.2",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@mozilla/readability": "^0.6.0",
     "@opentelemetry/api": "^1.9.1",

--- a/src/providers/bedrockShared.ts
+++ b/src/providers/bedrockShared.ts
@@ -53,6 +53,7 @@ type BedrockClientConfig = {
     sessionToken?: string;
   };
   token?: { token: string };
+  bearerToken?: string;
 };
 
 type CachedBedrockModel = ProviderCatalogModelEntry & {
@@ -298,6 +299,7 @@ export function bedrockClientConfig(
     };
   }
   if (auth.methodId === "api_key" && auth.apiKey) {
+    config.bearerToken = auth.apiKey;
     config.token = { token: auth.apiKey };
   }
   return config;

--- a/src/runtime/bedrockProviderModule.ts
+++ b/src/runtime/bedrockProviderModule.ts
@@ -51,16 +51,33 @@ export const streamBedrock = (model, context, options = {}) => {
     const config = {
       profile: options.profile,
       ...(options.credentials ? { credentials: options.credentials } : {}),
-      ...(options.token ? { token: options.token } : {}),
-      ...(options.token ? { authSchemePreference: ["httpBearerAuth"] } : {}),
     };
+    const configuredRegion = getConfiguredBedrockRegion(options);
+    const hasConfiguredProfile = hasConfiguredBedrockProfile(options);
+    const endpointRegion = getStandardBedrockEndpointRegion(model.baseUrl);
+    const useExplicitEndpoint = shouldUseExplicitBedrockEndpoint(
+      model.baseUrl,
+      configuredRegion,
+      hasConfiguredProfile,
+    );
+    if (useExplicitEndpoint) {
+      config.endpoint = model.baseUrl;
+    }
+
+    const bearerToken =
+      options.bearerToken ||
+      options.token?.token ||
+      (typeof process !== "undefined" ? process.env.AWS_BEARER_TOKEN_BEDROCK : undefined);
+    const useBearerToken =
+      bearerToken !== undefined &&
+      (typeof process === "undefined" || process.env.AWS_BEDROCK_SKIP_AUTH !== "1");
 
     if (typeof process !== "undefined" && (process.versions?.node || process.versions?.bun)) {
-      const explicitRegion =
-        options.region || process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION;
-      if (explicitRegion) {
-        config.region = explicitRegion;
-      } else if (!process.env.AWS_PROFILE && !options.profile) {
+      if (configuredRegion) {
+        config.region = configuredRegion;
+      } else if (endpointRegion && useExplicitEndpoint) {
+        config.region = endpointRegion;
+      } else if (!hasConfiguredProfile) {
         config.region = "us-east-1";
       }
       if (process.env.AWS_BEDROCK_SKIP_AUTH === "1") {
@@ -89,7 +106,13 @@ export const streamBedrock = (model, context, options = {}) => {
         config.requestHandler = new nodeHttpHandler.NodeHttpHandler();
       }
     } else {
-      config.region = options.region || "us-east-1";
+      config.region =
+        configuredRegion || (endpointRegion && useExplicitEndpoint ? endpointRegion : undefined) || "us-east-1";
+    }
+
+    if (useBearerToken) {
+      config.token = { token: bearerToken };
+      config.authSchemePreference = ["httpBearerAuth"];
     }
 
     try {
@@ -99,7 +122,10 @@ export const streamBedrock = (model, context, options = {}) => {
         modelId: model.id,
         messages: convertMessages(context, model, cacheRetention),
         system: buildSystemPrompt(context.systemPrompt, model, cacheRetention),
-        inferenceConfig: { maxTokens: options.maxTokens, temperature: options.temperature },
+        inferenceConfig: {
+          ...(options.maxTokens !== undefined ? { maxTokens: options.maxTokens } : {}),
+          ...(options.temperature !== undefined ? { temperature: options.temperature } : {}),
+        },
         toolConfig: convertToolConfig(context.tools, options.toolChoice),
         additionalModelRequestFields: buildAdditionalModelRequestFields(model, options),
         ...(options.requestMetadata !== undefined
@@ -112,6 +138,16 @@ export const streamBedrock = (model, context, options = {}) => {
       }
       const command = new ConverseStreamCommand(commandInput);
       const response = await client.send(command, { abortSignal: options.signal });
+      if (response.$metadata.httpStatusCode !== undefined) {
+        const responseHeaders = {};
+        if (response.$metadata.requestId) {
+          responseHeaders["x-amzn-requestid"] = response.$metadata.requestId;
+        }
+        await options?.onResponse?.(
+          { status: response.$metadata.httpStatusCode, headers: responseHeaders },
+          model,
+        );
+      }
       for await (const item of response.stream) {
         if (item.messageStart) {
           if (item.messageStart.role !== ConversationRole.ASSISTANT) {
@@ -193,6 +229,7 @@ export const streamSimpleBedrock = (model, context, options) => {
       ...(options?.token ? { token: options.token } : {}),
       ...(options?.toolChoice ? { toolChoice: options.toolChoice } : {}),
       ...(options?.requestMetadata ? { requestMetadata: options.requestMetadata } : {}),
+      ...(options?.thinkingDisplay ? { thinkingDisplay: options.thinkingDisplay } : {}),
       ...(options?.interleavedThinking !== undefined
         ? { interleavedThinking: options.interleavedThinking }
         : {}),
@@ -210,6 +247,7 @@ export const streamSimpleBedrock = (model, context, options) => {
         ...(options?.token ? { token: options.token } : {}),
         ...(options?.toolChoice ? { toolChoice: options.toolChoice } : {}),
         ...(options?.requestMetadata ? { requestMetadata: options.requestMetadata } : {}),
+        ...(options?.thinkingDisplay ? { thinkingDisplay: options.thinkingDisplay } : {}),
         ...(options?.interleavedThinking !== undefined
           ? { interleavedThinking: options.interleavedThinking }
           : {}),
@@ -235,6 +273,7 @@ export const streamSimpleBedrock = (model, context, options) => {
       ...(options?.token ? { token: options.token } : {}),
       ...(options?.toolChoice ? { toolChoice: options.toolChoice } : {}),
       ...(options?.requestMetadata ? { requestMetadata: options.requestMetadata } : {}),
+      ...(options?.thinkingDisplay ? { thinkingDisplay: options.thinkingDisplay } : {}),
       ...(options?.interleavedThinking !== undefined
         ? { interleavedThinking: options.interleavedThinking }
         : {}),
@@ -250,6 +289,7 @@ export const streamSimpleBedrock = (model, context, options) => {
     ...(options?.token ? { token: options.token } : {}),
     ...(options?.toolChoice ? { toolChoice: options.toolChoice } : {}),
     ...(options?.requestMetadata ? { requestMetadata: options.requestMetadata } : {}),
+    ...(options?.thinkingDisplay ? { thinkingDisplay: options.thinkingDisplay } : {}),
     ...(options?.interleavedThinking !== undefined
       ? { interleavedThinking: options.interleavedThinking }
       : {}),
@@ -372,6 +412,8 @@ function supportsAdaptiveThinking(modelId) {
   return (
     modelId.includes("opus-4-6") ||
     modelId.includes("opus-4.6") ||
+    modelId.includes("opus-4-7") ||
+    modelId.includes("opus-4.7") ||
     modelId.includes("sonnet-4-6") ||
     modelId.includes("sonnet-4.6")
   );
@@ -387,7 +429,13 @@ function mapThinkingLevelToEffort(level, modelId) {
     case "high":
       return "high";
     case "xhigh":
-      return modelId.includes("opus-4-6") || modelId.includes("opus-4.6") ? "max" : "high";
+      if (modelId.includes("opus-4-6") || modelId.includes("opus-4.6")) {
+        return "max";
+      }
+      if (modelId.includes("opus-4-7") || modelId.includes("opus-4.7")) {
+        return "xhigh";
+      }
+      return "high";
     default:
       return "high";
   }
@@ -613,14 +661,66 @@ function mapStopReason(reason) {
   }
 }
 
+function getConfiguredBedrockRegion(options) {
+  if (typeof process === "undefined") {
+    return options.region;
+  }
+  return options.region || process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION || undefined;
+}
+
+function hasConfiguredBedrockProfile(options) {
+  if (options.profile) {
+    return true;
+  }
+  if (typeof process === "undefined") {
+    return false;
+  }
+  return Boolean(process.env.AWS_PROFILE);
+}
+
+function getStandardBedrockEndpointRegion(baseUrl) {
+  if (!baseUrl) {
+    return undefined;
+  }
+  try {
+    const { hostname } = new URL(baseUrl);
+    const match = hostname
+      .toLowerCase()
+      .match(/^bedrock-runtime(?:-fips)?\.([a-z0-9-]+)\.amazonaws\.com(?:\.cn)?$/);
+    return match?.[1];
+  } catch {
+    return undefined;
+  }
+}
+
+function shouldUseExplicitBedrockEndpoint(baseUrl, configuredRegion, hasConfiguredProfile) {
+  const endpointRegion = getStandardBedrockEndpointRegion(baseUrl);
+  if (!endpointRegion) {
+    return true;
+  }
+  return !configuredRegion && !hasConfiguredProfile;
+}
+
+function isGovCloudBedrockTarget(model, options) {
+  const region = getConfiguredBedrockRegion(options);
+  if (region?.toLowerCase().startsWith("us-gov-")) {
+    return true;
+  }
+  const modelId = model.id.toLowerCase();
+  return modelId.startsWith("us-gov.") || modelId.startsWith("arn:aws-us-gov:");
+}
+
 function buildAdditionalModelRequestFields(model, options) {
   if (!options.reasoning || !model.reasoning) {
     return undefined;
   }
   if (model.id.includes("anthropic.claude") || model.id.includes("anthropic/claude")) {
+    const display = isGovCloudBedrockTarget(model, options)
+      ? undefined
+      : (options.thinkingDisplay ?? "summarized");
     const result = supportsAdaptiveThinking(model.id)
       ? {
-          thinking: { type: "adaptive" },
+          thinking: { type: "adaptive", ...(display !== undefined ? { display } : {}) },
           output_config: { effort: mapThinkingLevelToEffort(options.reasoning, model.id) },
         }
       : (() => {
@@ -637,6 +737,7 @@ function buildAdditionalModelRequestFields(model, options) {
             thinking: {
               type: "enabled",
               budget_tokens: budget,
+              ...(display !== undefined ? { display } : {}),
             },
           };
         })();

--- a/src/runtime/piRuntimeOptions.ts
+++ b/src/runtime/piRuntimeOptions.ts
@@ -192,6 +192,9 @@ export function buildPiStreamOptions(
     const reasoning = asNonEmptyString(providerSection.reasoning);
     if (reasoning) options.reasoning = reasoning;
 
+    const thinkingDisplay = asNonEmptyString(providerSection.thinkingDisplay);
+    if (thinkingDisplay) options.thinkingDisplay = thinkingDisplay;
+
     const thinkingBudgets = asRecord(providerSection.thinkingBudgets);
     if (thinkingBudgets) {
       const minimalBudget = asFiniteNumber(thinkingBudgets.minimal);

--- a/test/providers/bedrock-shared.test.ts
+++ b/test/providers/bedrock-shared.test.ts
@@ -80,6 +80,21 @@ describe("providers/bedrockShared", () => {
     expect(typeof client.config.credentialDefaultProvider).toBe("function");
   });
 
+  test("maps saved Bedrock API keys to PI bearer token options", () => {
+    expect(
+      bedrockClientConfig({
+        methodId: "api_key",
+        source: "saved",
+        apiKey: "bedrock-api-key-1234",
+        region: "us-west-2",
+      }),
+    ).toEqual({
+      bearerToken: "bedrock-api-key-1234",
+      token: { token: "bedrock-api-key-1234" },
+      region: "us-west-2",
+    });
+  });
+
   test("does not force a default region for saved aws_default auth", async () => {
     const home = await makeTmpHome();
     const paths = getAiCoworkerPaths({ homedir: home });

--- a/test/runtime.pi-options.test.ts
+++ b/test/runtime.pi-options.test.ts
@@ -187,6 +187,7 @@ describe("pi runtime provider option mapping", () => {
               environment: "dev",
               team: "core",
             },
+            thinkingDisplay: "omitted",
             temperature: 0.3,
             maxTokens: 2048,
           },
@@ -202,6 +203,7 @@ describe("pi runtime provider option mapping", () => {
     expect(mapped.thinkingBudgets).toEqual({ low: 1024, medium: 4096 });
     expect(mapped.interleavedThinking).toBe(false);
     expect(mapped.requestMetadata).toEqual({ environment: "dev", team: "core" });
+    expect(mapped.thinkingDisplay).toBe("omitted");
     expect(mapped.temperature).toBe(0.3);
     expect(mapped.maxTokens).toBe(2048);
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Update `@mariozechner/pi-ai` to `0.70.2`.
- Align the Cowork Bedrock PI provider override with the updated PI Bedrock behavior while preserving saved credential handling.
- Add regression coverage for Bedrock bearer-token option mapping and `thinkingDisplay` stream options.
- Isolate the desktop files IPC Electron mock so the full Bun suite no longer leaks a partial Electron mock into quick-chat tests.

## Testing
- `bun test test/runtime.pi-options.test.ts test/providers/bedrock-shared.test.ts test/runtime.pi-runtime.test.ts test/runtime.pi-message-bridge.test.ts test/runtime.selection.test.ts`
- `bun test apps/desktop/test/ipc-files.test.ts apps/desktop/test/quick-chat-controller.test.ts --max-concurrency 1`
- `bun test --max-concurrency 1`
- `bun run typecheck`
- `bun run docs:check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-42b2808d-6f76-43ee-b7d9-4b946d30ae17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-42b2808d-6f76-43ee-b7d9-4b946d30ae17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

