### PR TITLE
fix: load reflect metadata in server sidecar

### DIFF
--- a/apps/desktop/electron/services/appearance.ts
+++ b/apps/desktop/electron/services/appearance.ts
@@ -98,9 +98,7 @@ export function syncWindowAppearance(
     platform,
   });
 
-  if (platform !== "linux") {
-    win.setBackgroundColor(backgroundColor);
-  }
+  win.setBackgroundColor(backgroundColor);
 
   if (backgroundMaterial) {
     setWindowBackgroundMaterial(win, backgroundMaterial, platform);

--- a/apps/desktop/test/helpers/mockElectron.ts
+++ b/apps/desktop/test/helpers/mockElectron.ts
@@ -71,6 +71,18 @@ const defaultDialog = {
   },
 };
 
+const defaultNativeTheme = {
+  themeSource: "system",
+  shouldUseDarkColors: false,
+  shouldUseDarkColorsForSystemIntegratedUI: false,
+  shouldUseHighContrastColors: false,
+  shouldUseInvertedColorScheme: false,
+  prefersReducedTransparency: false,
+  inForcedColorsMode: false,
+  on() {},
+  off() {},
+};
+
 class DefaultTray {
   setToolTip() {}
 
@@ -131,6 +143,9 @@ const electronMock = {
   },
   get dialog() {
     return mergeMock(defaultDialog, "dialog");
+  },
+  get nativeTheme() {
+    return mergeMock(defaultNativeTheme, "nativeTheme");
   },
 };
 

--- a/apps/desktop/test/window-appearance-sync.test.ts
+++ b/apps/desktop/test/window-appearance-sync.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { BrowserWindow } from "electron";
+
+import { createElectronMock } from "./helpers/mockElectron";
+
+mock.module("electron", () => createElectronMock());
+
+const { syncWindowAppearance } = await import("../electron/services/appearance");
+
+function createWindowStub() {
+  return {
+    backgroundColorCalls: [] as string[],
+    backgroundMaterialCalls: [] as unknown[],
+    titleBarOverlayCalls: [] as unknown[],
+    setBackgroundColor(color: string) {
+      this.backgroundColorCalls.push(color);
+    },
+    setBackgroundMaterial(material: unknown) {
+      this.backgroundMaterialCalls.push(material);
+    },
+    setTitleBarOverlay(overlay: unknown) {
+      this.titleBarOverlayCalls.push(overlay);
+    },
+  };
+}
+
+describe("syncWindowAppearance", () => {
+  test("applies the resolved solid shell background on Linux", () => {
+    const win = createWindowStub();
+
+    syncWindowAppearance(win as unknown as BrowserWindow, {
+      platform: "linux",
+      useDarkColors: false,
+    });
+
+    expect(win.backgroundColorCalls).toEqual(["#dfe2cc"]);
+    expect(win.backgroundMaterialCalls).toEqual([]);
+    expect(win.titleBarOverlayCalls).toEqual([
+      {
+        color: "#00000000",
+        symbolColor: "#556041",
+        height: 48,
+      },
+    ]);
+  });
+});

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env bun
 
+import "reflect-metadata";
+
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";

--- a/test/server-entrypoint-bootstrap.test.ts
+++ b/test/server-entrypoint-bootstrap.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from "bun:test";
+import fs from "node:fs/promises";
+
+test("server entrypoint loads reflect metadata before sidecar server imports", async () => {
+  const source = await fs.readFile(new URL("../src/server/index.ts", import.meta.url), "utf8");
+
+  const reflectImportIndex = source.indexOf('import "reflect-metadata";');
+  const startServerImportIndex = source.indexOf('import("./startServer")');
+
+  expect(reflectImportIndex).toBeGreaterThanOrEqual(0);
+  expect(startServerImportIndex).toBeGreaterThanOrEqual(0);
+  expect(reflectImportIndex).toBeLessThan(startServerImportIndex);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Load `reflect-metadata` at the server entrypoint so the Linux packaged sidecar initializes `@peculiar/x509`/`tsyringe` correctly.
- Paint the resolved solid shell background during Linux window appearance sync so hidden-titlebar windows do not show compositor transparency.
- Add regression tests for server bootstrap ordering and Linux window background sync.

## Walkthrough
[linux_desktop_onboarding_fixed.mp4](https://cursor.com/agents/bc-b069aaf8-485d-49e4-8d80-3f7040e16fe9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flinux_desktop_onboarding_fixed.mp4)

## Testing
- `bun test test/server-entrypoint-bootstrap.test.ts apps/desktop/test/window-appearance-sync.test.ts apps/desktop/test/window-appearance-paint.test.ts apps/desktop/test/window-enhancements.test.ts` passed.
- `bun run desktop:build` passed and produced Linux AppImage/deb artifacts.
- Packaged Linux smoke passed via `linux-unpacked` and AppImage `APPIMAGE_EXTRACT_AND_RUN=1`, including server listening, prompt load, and turn completion.
- Live packaged Linux app walkthrough passed; onboarding advances from welcome to add workspace with an opaque window background.
- `bun run typecheck` passed.
- `bun run docs:check` passed.
- `bun test --max-concurrency 1` has an unrelated existing failure in `apps/desktop/test/dialog-component.test.tsx`: the test expects `bg-background`, while the current dialog component renders `bg-popover`. Backup-page failures from the full run passed when rerun with the failing files.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b069aaf8-485d-49e4-8d80-3f7040e16fe9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b069aaf8-485d-49e4-8d80-3f7040e16fe9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

