### PR TITLE
fix: handle codex image attachments

### DIFF
--- a/apps/desktop/src/components/ai-elements/prompt-input.tsx
+++ b/apps/desktop/src/components/ai-elements/prompt-input.tsx
@@ -157,7 +157,7 @@ export function PromptInputAttachmentPreviews({
           return (
             <div
               key={`${item.filename}:${item.mimeType}:${item.previewUrl ?? ""}`}
-              className="group inline-flex min-w-0 max-w-full items-center gap-2 rounded-full border border-border/55 bg-background/70 py-1 pl-1.5 pr-1 text-sm shadow-[inset_0_1px_0_var(--border-glass)]"
+              className="group inline-flex min-w-0 max-w-full items-center gap-2 overflow-hidden rounded-full border border-border/55 bg-background/70 py-1 pl-1.5 pr-1 text-sm shadow-[inset_0_1px_0_var(--border-glass)]"
             >
               <div className="flex size-6 shrink-0 items-center justify-center overflow-hidden rounded-full bg-muted/45 ring-1 ring-border/40">
                 {src ? (
@@ -166,9 +166,9 @@ export function PromptInputAttachmentPreviews({
                   attachmentPreviewIcon(item)
                 )}
               </div>
-              <div className="flex min-w-0 items-center gap-1.5">
+              <div className="flex min-w-0 flex-1 items-center gap-1.5 overflow-hidden">
                 <p
-                  className="max-w-[18rem] truncate text-[13px] font-medium leading-5 text-foreground/88"
+                  className="min-w-0 flex-1 truncate text-[13px] font-medium leading-5 text-foreground/88"
                   title={item.filename}
                 >
                   {item.filename}

--- a/apps/desktop/src/ui/chat/ChatComposer.tsx
+++ b/apps/desktop/src/ui/chat/ChatComposer.tsx
@@ -128,9 +128,11 @@ export function ChatComposer(props: {
             <PromptInputStatusRow>{composerHint}</PromptInputStatusRow>
             <PromptInputBody>
               {attachmentPickerError ? (
-                <div className="flex items-center gap-1.5 px-1 pb-1 text-xs text-destructive">
+                <div className="flex min-w-0 items-start gap-1.5 px-1 pb-1 text-xs text-destructive">
                   <AlertTriangleIcon className="size-3.5 shrink-0" />
-                  <span>{attachmentPickerError}</span>
+                  <span className="min-w-0 break-words [overflow-wrap:anywhere]">
+                    {attachmentPickerError}
+                  </span>
                 </div>
               ) : null}
               <PromptInputTextarea

--- a/apps/desktop/src/ui/chat/FeedRow.tsx
+++ b/apps/desktop/src/ui/chat/FeedRow.tsx
@@ -104,7 +104,7 @@ export const FeedRow = memo(function FeedRow(props: {
                       </div>
                     ) : null}
                     {fileNames.length > 0 && (
-                      <div className="flex flex-wrap gap-2 mt-1">
+                      <div className="flex min-w-0 flex-wrap gap-2 mt-1">
                         {fileNames.map((fileName) => {
                           const isAudio = /\.(mp3|wav|ogg|m4a|aac|flac)$/i.test(fileName);
                           const isImage = /\.(png|jpe?g|gif|webp|svg)$/i.test(fileName);
@@ -120,11 +120,11 @@ export const FeedRow = memo(function FeedRow(props: {
                           return (
                             <div
                               key={fileName}
-                              className="inline-flex items-center gap-2 rounded-lg border border-border/40 bg-muted/40 px-2.5 py-1.5 text-xs shadow-sm"
+                              className="inline-flex min-w-0 max-w-full items-center gap-2 overflow-hidden rounded-lg border border-border/40 bg-muted/40 px-2.5 py-1.5 text-xs shadow-sm"
                             >
                               <IconComponent className="size-4 text-muted-foreground shrink-0" />
                               <span
-                                className="font-medium text-foreground truncate max-w-[16rem]"
+                                className="min-w-0 truncate font-medium text-foreground"
                                 title={fileName}
                               >
                                 {fileName}
@@ -192,10 +192,12 @@ export const FeedRow = memo(function FeedRow(props: {
 
   if (item.kind === "error") {
     return (
-      <Card className="max-w-3xl border-destructive/40 bg-destructive/10">
+      <Card className="w-full min-w-0 max-w-3xl overflow-hidden border-destructive/40 bg-destructive/10">
         <CardContent className="select-text p-3 text-sm">
           <div className="mb-1 font-semibold uppercase tracking-wide text-destructive">Error</div>
-          <div>{item.message}</div>
+          <div className="whitespace-pre-wrap break-words [overflow-wrap:anywhere]">
+            {item.message}
+          </div>
         </CardContent>
       </Card>
     );

--- a/apps/desktop/src/ui/chat/NewChatLanding.tsx
+++ b/apps/desktop/src/ui/chat/NewChatLanding.tsx
@@ -304,9 +304,11 @@ export function NewChatLanding() {
             </PromptInputStatusRow>
             <PromptInputBody>
               {attachmentPickerError ? (
-                <div className="flex items-center gap-1.5 px-1 pb-1 text-xs text-destructive">
+                <div className="flex min-w-0 items-start gap-1.5 px-1 pb-1 text-xs text-destructive">
                   <AlertTriangleIcon className="size-3.5 shrink-0" />
-                  <span>{attachmentPickerError}</span>
+                  <span className="min-w-0 break-words [overflow-wrap:anywhere]">
+                    {attachmentPickerError}
+                  </span>
                 </div>
               ) : null}
               <PromptInputTextarea

--- a/src/managedSofficeRuntime/assets/managed-soffice-helper.mjs
+++ b/src/managedSofficeRuntime/assets/managed-soffice-helper.mjs
@@ -151,6 +151,12 @@ function managedSofficePath(version = DEFAULT_LIBREOFFICE_VERSION) {
 
 function candidateSystemSofficePaths() {
   const candidates = [];
+  const pathEntries = (process.env.PATH || "")
+    .split(path.delimiter)
+    .filter((entry) => entry && path.resolve(entry) !== path.resolve(shimDir));
+  for (const entry of pathEntries) {
+    candidates.push(path.join(entry, commandLineSofficeName()));
+  }
   if (process.platform === "darwin") {
     candidates.push("/Applications/LibreOffice.app/Contents/MacOS/soffice");
   } else if (process.platform === "win32") {
@@ -163,12 +169,6 @@ function candidateSystemSofficePaths() {
         candidates.push(path.join(programFilesDir, "LibreOffice", "program", "soffice.com"));
       }
     }
-  }
-  const pathEntries = (process.env.PATH || "")
-    .split(path.delimiter)
-    .filter((entry) => entry && path.resolve(entry) !== path.resolve(shimDir));
-  for (const entry of pathEntries) {
-    candidates.push(path.join(entry, commandLineSofficeName()));
   }
   return [...new Set(candidates)];
 }

--- a/src/runtime/codexAppServer/turnInput.ts
+++ b/src/runtime/codexAppServer/turnInput.ts
@@ -1,6 +1,6 @@
-import { asRecord, asString } from "../../shared/recordParsing";
+import { asFiniteNumber, asRecord, asString } from "../../shared/recordParsing";
 import type { ModelMessage } from "../../types";
-import type { CodexTextElement, CodexTurnInputPart } from "./types";
+import type { CodexImageDetail, CodexTextElement, CodexTurnInputPart } from "./types";
 
 export function extractTextContent(content: unknown): string {
   if (typeof content === "string") return content;
@@ -22,9 +22,7 @@ export function latestUserMessage(messages: readonly ModelMessage[]): ModelMessa
   for (let index = messages.length - 1; index >= 0; index -= 1) {
     const message = messages[index];
     if (message?.role === "user") {
-      const text = extractTextContent(message.content).trim();
-      const hasElements = extractTextElements(message.content).length > 0;
-      if (text || hasElements) return message;
+      if (codexInputPartsForMessage(message, { includeRole: false }).length > 0) return message;
     }
   }
   return null;
@@ -36,44 +34,106 @@ export function extractTextElements(content: unknown): CodexTextElement[] {
   for (const part of content) {
     const record = asRecord(part);
     if (!record) continue;
-    const type = asString(record.type);
-    const mimeType = asString(record.mimeType);
-    const data = asString(record.data);
-    const path = asString(record.path);
-    const filename = asString(record.filename);
-    if (!type && !mimeType && !data && !path && !filename) continue;
-    if (type === "text" || type === "inputText" || type === "output_text") continue;
+    const byteRange = asRecord(record.byteRange);
+    const start = asFiniteNumber(byteRange?.start);
+    const end = asFiniteNumber(byteRange?.end);
+    if (start === undefined || end === undefined) continue;
     elements.push({
-      ...(type ? { type } : { type: "file" }),
-      ...(mimeType ? { mimeType } : {}),
-      ...(data ? { data } : {}),
-      ...(path ? { path } : {}),
-      ...(filename ? { filename } : {}),
+      byteRange: { start, end },
+      placeholder: asString(record.placeholder) ?? null,
     });
   }
   return elements;
 }
 
+function codexImageDetail(value: unknown): CodexImageDetail | undefined {
+  const detail = asString(value);
+  if (detail === "low" || detail === "high" || detail === "original") return detail;
+  return undefined;
+}
+
+function codexImageInputPartForRecord(record: Record<string, unknown>): CodexTurnInputPart | null {
+  const type = asString(record.type);
+  const mimeType = asString(record.mimeType) ?? asString(record.mime_type);
+  const path = asString(record.path);
+  const url = asString(record.url) ?? asString(record.imageUrl) ?? asString(record.image_url);
+  const data = asString(record.data);
+  const detail = codexImageDetail(record.detail);
+  const imageMimeType = mimeType?.toLowerCase().startsWith("image/") ? mimeType : null;
+  const imageTyped = type === "image" || type === "input_image" || type === "inputImage";
+
+  if ((type === "localImage" || type === "local_image" || imageMimeType) && path) {
+    return {
+      type: "localImage",
+      path,
+      ...(detail ? { detail } : {}),
+    };
+  }
+  if (url && (imageTyped || imageMimeType)) {
+    return {
+      type: "image",
+      url,
+      ...(detail ? { detail } : {}),
+    };
+  }
+  if (data && (imageTyped || imageMimeType)) {
+    return {
+      type: "image",
+      url: `data:${imageMimeType ?? "image/png"};base64,${data}`,
+      ...(detail ? { detail } : {}),
+    };
+  }
+  return null;
+}
+
+function extractImageInputParts(content: unknown): CodexTurnInputPart[] {
+  if (!Array.isArray(content)) return [];
+  const parts: CodexTurnInputPart[] = [];
+  for (const part of content) {
+    const record = asRecord(part);
+    if (!record) continue;
+    const imagePart = codexImageInputPartForRecord(record);
+    if (imagePart) parts.push(imagePart);
+  }
+  return parts;
+}
+
+function roleLabel(role: ModelMessage["role"]): string {
+  return role === "user" ? "User" : role === "assistant" ? "Assistant" : String(role || "message");
+}
+
 function codexInputTextForMessage(message: ModelMessage, opts: { includeRole: boolean }): string {
   const text = extractTextContent(message.content).trim();
   if (!opts.includeRole) return text;
-  const role = String(message.role || "message");
-  const label = role === "user" ? "User" : role === "assistant" ? "Assistant" : role;
-  return text ? `${label}: ${text}` : `${label}: [attachment]`;
+  return text ? `${roleLabel(message.role)}: ${text}` : "";
 }
 
-function codexInputPartForMessage(
+function codexInputPartsForMessage(
   message: ModelMessage,
   opts: { includeRole: boolean },
-): CodexTurnInputPart | null {
+): CodexTurnInputPart[] {
   const textElements = extractTextElements(message.content);
   const text = codexInputTextForMessage(message, opts);
-  if (!text && textElements.length === 0) return null;
-  return {
-    type: "text",
-    text: text || "[attachment]",
-    text_elements: textElements,
-  };
+  const imageParts = extractImageInputParts(message.content);
+  if (!text && textElements.length === 0 && imageParts.length === 0) return [];
+
+  const parts: CodexTurnInputPart[] = [];
+  const textForPart =
+    text ||
+    (imageParts.length > 0
+      ? opts.includeRole
+        ? `${roleLabel(message.role)}: [attachment]`
+        : "[attachment]"
+      : "");
+  if (textForPart || textElements.length > 0) {
+    parts.push({
+      type: "text",
+      text: textForPart || "[attachment]",
+      text_elements: textElements,
+    });
+  }
+  parts.push(...imageParts);
+  return parts;
 }
 
 export function buildCodexTurnInput(
@@ -82,11 +142,9 @@ export function buildCodexTurnInput(
 ): CodexTurnInputPart[] {
   if (opts.resumedThread) {
     const latest = latestUserMessage(messages);
-    const part = latest ? codexInputPartForMessage(latest, { includeRole: false }) : null;
-    return part ? [part] : [];
+    return latest ? codexInputPartsForMessage(latest, { includeRole: false }) : [];
   }
-  return messages
-    .filter((message) => message.role !== "system")
-    .map((message) => codexInputPartForMessage(message, { includeRole: true }))
-    .filter((part): part is CodexTurnInputPart => part !== null);
+  return messages.flatMap((message) =>
+    message.role === "system" ? [] : codexInputPartsForMessage(message, { includeRole: true }),
+  );
 }

--- a/src/runtime/codexAppServer/turnInput.ts
+++ b/src/runtime/codexAppServer/turnInput.ts
@@ -120,7 +120,7 @@ function codexInputPartsForMessage(
   const parts: CodexTurnInputPart[] = [];
   const textForPart =
     text ||
-    (imageParts.length > 0
+    (imageParts.length > 0 || textElements.length > 0
       ? opts.includeRole
         ? `${roleLabel(message.role)}: [attachment]`
         : "[attachment]"

--- a/src/runtime/codexAppServer/types.ts
+++ b/src/runtime/codexAppServer/types.ts
@@ -38,11 +38,23 @@ export type CodexSandboxPolicy =
     };
 
 export type CodexTextElement = Record<string, unknown>;
-export type CodexTurnInputPart = {
-  type: "text";
-  text: string;
-  text_elements: CodexTextElement[];
-};
+export type CodexImageDetail = "low" | "high" | "original";
+export type CodexTurnInputPart =
+  | {
+      type: "text";
+      text: string;
+      text_elements: CodexTextElement[];
+    }
+  | {
+      type: "image";
+      url: string;
+      detail?: CodexImageDetail;
+    }
+  | {
+      type: "localImage";
+      path: string;
+      detail?: CodexImageDetail;
+    };
 
 export type CodexDynamicToolSpec = {
   name: string;

--- a/src/runtime/codexAppServer/types.ts
+++ b/src/runtime/codexAppServer/types.ts
@@ -37,7 +37,10 @@ export type CodexSandboxPolicy =
       excludeSlashTmp: boolean;
     };
 
-export type CodexTextElement = Record<string, unknown>;
+export type CodexTextElement = {
+  byteRange: { start: number; end: number };
+  placeholder: string | null;
+};
 export type CodexImageDetail = "low" | "high" | "original";
 export type CodexTurnInputPart =
   | {

--- a/test/runtime/codex-app-server/turn.test.ts
+++ b/test/runtime/codex-app-server/turn.test.ts
@@ -165,7 +165,7 @@ describe("codex app-server turn lifecycle", () => {
   });
 
   test.serial(
-    "preserves fresh conversation history and attachment order in text_elements",
+    "preserves fresh conversation history and sends image attachments as app-server inputs",
     async () => {
       const dir = await fs.mkdtemp(path.join(os.tmpdir(), "cowork-codex-app-server-attachments-"));
       const capturePath = path.join(dir, "requests.jsonl");
@@ -184,6 +184,12 @@ describe("codex app-server turn lifecycle", () => {
               { type: "text", text: "Look at these" },
               { type: "image", mimeType: "image/png", data: "abc", filename: "chart.png" },
               { type: "file", mimeType: "text/plain", data: "inline", filename: "note.txt" },
+              {
+                type: "file",
+                mimeType: "image/jpeg",
+                path: "/tmp/uploaded.jpg",
+                filename: "uploaded.jpg",
+              },
               { type: "file", path: "/tmp/uploaded.pdf", filename: "uploaded.pdf" },
             ],
           },
@@ -200,11 +206,15 @@ describe("codex app-server turn lifecycle", () => {
         {
           type: "text",
           text: "User: Look at these",
-          text_elements: [
-            { type: "image", mimeType: "image/png", data: "abc", filename: "chart.png" },
-            { type: "file", mimeType: "text/plain", data: "inline", filename: "note.txt" },
-            { type: "file", path: "/tmp/uploaded.pdf", filename: "uploaded.pdf" },
-          ],
+          text_elements: [],
+        },
+        {
+          type: "image",
+          url: "data:image/png;base64,abc",
+        },
+        {
+          type: "localImage",
+          path: "/tmp/uploaded.jpg",
         },
       ]);
     },

--- a/test/runtime/codex-app-server/turn.test.ts
+++ b/test/runtime/codex-app-server/turn.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { z } from "zod";
 
 import { createRuntime } from "../../../src/runtime";
+import { buildCodexTurnInput } from "../../../src/runtime/codexAppServer/turnInput";
 import { mockInterrupts, writeMockAppServer } from "../../fixtures/codexAppServerMock";
 import {
   installCodexAppServerTestHooks,
@@ -182,12 +183,19 @@ describe("codex app-server turn lifecycle", () => {
             role: "user",
             content: [
               { type: "text", text: "Look at these" },
-              { type: "image", mimeType: "image/png", data: "abc", filename: "chart.png" },
+              {
+                type: "image",
+                mimeType: "image/png",
+                data: "abc",
+                detail: "low",
+                filename: "chart.png",
+              },
               { type: "file", mimeType: "text/plain", data: "inline", filename: "note.txt" },
               {
                 type: "file",
                 mimeType: "image/jpeg",
                 path: "/tmp/uploaded.jpg",
+                detail: "high",
                 filename: "uploaded.jpg",
               },
               { type: "file", path: "/tmp/uploaded.pdf", filename: "uploaded.pdf" },
@@ -210,15 +218,68 @@ describe("codex app-server turn lifecycle", () => {
         },
         {
           type: "image",
+          detail: "low",
           url: "data:image/png;base64,abc",
         },
         {
           type: "localImage",
+          detail: "high",
           path: "/tmp/uploaded.jpg",
         },
       ]);
     },
   );
+
+  test("omits non-image files and preserves attachment-only text element context", () => {
+    expect(
+      buildCodexTurnInput(
+        [
+          {
+            role: "user",
+            content: [
+              { type: "file", mimeType: "text/plain", data: "inline", filename: "note.txt" },
+              { type: "file", path: "/tmp/uploaded.pdf", filename: "uploaded.pdf" },
+              { byteRange: { start: 4, end: 12 }, placeholder: "[selection]" },
+            ],
+          },
+        ],
+        { resumedThread: false },
+      ),
+    ).toEqual([
+      {
+        type: "text",
+        text: "User: [attachment]",
+        text_elements: [{ byteRange: { start: 4, end: 12 }, placeholder: "[selection]" }],
+      },
+    ]);
+  });
+
+  test("sends image-only resumed user messages without replaying prior context", () => {
+    expect(
+      buildCodexTurnInput(
+        [
+          { role: "user", content: "Earlier question" },
+          { role: "assistant", content: "Earlier answer" },
+          {
+            role: "user",
+            content: [
+              {
+                type: "image",
+                mimeType: "image/png",
+                data: "abc",
+                detail: "original",
+                filename: "chart.png",
+              },
+            ],
+          },
+        ],
+        { resumedThread: true },
+      ),
+    ).toEqual([
+      { type: "text", text: "[attachment]", text_elements: [] },
+      { type: "image", detail: "original", url: "data:image/png;base64,abc" },
+    ]);
+  });
 
   test.serial("aborts active app-server turns through interruptTurn", async () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "cowork-codex-app-server-abort-"));

--- a/test/session/agentSession.messaging.test.ts
+++ b/test/session/agentSession.messaging.test.ts
@@ -1470,6 +1470,42 @@ describe("AgentSession", () => {
       });
     });
 
+    test("preserves Codex image attachment input through the session path", async () => {
+      const dir = await fs.mkdtemp(path.join(os.tmpdir(), "session-codex-attachments-"));
+      const uploadsDir = path.join(dir, "uploads");
+      const uploadedPath = path.join(uploadsDir, "codex-photo.png");
+      await fs.mkdir(uploadsDir, { recursive: true });
+      await fs.writeFile(uploadedPath, "codex-image-bytes");
+      const { session } = makeSession({
+        config: {
+          ...makeConfig(dir),
+          provider: "codex-cli",
+          model: "gpt-5.4",
+          preferredChildModel: "gpt-5.4",
+        },
+      });
+
+      await session.sendUserMessage("describe this", "msg-codex-uploaded-image", undefined, [
+        {
+          filename: "codex-photo.png",
+          path: uploadedPath,
+          mimeType: "image/png",
+        },
+      ]);
+
+      const call = mockRunTurn.mock.calls.at(-1)?.[0] as any;
+      expect(call.config.provider).toBe("codex-cli");
+      expect(call.messages.at(-1)?.content).toContainEqual({
+        type: "text",
+        text: "describe this",
+      });
+      expect(call.messages.at(-1)?.content).toContainEqual({
+        type: "image",
+        data: Buffer.from("codex-image-bytes").toString("base64"),
+        mimeType: "image/png",
+      });
+    });
+
     test("preserves correct multimodal part types for uploaded Google attachments", async () => {
       const dir = await fs.mkdtemp(path.join(os.tmpdir(), "session-attachments-"));
       const uploadsDir = path.join(dir, "uploads");


### PR DESCRIPTION
## Summary
- Send Codex app-server image attachments as `image`/`localImage` inputs instead of malformed `text_elements` that require `byteRange`.
- Constrain Quick Chat attachment chips and error cards so long filenames and errors stay inside the popout.
- Keep managed LibreOffice lookup PATH-first before platform fallbacks so the full test suite is deterministic when a local LibreOffice app is installed.

## Root Cause
Codex app-server `text_elements` are byte-ranged text spans. Cowork was forwarding attachment records through that field, so image attachments without `byteRange` were rejected by app-server before the turn could run.

## Validation
- `bun test`
- `bun run typecheck`
- `git diff --check`
- `bunx biome check <touched files>` (exit 0; existing helper asset style warnings only)
