### PR TITLE
fix(spreadsheet): atomic batch patches + per-file write lock

### DIFF
--- a/apps/desktop/scripts/notarize.cjs
+++ b/apps/desktop/scripts/notarize.cjs
@@ -18,11 +18,13 @@ function getErrorText(error) {
 function isRetryableNotarizeError(error) {
   const text = getErrorText(error);
 
-  return /NSURLErrorDomain Code=-(1001|1005|1009)\b/.test(text)
-    || /\b(ECONNRESET|ETIMEDOUT|EAI_AGAIN|ENOTFOUND|ENETDOWN|ENETUNREACH)\b/.test(text)
-    || /\b(?:statusCode|status code)[:=]\s*(?:429|5\d\d)\b/i.test(text)
-    || /The Internet connection appears to be offline/i.test(text)
-    || /network.*(?:timeout|offline|reset|unreachable)/i.test(text);
+  return (
+    /NSURLErrorDomain Code=-(1001|1005|1009)\b/.test(text) ||
+    /\b(ECONNRESET|ETIMEDOUT|EAI_AGAIN|ENOTFOUND|ENETDOWN|ENETUNREACH)\b/.test(text) ||
+    /\b(?:statusCode|status code)[:=]\s*(?:429|5\d\d)\b/i.test(text) ||
+    /The Internet connection appears to be offline/i.test(text) ||
+    /network.*(?:timeout|offline|reset|unreachable)/i.test(text)
+  );
 }
 
 function sleep(ms) {

--- a/apps/desktop/src/app/store.actions/preview.ts
+++ b/apps/desktop/src/app/store.actions/preview.ts
@@ -17,8 +17,8 @@ import {
   formatJsonRpcWorkspaceSpreadsheet,
   patchJsonRpcWorkspaceSpreadsheet,
   previewJsonRpcWorkspacePresentation,
-  previewJsonRpcWorkspaceSpreadsheetWorkbook,
   previewJsonRpcWorkspaceSpreadsheet,
+  previewJsonRpcWorkspaceSpreadsheetWorkbook,
   versionJsonRpcWorkspaceSpreadsheet,
 } from "../store.helpers/jsonRpcSocket";
 

--- a/apps/desktop/src/app/store.helpers.ts
+++ b/apps/desktop/src/app/store.helpers.ts
@@ -5,13 +5,13 @@ import type {
   DesktopFeatureFlags,
 } from "../../../../src/shared/featureFlags";
 import type {
-  SpreadsheetCellEditResult,
   SpreadsheetBatchPatchOperation,
   SpreadsheetBatchPatchResult,
+  SpreadsheetCellEditResult,
+  SpreadsheetCellStylePatch,
   SpreadsheetFileVersionResult,
   SpreadsheetPreviewResult,
   SpreadsheetPreviewViewportRequest,
-  SpreadsheetCellStylePatch,
   SpreadsheetRangeFormatResult,
   SpreadsheetWorkbookSnapshotResult,
 } from "../../../../src/shared/spreadsheetPreview";

--- a/apps/desktop/src/components/ai-elements/message.tsx
+++ b/apps/desktop/src/components/ai-elements/message.tsx
@@ -982,8 +982,7 @@ export function rewriteDesktopFileLinksInTree(
     typeof node.properties?.href === "string"
   ) {
     const href = node.properties.href;
-    const rebased =
-      resolveAbsoluteDesktopFileHref(href) ?? resolveRelativeFileHref(href, basePath);
+    const rebased = resolveAbsoluteDesktopFileHref(href) ?? resolveRelativeFileHref(href, basePath);
     if (rebased) {
       node.properties.href = rebased;
     }

--- a/apps/desktop/src/lib/univerSpreadsheet.ts
+++ b/apps/desktop/src/lib/univerSpreadsheet.ts
@@ -15,7 +15,6 @@ import type {
   SpreadsheetCellStyle,
   SpreadsheetCellStylePatch,
   SpreadsheetPreviewCell,
-  SpreadsheetTableSummary,
   SpreadsheetWorkbookSnapshot,
   SpreadsheetWorkbookSnapshotSheet,
 } from "../../../../src/shared/spreadsheetPreview";
@@ -209,7 +208,11 @@ function sheetSnapshotToUniverSheet(
   for (const cell of sheet.cells) {
     const univerCell = previewCellToUniverCell(cell, styles, styleIds);
     if (Object.keys(univerCell).length === 0) continue;
-    const row = (cellData[cell.row] ??= {});
+    let row = cellData[cell.row];
+    if (!row) {
+      row = {};
+      cellData[cell.row] = row;
+    }
     row[cell.col] = univerCell;
   }
 

--- a/apps/desktop/src/lib/univerSpreadsheet.ts
+++ b/apps/desktop/src/lib/univerSpreadsheet.ts
@@ -2,12 +2,12 @@ import {
   BooleanNumber,
   CellValueType,
   HorizontalAlign,
-  LocaleType,
   type ICellData,
   type IRange,
   type IStyleData,
   type IWorkbookData,
   type IWorksheetData,
+  LocaleType,
 } from "@univerjs/core";
 
 import type {
@@ -94,7 +94,9 @@ export function diffUniverWorkbookPatches(
         });
       }
 
-      const previousStyle = stylePatchFromUniverStyle(resolveUniverStyle(previous, previousCell?.s));
+      const previousStyle = stylePatchFromUniverStyle(
+        resolveUniverStyle(previous, previousCell?.s),
+      );
       const currentStyle = stylePatchFromUniverStyle(resolveUniverStyle(current, currentCell?.s));
       const patch = stylePatchBetween(previousStyle, currentStyle);
       if (Object.keys(patch).length > 0) {
@@ -180,8 +182,7 @@ export function selectionContextFromWorkbook(
     activeCellA1 ?? rangeA1.split(":")[0] ?? "A1",
   );
   const activeStyle =
-    activeCell?.style ??
-    styleFromUniverStyle(resolveUniverStyle(data, currentCellData?.s));
+    activeCell?.style ?? styleFromUniverStyle(resolveUniverStyle(data, currentCellData?.s));
   const activeFormula =
     typeof currentCellData?.f === "string" && currentCellData.f.trim() !== ""
       ? rawInputFromCellData(currentCellData)

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -55,6 +55,10 @@ code {
   -webkit-user-select: text;
 }
 
+* {
+  box-sizing: border-box;
+}
+
 [data-cowork-univer-canvas="true"],
 [data-cowork-univer-canvas="true"] * {
   --primary-color: var(--accent);
@@ -76,6 +80,7 @@ code {
 }
 
 [data-cowork-univer-canvas="true"] [data-u-comp="formula-bar"] {
+  /* biome-ignore lint/complexity/noImportantStyles: override Univer's own formula-bar height */
   height: 2.25rem !important;
   min-height: 2.25rem;
   overflow: hidden;
@@ -109,10 +114,6 @@ kbd,
 pre,
 samp {
   font-family: var(--font-mono);
-}
-
-* {
-  box-sizing: border-box;
 }
 
 /* Thin overlay-style scrollbars for Chromium 146+ */

--- a/apps/desktop/src/ui/SpreadsheetPreview.tsx
+++ b/apps/desktop/src/ui/SpreadsheetPreview.tsx
@@ -12,10 +12,10 @@ import {
   ItalicIcon,
   Loader2Icon,
   Maximize2Icon,
+  Minimize2Icon,
   MoreHorizontalIcon,
   PaintBucketIcon,
   PaletteIcon,
-  Minimize2Icon,
   Redo2Icon,
   SparklesIcon,
   Table2Icon,
@@ -39,8 +39,8 @@ import type {
   SpreadsheetPreviewCell,
   SpreadsheetPreview as SpreadsheetPreviewData,
   SpreadsheetPreviewResult,
-  SpreadsheetTableSummary,
   SpreadsheetPreviewViewport,
+  SpreadsheetTableSummary,
 } from "../../../../src/shared/spreadsheetPreview";
 import { useAppStore } from "../app/store";
 import { Button } from "../components/ui/button";

--- a/apps/desktop/src/ui/SpreadsheetPreview.tsx
+++ b/apps/desktop/src/ui/SpreadsheetPreview.tsx
@@ -1216,6 +1216,7 @@ export function SpreadsheetPreview({ path, compact = false }: SpreadsheetPreview
 
       <div
         className="flex shrink-0 items-center gap-1 overflow-x-auto border-b border-[var(--border-spreadsheet)] bg-[var(--surface-spreadsheet-toolbar)] px-3 py-1.5"
+        role="toolbar"
         aria-label="Spreadsheet formatting controls"
       >
         <Button
@@ -1267,7 +1268,8 @@ export function SpreadsheetPreview({ path, compact = false }: SpreadsheetPreview
           ))}
         </select>
         <div className="mx-1 h-5 w-px bg-[var(--border-spreadsheet)]" aria-hidden />
-        <div className="flex items-center gap-0.5" aria-label="Text color">
+        {/* biome-ignore lint/a11y/useSemanticElements: ARIA toolbar sub-group; fieldset is for forms */}
+        <div className="flex items-center gap-0.5" role="group" aria-label="Text color">
           <PaletteIcon className="mx-1 size-3.5 text-[var(--text-spreadsheet-muted)]" />
           {TEXT_COLOR_SWATCHES.map((hexBody) => {
             const color = spreadsheetSwatchColor(hexBody);
@@ -1285,7 +1287,8 @@ export function SpreadsheetPreview({ path, compact = false }: SpreadsheetPreview
             );
           })}
         </div>
-        <div className="flex items-center gap-0.5" aria-label="Fill color">
+        {/* biome-ignore lint/a11y/useSemanticElements: ARIA toolbar sub-group; fieldset is for forms */}
+        <div className="flex items-center gap-0.5" role="group" aria-label="Fill color">
           <PaintBucketIcon className="mx-1 size-3.5 text-[var(--text-spreadsheet-muted)]" />
           {FILL_COLOR_SWATCHES.map((hexBody) => {
             const color = spreadsheetSwatchColor(hexBody);

--- a/apps/desktop/src/ui/UniverSpreadsheetCanvas.tsx
+++ b/apps/desktop/src/ui/UniverSpreadsheetCanvas.tsx
@@ -9,14 +9,20 @@ import "@univerjs/preset-sheets-hyper-link/lib/index.css";
 import "@univerjs/preset-sheets-table/lib/index.css";
 import "@univerjs/preset-sheets-thread-comment/lib/index.css";
 
-import { LocaleType, mergeLocales, type IDisposable, type IRange, type IWorkbookData } from "@univerjs/core";
-import sheetsConditionalFormattingEnUS from "@univerjs/preset-sheets-conditional-formatting/locales/en-US";
+import {
+  type IDisposable,
+  type IRange,
+  type IWorkbookData,
+  LocaleType,
+  mergeLocales,
+} from "@univerjs/core";
 import { UniverSheetsConditionalFormattingPreset } from "@univerjs/preset-sheets-conditional-formatting";
+import sheetsConditionalFormattingEnUS from "@univerjs/preset-sheets-conditional-formatting/locales/en-US";
 import { UniverSheetsCorePreset } from "@univerjs/preset-sheets-core";
-import sheetsCoreEnUS from "@univerjs/preset-sheets-core/locales/en-US";
 import workerUrl from "@univerjs/preset-sheets-core/lib/worker.js?url";
-import sheetsDataValidationEnUS from "@univerjs/preset-sheets-data-validation/locales/en-US";
+import sheetsCoreEnUS from "@univerjs/preset-sheets-core/locales/en-US";
 import { UniverSheetsDataValidationPreset } from "@univerjs/preset-sheets-data-validation";
+import sheetsDataValidationEnUS from "@univerjs/preset-sheets-data-validation/locales/en-US";
 import { UniverSheetsFilterPreset } from "@univerjs/preset-sheets-filter";
 import sheetsFilterEnUS from "@univerjs/preset-sheets-filter/locales/en-US";
 import { UniverSheetsFindReplacePreset } from "@univerjs/preset-sheets-find-replace";
@@ -160,10 +166,7 @@ export function UniverSpreadsheetCanvas({ path, compact = false }: UniverSpreads
       try {
         const currentWorkbook = workbookRef.current;
         const sheetName = selectionRef.current?.sheetName ?? currentWorkbook?.activeSheetName;
-        const response = await loadSpreadsheetWorkbook(
-          path,
-          sheetName ? { sheetName } : undefined,
-        );
+        const response = await loadSpreadsheetWorkbook(path, sheetName ? { sheetName } : undefined);
         if (!response.ok) {
           setSaveState("error");
           setSaveError(`Reload failed: ${response.error.message}`);
@@ -328,7 +331,10 @@ export function UniverSpreadsheetCanvas({ path, compact = false }: UniverSpreads
       const currentWorkbook = workbookApiRef.current;
       const previousData = lastSavedDataRef.current;
       if (!currentWorkbook || !previousData) return [];
-      return diffUniverWorkbookPatches(previousData, cloneUniverWorkbookData(currentWorkbook.save()));
+      return diffUniverWorkbookPatches(
+        previousData,
+        cloneUniverWorkbookData(currentWorkbook.save()),
+      );
     };
 
     const refreshSourceVersion = async () => {
@@ -498,7 +504,10 @@ export function UniverSpreadsheetCanvas({ path, compact = false }: UniverSpreads
           <span className="truncate">{statusLabel}</span>
         </div>
         {saveError ? <span className="truncate text-xs text-destructive">{saveError}</span> : null}
-        <form className="ml-auto flex min-w-[260px] max-w-[560px] flex-1 items-center gap-2" onSubmit={handlePromptSubmit}>
+        <form
+          className="ml-auto flex min-w-[260px] max-w-[560px] flex-1 items-center gap-2"
+          onSubmit={handlePromptSubmit}
+        >
           <Input
             className="h-8 border-border bg-white text-sm shadow-none"
             value={promptText}

--- a/apps/desktop/src/ui/UniverSpreadsheetCanvas.tsx
+++ b/apps/desktop/src/ui/UniverSpreadsheetCanvas.tsx
@@ -519,7 +519,7 @@ export function UniverSpreadsheetCanvas({ path, compact = false }: UniverSpreads
 function SaveStateIcon({ state }: { state: SaveState }) {
   if (state === "saving") return <Loader2Icon className="size-3.5 animate-spin" />;
   if (state === "saved") return <CheckIcon className="size-3.5 text-success" />;
-  if (state === "dirty") return <SaveIcon className="size-3.5 text-[var(--accent)]" />;
+  if (state === "dirty") return <SaveIcon className="size-3.5 text-primary" />;
   if (state === "error") return <AlertCircleIcon className="size-3.5 text-destructive" />;
   return <SaveIcon className="size-3.5 text-muted-foreground" />;
 }

--- a/apps/desktop/test/univer-spreadsheet.test.ts
+++ b/apps/desktop/test/univer-spreadsheet.test.ts
@@ -1,5 +1,5 @@
-import { BooleanNumber, HorizontalAlign } from "@univerjs/core";
 import { describe, expect, test } from "bun:test";
+import { BooleanNumber, HorizontalAlign } from "@univerjs/core";
 
 import type { SpreadsheetWorkbookSnapshot } from "../../../src/shared/spreadsheetPreview";
 import {

--- a/src/server/spreadsheetEdit.ts
+++ b/src/server/spreadsheetEdit.ts
@@ -6,8 +6,10 @@ import JSZip from "jszip";
 import * as XLSX from "xlsx";
 
 import type {
+  SpreadsheetBatchPatchOperation,
   SpreadsheetBatchPatchRequest,
   SpreadsheetBatchPatchResult,
+  SpreadsheetCellEditFailureKind,
   SpreadsheetCellEditRequest,
   SpreadsheetCellEditResult,
   SpreadsheetCellStylePatch,
@@ -17,6 +19,14 @@ import type {
 import { resolveWorkspaceFilePath, validateXlsxZipSignature } from "./spreadsheetPreview";
 
 const MAX_BATCH_PATCH_OPERATIONS = 2_000;
+
+type EditFailure = { kind: SpreadsheetCellEditFailureKind; message: string };
+
+/**
+ * Outcome of applying an ordered list of operations to one file. `index` marks
+ * which operation failed so the batch entry point can attribute the error.
+ */
+type OpsOutcome = { ok: true } | { ok: false; index: number; error: EditFailure };
 
 /**
  * Apply a single-cell edit to a CSV or XLSX file and persist it, losslessly.
@@ -33,69 +43,42 @@ const MAX_BATCH_PATCH_OPERATIONS = 2_000;
 export async function editSpreadsheetCell(
   req: SpreadsheetCellEditRequest,
 ): Promise<SpreadsheetCellEditResult> {
-  let resolvedPath: string;
-  try {
-    resolvedPath = await resolveWorkspaceFilePath(req.cwd, req.filePath);
-  } catch (error) {
-    return {
-      ok: false,
-      error: { kind: "not_found", message: error instanceof Error ? error.message : String(error) },
-    };
-  }
-
-  const ext = path.extname(resolvedPath).toLowerCase();
-  try {
-    if (ext === ".csv") return await editCsvCell(resolvedPath, req);
-    if (ext === ".xlsx") return await editXlsxCell(resolvedPath, req);
-    return {
-      ok: false,
-      error: { kind: "unsupported_format", message: "Editing supports CSV and XLSX files." },
-    };
-  } catch (error) {
-    return {
-      ok: false,
-      error: {
-        kind: "write_error",
-        message: error instanceof Error ? error.message : String(error),
-      },
-    };
-  }
+  const target = await resolveEditTarget(req.cwd, req.filePath);
+  if (!target.ok) return target;
+  const outcome = await executeOps(target.resolvedPath, target.ext, [
+    {
+      type: "cell",
+      ...(req.sheetName ? { sheetName: req.sheetName } : {}),
+      address: req.address,
+      rawInput: req.rawInput,
+    },
+  ]);
+  return outcome.ok ? { ok: true } : { ok: false, error: outcome.error };
 }
 
 export async function formatSpreadsheetRange(
   req: SpreadsheetRangeFormatRequest,
 ): Promise<SpreadsheetRangeFormatResult> {
-  let resolvedPath: string;
-  try {
-    resolvedPath = await resolveWorkspaceFilePath(req.cwd, req.filePath);
-  } catch (error) {
-    return {
-      ok: false,
-      error: { kind: "not_found", message: error instanceof Error ? error.message : String(error) },
-    };
-  }
-
-  const ext = path.extname(resolvedPath).toLowerCase();
-  if (ext !== ".xlsx") {
-    return {
-      ok: false,
-      error: { kind: "unsupported_format", message: "Formatting supports XLSX files." },
-    };
-  }
-
-  try {
-    return await formatXlsxRange(resolvedPath, req);
-  } catch (error) {
-    return {
-      ok: false,
-      error: {
-        kind: "write_error",
-        message: error instanceof Error ? error.message : String(error),
-      },
-    };
-  }
+  const target = await resolveEditTarget(req.cwd, req.filePath);
+  if (!target.ok) return target;
+  const outcome = await executeOps(target.resolvedPath, target.ext, [
+    {
+      type: "format",
+      ...(req.sheetName ? { sheetName: req.sheetName } : {}),
+      range: req.range,
+      style: req.style,
+    },
+  ]);
+  return outcome.ok ? { ok: true } : { ok: false, error: outcome.error };
 }
 
+/**
+ * Apply an ordered batch of cell/format operations as a single atomic
+ * read-modify-write: the file is read and (for XLSX) unzipped exactly once, all
+ * operations are applied in memory, and the result is written exactly once. A
+ * mid-batch failure aborts before any bytes are persisted, so partial batches
+ * never land on disk.
+ */
 export async function patchSpreadsheetBatch(
   req: SpreadsheetBatchPatchRequest,
 ): Promise<SpreadsheetBatchPatchResult> {
@@ -109,35 +92,81 @@ export async function patchSpreadsheetBatch(
     };
   }
 
-  for (const [index, operation] of req.operations.entries()) {
-    const result =
-      operation.type === "cell"
-        ? await editSpreadsheetCell({
-            cwd: req.cwd,
-            filePath: req.filePath,
-            ...(operation.sheetName ? { sheetName: operation.sheetName } : {}),
-            address: operation.address,
-            rawInput: operation.rawInput,
-          })
-        : await formatSpreadsheetRange({
-            cwd: req.cwd,
-            filePath: req.filePath,
-            ...(operation.sheetName ? { sheetName: operation.sheetName } : {}),
-            range: operation.range,
-            style: operation.style,
-          });
-    if (!result.ok) {
+  const target = await resolveEditTarget(req.cwd, req.filePath);
+  if (!target.ok) return target;
+  const outcome = await executeOps(target.resolvedPath, target.ext, req.operations);
+  if (outcome.ok) return { ok: true };
+  return {
+    ok: false,
+    error: {
+      kind: outcome.error.kind,
+      message: `Operation ${outcome.index + 1} failed: ${outcome.error.message}`,
+    },
+  };
+}
+
+async function resolveEditTarget(
+  cwd: string,
+  filePath: string,
+): Promise<{ ok: true; resolvedPath: string; ext: string } | { ok: false; error: EditFailure }> {
+  try {
+    const resolvedPath = await resolveWorkspaceFilePath(cwd, filePath);
+    return { ok: true, resolvedPath, ext: path.extname(resolvedPath).toLowerCase() };
+  } catch (error) {
+    return {
+      ok: false,
+      error: { kind: "not_found", message: error instanceof Error ? error.message : String(error) },
+    };
+  }
+}
+
+/**
+ * Serialize all read-modify-write cycles against a given resolved path so two
+ * concurrent edits to the same workbook can never interleave and clobber each
+ * other. Failures don't poison the lock; the next waiter still runs.
+ */
+const fileWriteChains = new Map<string, Promise<void>>();
+
+function withFileLock<T>(filePath: string, fn: () => Promise<T>): Promise<T> {
+  const previous = fileWriteChains.get(filePath) ?? Promise.resolve();
+  const result = previous.then(fn, fn);
+  const settled = result.then(
+    () => undefined,
+    () => undefined,
+  );
+  fileWriteChains.set(filePath, settled);
+  void settled.then(() => {
+    if (fileWriteChains.get(filePath) === settled) fileWriteChains.delete(filePath);
+  });
+  return result;
+}
+
+/** Acquire the per-file lock, dispatch by extension, and map throws to write_error. */
+function executeOps(
+  resolvedPath: string,
+  ext: string,
+  operations: SpreadsheetBatchPatchOperation[],
+): Promise<OpsOutcome> {
+  return withFileLock(resolvedPath, async () => {
+    try {
+      if (ext === ".csv") return await runCsvOps(resolvedPath, operations);
+      if (ext === ".xlsx") return await runXlsxOps(resolvedPath, operations);
+      const message =
+        operations[0]?.type === "format"
+          ? "Formatting supports XLSX files."
+          : "Editing supports CSV and XLSX files.";
+      return { ok: false, index: 0, error: { kind: "unsupported_format", message } };
+    } catch (error) {
       return {
         ok: false,
+        index: 0,
         error: {
-          kind: result.error.kind,
-          message: `Operation ${index + 1} failed: ${result.error.message}`,
+          kind: "write_error",
+          message: error instanceof Error ? error.message : String(error),
         },
       };
     }
-  }
-
-  return { ok: true };
+  });
 }
 
 type CellAddress = { row: number; col: number };
@@ -191,18 +220,10 @@ async function writeFileAtomic(filePath: string, data: Buffer | string): Promise
 // CSV
 // ---------------------------------------------------------------------------
 
-async function editCsvCell(
+async function runCsvOps(
   filePath: string,
-  req: SpreadsheetCellEditRequest,
-): Promise<SpreadsheetCellEditResult> {
-  const addr = parseAddress(req.address);
-  if (!addr) {
-    return {
-      ok: false,
-      error: { kind: "parse_error", message: `Invalid cell address: ${req.address}` },
-    };
-  }
-
+  operations: SpreadsheetBatchPatchOperation[],
+): Promise<OpsOutcome> {
   const raw = (await fs.readFile(filePath)).toString("utf8");
   const hasBom = raw.charCodeAt(0) === 0xfeff;
   const text = hasBom ? raw.slice(1) : raw;
@@ -210,10 +231,27 @@ async function editCsvCell(
   const hasTrailingNewline = /\r?\n$/.test(text);
 
   const rows = parseCsv(text);
-  while (rows.length <= addr.row) rows.push([]);
-  const row = rows[addr.row] as string[];
-  while (row.length <= addr.col) row.push("");
-  row[addr.col] = req.rawInput;
+  for (const [index, op] of operations.entries()) {
+    if (op.type === "format") {
+      return {
+        ok: false,
+        index,
+        error: { kind: "unsupported_format", message: "Formatting supports XLSX files." },
+      };
+    }
+    const addr = parseAddress(op.address);
+    if (!addr) {
+      return {
+        ok: false,
+        index,
+        error: { kind: "parse_error", message: `Invalid cell address: ${op.address}` },
+      };
+    }
+    while (rows.length <= addr.row) rows.push([]);
+    const row = rows[addr.row] as string[];
+    while (row.length <= addr.col) row.push("");
+    row[addr.col] = op.rawInput;
+  }
 
   let out = rows.map((cells) => cells.map(csvQuoteField).join(",")).join(eol);
   if (hasTrailingNewline) out += eol;
@@ -290,150 +328,189 @@ function csvQuoteField(value: string): string {
 // XLSX (surgical, lossless)
 // ---------------------------------------------------------------------------
 
-async function editXlsxCell(
-  filePath: string,
-  req: SpreadsheetCellEditRequest,
-): Promise<SpreadsheetCellEditResult> {
-  const addr = parseAddress(req.address);
-  if (!addr) {
-    return {
-      ok: false,
-      error: { kind: "parse_error", message: `Invalid cell address: ${req.address}` },
-    };
-  }
+/**
+ * In-memory editing session over a single workbook: the zip is loaded once and
+ * worksheet XML parts plus the stylesheet are read, mutated, and cached here so
+ * a whole batch shares one read-modify-write cycle. Nothing touches disk until
+ * {@link flushXlsxSession} validates and {@link writeXlsxSession} persists.
+ */
+type XlsxSession = {
+  zip: JSZip;
+  sheetXmlByPart: Map<string, string>;
+  partBySheet: Map<string, string | null>;
+  dirtyParts: Set<string>;
+  styles: ReturnType<typeof parseStylesheet> | null;
+  stylesDirty: boolean;
+};
 
+async function runXlsxOps(
+  filePath: string,
+  operations: SpreadsheetBatchPatchOperation[],
+): Promise<OpsOutcome> {
   const bytes = await fs.readFile(filePath);
   validateXlsxZipSignature(bytes);
-  const zip = await JSZip.loadAsync(bytes);
+  const session: XlsxSession = {
+    zip: await JSZip.loadAsync(bytes),
+    sheetXmlByPart: new Map(),
+    partBySheet: new Map(),
+    dirtyParts: new Set(),
+    styles: null,
+    stylesDirty: false,
+  };
 
-  const partPath = await resolveWorksheetPart(zip, req.sheetName);
-  if (!partPath) {
-    return {
-      ok: false,
-      error: { kind: "not_found", message: `Sheet not found: ${req.sheetName ?? "(first sheet)"}` },
-    };
-  }
-  const partFile = zip.file(partPath);
-  if (!partFile) {
-    return {
-      ok: false,
-      error: { kind: "parse_error", message: `Worksheet part missing: ${partPath}` },
-    };
-  }
-
-  const sheetXml = await partFile.async("string");
-  const ref = XLSX.utils.encode_cell({ r: addr.row, c: addr.col });
-  const styleAttr = readCellStyleAttr(sheetXml, ref);
-  const cellXml = encodeCellXml(ref, styleAttr, req.rawInput);
-  const newSheetXml = applyCellEdit(sheetXml, addr, ref, cellXml);
-
-  const validation = XMLValidator.validate(newSheetXml);
-  if (validation !== true) {
-    return {
-      ok: false,
-      error: {
-        kind: "parse_error",
-        message: `Edited worksheet XML is invalid: ${validation.err?.msg ?? "unknown error"}`,
-      },
-    };
+  for (const [index, op] of operations.entries()) {
+    const failure =
+      op.type === "cell"
+        ? await applyXlsxCellOp(session, op)
+        : await applyXlsxFormatOp(session, op);
+    if (failure) return { ok: false, index, error: failure };
   }
 
-  zip.file(partPath, newSheetXml);
-  const out = await zip.generateAsync({ type: "nodebuffer", compression: "DEFLATE" });
-  await writeFileAtomic(filePath, out);
+  const flushed = flushXlsxSession(session);
+  if (!flushed.ok) return { ok: false, index: 0, error: flushed.error };
+
+  await writeXlsxSession(session, filePath);
   return { ok: true };
 }
 
-async function formatXlsxRange(
-  filePath: string,
-  req: SpreadsheetRangeFormatRequest,
-): Promise<SpreadsheetRangeFormatResult> {
-  const range = parseRange(req.range);
-  if (!range) {
-    return {
-      ok: false,
-      error: { kind: "parse_error", message: `Invalid cell range: ${req.range}` },
-    };
+async function sessionWorksheetPart(
+  session: XlsxSession,
+  sheetName?: string,
+): Promise<string | null> {
+  const key = sheetName ?? "";
+  if (!session.partBySheet.has(key)) {
+    session.partBySheet.set(key, await resolveWorksheetPart(session.zip, sheetName));
+  }
+  return session.partBySheet.get(key) ?? null;
+}
+
+async function sessionSheetXml(session: XlsxSession, partPath: string): Promise<string | null> {
+  const cached = session.sheetXmlByPart.get(partPath);
+  if (cached !== undefined) return cached;
+  const file = session.zip.file(partPath);
+  if (!file) return null;
+  const xml = await file.async("string");
+  session.sheetXmlByPart.set(partPath, xml);
+  return xml;
+}
+
+async function sessionStyles(session: XlsxSession): Promise<ReturnType<typeof parseStylesheet>> {
+  if (!session.styles) {
+    session.styles = parseStylesheet(await ensureStylesXml(session.zip));
+  }
+  return session.styles;
+}
+
+async function applyXlsxCellOp(
+  session: XlsxSession,
+  op: { sheetName?: string; address: string; rawInput: string },
+): Promise<EditFailure | null> {
+  const addr = parseAddress(op.address);
+  if (!addr) return { kind: "parse_error", message: `Invalid cell address: ${op.address}` };
+
+  const partPath = await sessionWorksheetPart(session, op.sheetName);
+  if (!partPath) {
+    return { kind: "not_found", message: `Sheet not found: ${op.sheetName ?? "(first sheet)"}` };
+  }
+  const sheetXml = await sessionSheetXml(session, partPath);
+  if (sheetXml === null) {
+    return { kind: "parse_error", message: `Worksheet part missing: ${partPath}` };
   }
 
-  const cellCount =
-    (range.end.row - range.start.row + 1) * (range.end.col - range.start.col + 1);
+  const ref = XLSX.utils.encode_cell({ r: addr.row, c: addr.col });
+  const styleAttr = readCellStyleAttr(sheetXml, ref);
+  const cellXml = encodeCellXml(ref, styleAttr, op.rawInput);
+  session.sheetXmlByPart.set(partPath, applyCellEdit(sheetXml, addr, ref, cellXml));
+  session.dirtyParts.add(partPath);
+  return null;
+}
+
+async function applyXlsxFormatOp(
+  session: XlsxSession,
+  op: { sheetName?: string; range: string; style: SpreadsheetCellStylePatch },
+): Promise<EditFailure | null> {
+  const range = parseRange(op.range);
+  if (!range) return { kind: "parse_error", message: `Invalid cell range: ${op.range}` };
+
+  const cellCount = (range.end.row - range.start.row + 1) * (range.end.col - range.start.col + 1);
   if (cellCount > 50_000) {
     return {
-      ok: false,
-      error: {
-        kind: "parse_error",
-        message: "Formatting ranges are limited to 50,000 cells per request.",
-      },
+      kind: "parse_error",
+      message: "Formatting ranges are limited to 50,000 cells per request.",
     };
   }
 
-  const bytes = await fs.readFile(filePath);
-  validateXlsxZipSignature(bytes);
-  const zip = await JSZip.loadAsync(bytes);
-
-  const partPath = await resolveWorksheetPart(zip, req.sheetName);
+  const partPath = await sessionWorksheetPart(session, op.sheetName);
   if (!partPath) {
-    return {
-      ok: false,
-      error: { kind: "not_found", message: `Sheet not found: ${req.sheetName ?? "(first sheet)"}` },
-    };
+    return { kind: "not_found", message: `Sheet not found: ${op.sheetName ?? "(first sheet)"}` };
   }
-  const partFile = zip.file(partPath);
-  if (!partFile) {
-    return {
-      ok: false,
-      error: { kind: "parse_error", message: `Worksheet part missing: ${partPath}` },
-    };
+  let sheetXml = await sessionSheetXml(session, partPath);
+  if (sheetXml === null) {
+    return { kind: "parse_error", message: `Worksheet part missing: ${partPath}` };
   }
 
-  const stylesXml = await ensureStylesXml(zip);
-  const styles = parseStylesheet(stylesXml);
-  let sheetXml = await partFile.async("string");
+  const styles = await sessionStyles(session);
   const styleCache = new Map<string, number>();
-
   for (let row = range.start.row; row <= range.end.row; row += 1) {
     for (let col = range.start.col; col <= range.end.col; col += 1) {
       const ref = XLSX.utils.encode_cell({ r: row, c: col });
       const currentStyle = Number.parseInt(readCellStyleIndex(sheetXml, ref) ?? "0", 10);
       const baseStyle = Number.isFinite(currentStyle) && currentStyle >= 0 ? currentStyle : 0;
-      const cacheKey = `${baseStyle}:${JSON.stringify(req.style)}`;
+      const cacheKey = `${baseStyle}:${JSON.stringify(op.style)}`;
       let nextStyle = styleCache.get(cacheKey);
       if (nextStyle === undefined) {
-        nextStyle = styles.applyPatch(baseStyle, req.style);
+        nextStyle = styles.applyPatch(baseStyle, op.style);
         styleCache.set(cacheKey, nextStyle);
       }
       sheetXml = applyCellStyle(sheetXml, { row, col }, ref, nextStyle);
     }
   }
 
-  const newStylesXml = styles.toXml();
-  const sheetValidation = XMLValidator.validate(sheetXml);
-  if (sheetValidation !== true) {
-    return {
-      ok: false,
-      error: {
-        kind: "parse_error",
-        message: `Formatted worksheet XML is invalid: ${sheetValidation.err?.msg ?? "unknown error"}`,
-      },
-    };
-  }
-  const stylesValidation = XMLValidator.validate(newStylesXml);
-  if (stylesValidation !== true) {
-    return {
-      ok: false,
-      error: {
-        kind: "parse_error",
-        message: `Formatted styles XML is invalid: ${stylesValidation.err?.msg ?? "unknown error"}`,
-      },
-    };
+  session.sheetXmlByPart.set(partPath, sheetXml);
+  session.dirtyParts.add(partPath);
+  session.stylesDirty = true;
+  return null;
+}
+
+/** Validate every mutated part once and stage it back into the in-memory zip. */
+function flushXlsxSession(session: XlsxSession): { ok: true } | { ok: false; error: EditFailure } {
+  for (const partPath of session.dirtyParts) {
+    const xml = session.sheetXmlByPart.get(partPath);
+    if (xml === undefined) continue;
+    const validation = XMLValidator.validate(xml);
+    if (validation !== true) {
+      return {
+        ok: false,
+        error: {
+          kind: "parse_error",
+          message: `Edited worksheet XML is invalid: ${validation.err?.msg ?? "unknown error"}`,
+        },
+      };
+    }
+    session.zip.file(partPath, xml);
   }
 
-  zip.file(partPath, sheetXml);
-  zip.file("xl/styles.xml", newStylesXml);
-  const out = await zip.generateAsync({ type: "nodebuffer", compression: "DEFLATE" });
-  await writeFileAtomic(filePath, out);
+  if (session.stylesDirty && session.styles) {
+    const newStylesXml = session.styles.toXml();
+    const validation = XMLValidator.validate(newStylesXml);
+    if (validation !== true) {
+      return {
+        ok: false,
+        error: {
+          kind: "parse_error",
+          message: `Formatted styles XML is invalid: ${validation.err?.msg ?? "unknown error"}`,
+        },
+      };
+    }
+    session.zip.file("xl/styles.xml", newStylesXml);
+  }
+
   return { ok: true };
+}
+
+async function writeXlsxSession(session: XlsxSession, filePath: string): Promise<void> {
+  const out = await session.zip.generateAsync({ type: "nodebuffer", compression: "DEFLATE" });
+  await writeFileAtomic(filePath, out);
 }
 
 const OOXML_STYLE_PARSER = new XMLParser({

--- a/src/server/spreadsheetEdit.ts
+++ b/src/server/spreadsheetEdit.ts
@@ -24,9 +24,11 @@ type EditFailure = { kind: SpreadsheetCellEditFailureKind; message: string };
 
 /**
  * Outcome of applying an ordered list of operations to one file. `index` marks
- * which operation failed so the batch entry point can attribute the error.
+ * which operation failed so the batch entry point can attribute the error, or is
+ * `null` when the failure isn't tied to a specific operation (file read/write,
+ * post-batch validation, or an unsupported file type).
  */
-type OpsOutcome = { ok: true } | { ok: false; index: number; error: EditFailure };
+type OpsOutcome = { ok: true } | { ok: false; index: number | null; error: EditFailure };
 
 /**
  * Apply a single-cell edit to a CSV or XLSX file and persist it, losslessly.
@@ -91,18 +93,20 @@ export async function patchSpreadsheetBatch(
       },
     };
   }
+  // A no-op batch must not touch disk (re-zipping or re-quoting would change the
+  // file's bytes and fingerprint with no actual edit).
+  if (req.operations.length === 0) return { ok: true };
 
   const target = await resolveEditTarget(req.cwd, req.filePath);
   if (!target.ok) return target;
   const outcome = await executeOps(target.resolvedPath, target.ext, req.operations);
   if (outcome.ok) return { ok: true };
-  return {
-    ok: false,
-    error: {
-      kind: outcome.error.kind,
-      message: `Operation ${outcome.index + 1} failed: ${outcome.error.message}`,
-    },
-  };
+  // Attribute the failure to a specific operation only when one is known.
+  const message =
+    outcome.index === null
+      ? outcome.error.message
+      : `Operation ${outcome.index + 1} failed: ${outcome.error.message}`;
+  return { ok: false, error: { kind: outcome.error.kind, message } };
 }
 
 async function resolveEditTarget(
@@ -155,11 +159,12 @@ function executeOps(
         operations[0]?.type === "format"
           ? "Formatting supports XLSX files."
           : "Editing supports CSV and XLSX files.";
-      return { ok: false, index: 0, error: { kind: "unsupported_format", message } };
+      return { ok: false, index: null, error: { kind: "unsupported_format", message } };
     } catch (error) {
+      // A throw here is from reading/loading or writing the file, not a single op.
       return {
         ok: false,
-        index: 0,
+        index: null,
         error: {
           kind: "write_error",
           message: error instanceof Error ? error.message : String(error),
@@ -359,17 +364,33 @@ async function runXlsxOps(
   };
 
   for (const [index, op] of operations.entries()) {
-    const failure =
-      op.type === "cell"
-        ? await applyXlsxCellOp(session, op)
-        : await applyXlsxFormatOp(session, op);
+    let failure: EditFailure | null;
+    try {
+      failure =
+        op.type === "cell"
+          ? await applyXlsxCellOp(session, op)
+          : await applyXlsxFormatOp(session, op);
+    } catch (error) {
+      // e.g. an invalid color reaching normalizeColor — attribute it to this op.
+      return {
+        ok: false,
+        index,
+        error: {
+          kind: "write_error",
+          message: error instanceof Error ? error.message : String(error),
+        },
+      };
+    }
     if (failure) return { ok: false, index, error: failure };
   }
 
   const flushed = flushXlsxSession(session);
-  if (!flushed.ok) return { ok: false, index: 0, error: flushed.error };
+  if (!flushed.ok) return { ok: false, index: null, error: flushed.error };
 
-  await writeXlsxSession(session, filePath);
+  // Skip the rewrite entirely when no operation actually mutated the workbook.
+  if (session.dirtyParts.size > 0 || session.stylesDirty) {
+    await writeXlsxSession(session, filePath);
+  }
   return { ok: true };
 }
 

--- a/src/server/spreadsheetEdit.ts
+++ b/src/server/spreadsheetEdit.ts
@@ -579,9 +579,7 @@ function parseStylesheet(xml: string): {
     fontsNode.count = String(fonts.length);
     fillsNode.count = String(fills.length);
     bordersNode.count = String(ensureNodeArray(bordersNode, "border", [defaultBorder()]).length);
-    cellStyleXfsNode.count = String(
-      ensureNodeArray(cellStyleXfsNode, "xf", [defaultXf()]).length,
-    );
+    cellStyleXfsNode.count = String(ensureNodeArray(cellStyleXfsNode, "xf", [defaultXf()]).length);
     cellXfsNode.count = String(cellXfs.length);
   };
 
@@ -690,7 +688,10 @@ function readCellStyleIndex(sheetXml: string, ref: string): string | undefined {
 function applyCellStyle(xml: string, addr: CellAddress, ref: string, styleIndex: number): string {
   const selfClose = new RegExp(`<c\\b[^>]*\\br="${ref}"[^>]*?/>`);
   if (selfClose.test(xml)) {
-    return maybeExpandDimension(xml.replace(selfClose, (cellXml) => setCellStyle(cellXml, styleIndex)), addr);
+    return maybeExpandDimension(
+      xml.replace(selfClose, (cellXml) => setCellStyle(cellXml, styleIndex)),
+      addr,
+    );
   }
   const withChildren = new RegExp(`<c\\b[^>]*\\br="${ref}"[^>]*?>[\\s\\S]*?</c>`);
   if (withChildren.test(xml)) {
@@ -699,7 +700,10 @@ function applyCellStyle(xml: string, addr: CellAddress, ref: string, styleIndex:
       addr,
     );
   }
-  return maybeExpandDimension(insertCell(xml, addr, ref, `<c r="${ref}" s="${styleIndex}"/>`), addr);
+  return maybeExpandDimension(
+    insertCell(xml, addr, ref, `<c r="${ref}" s="${styleIndex}"/>`),
+    addr,
+  );
 }
 
 function setCellStyle(cellXml: string, styleIndex: number): string {

--- a/src/server/spreadsheetPreview.ts
+++ b/src/server/spreadsheetPreview.ts
@@ -1,5 +1,5 @@
-import fs from "node:fs/promises";
 import type { Stats } from "node:fs";
+import fs from "node:fs/promises";
 import path from "node:path";
 import { XMLParser } from "fast-xml-parser";
 import JSZip from "jszip";
@@ -13,20 +13,20 @@ import {
   type SpreadsheetCellStyle,
   type SpreadsheetChartSummary,
   type SpreadsheetColumnWidth,
+  type SpreadsheetFileKind,
   type SpreadsheetFileVersion,
   type SpreadsheetFileVersionResult,
-  type SpreadsheetFileKind,
   type SpreadsheetMergedRange,
   type SpreadsheetPreview,
   type SpreadsheetPreviewCell,
   type SpreadsheetPreviewResult,
-  type SpreadsheetTableSummary,
   type SpreadsheetPreviewViewport,
   type SpreadsheetPreviewViewportRequest,
+  type SpreadsheetSheetSummary,
+  type SpreadsheetTableSummary,
   type SpreadsheetWorkbookSnapshot,
   type SpreadsheetWorkbookSnapshotResult,
   type SpreadsheetWorkbookSnapshotSheet,
-  type SpreadsheetSheetSummary,
 } from "../shared/spreadsheetPreview";
 
 type Worksheet = XLSX.WorkSheet;

--- a/test/spreadsheetEdit.test.ts
+++ b/test/spreadsheetEdit.test.ts
@@ -397,6 +397,55 @@ describe("xlsx single-cell edit (lossless)", () => {
     });
   });
 
+  test("treats an empty batch as a no-op without rewriting the file", async () => {
+    await withTempDir(async (dir) => {
+      const filePath = path.join(dir, "model.xlsx");
+      await fs.writeFile(filePath, await buildWorkbook());
+      const before = await entryBytes(await fs.readFile(filePath));
+      const beforeStat = await fs.stat(filePath);
+
+      const result = await patchSpreadsheetBatch({ cwd: dir, filePath, operations: [] });
+      expect(result).toEqual({ ok: true });
+
+      const after = await entryBytes(await fs.readFile(filePath));
+      const afterStat = await fs.stat(filePath);
+      expect([...after.entries()]).toEqual([...before.entries()]);
+      // The file must not be touched at all (same mtime, no re-zip).
+      expect(afterStat.mtimeMs).toBe(beforeStat.mtimeMs);
+    });
+  });
+
+  test("attributes a thrown batch failure to the offending operation index", async () => {
+    await withTempDir(async (dir) => {
+      const filePath = path.join(dir, "model.xlsx");
+      await fs.writeFile(filePath, await buildWorkbook());
+      const before = await entryBytes(await fs.readFile(filePath));
+
+      const result = await patchSpreadsheetBatch({
+        cwd: dir,
+        filePath,
+        operations: [
+          { type: "cell", sheetName: "Summary", address: "A1", rawInput: "ok" },
+          // Invalid color throws inside normalizeColor; the failure must be
+          // blamed on operation 2, not operation 1.
+          {
+            type: "format",
+            sheetName: "Summary",
+            range: "A1",
+            style: { fillColor: "not-a-color" },
+          },
+        ],
+      });
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.message).toContain("Operation 2 failed");
+      // The aborted batch must leave the file byte-identical.
+      const after = await entryBytes(await fs.readFile(filePath));
+      expect([...after.entries()]).toEqual([...before.entries()]);
+    });
+  });
+
   test("reports not_found for an unknown sheet", async () => {
     await withTempDir(async (dir) => {
       const filePath = path.join(dir, "model.xlsx");

--- a/test/spreadsheetEdit.test.ts
+++ b/test/spreadsheetEdit.test.ts
@@ -341,6 +341,62 @@ describe("xlsx single-cell edit (lossless)", () => {
     });
   });
 
+  test("aborts a batch atomically, leaving the file byte-identical, when an op fails", async () => {
+    await withTempDir(async (dir) => {
+      const filePath = path.join(dir, "model.xlsx");
+      await fs.writeFile(filePath, await buildWorkbook());
+      const before = await entryBytes(await fs.readFile(filePath));
+
+      const result = await patchSpreadsheetBatch({
+        cwd: dir,
+        filePath,
+        operations: [
+          { type: "cell", sheetName: "Summary", address: "A1", rawInput: "Changed" },
+          // Second op has a malformed address, so the whole batch must roll back.
+          { type: "cell", sheetName: "Summary", address: "B", rawInput: "boom" },
+        ],
+      });
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.kind).toBe("parse_error");
+      expect(result.error.message).toContain("Operation 2 failed");
+
+      // Nothing from the partially-applied batch should have touched disk.
+      const after = await entryBytes(await fs.readFile(filePath));
+      expect([...after.entries()]).toEqual([...before.entries()]);
+    });
+  });
+
+  test("serializes concurrent batches to the same file so neither edit is lost", async () => {
+    await withTempDir(async (dir) => {
+      const filePath = path.join(dir, "model.xlsx");
+      await fs.writeFile(filePath, await buildWorkbook());
+
+      const [first, second] = await Promise.all([
+        patchSpreadsheetBatch({
+          cwd: dir,
+          filePath,
+          operations: [{ type: "cell", sheetName: "Summary", address: "A1", rawInput: "One" }],
+        }),
+        patchSpreadsheetBatch({
+          cwd: dir,
+          filePath,
+          operations: [{ type: "cell", sheetName: "Summary", address: "B1", rawInput: "Two" }],
+        }),
+      ]);
+      expect(first).toEqual({ ok: true });
+      expect(second).toEqual({ ok: true });
+
+      const preview = await previewSpreadsheetFile({ cwd: dir, filePath, sheetName: "Summary" });
+      expect(preview.ok).toBe(true);
+      if (!preview.ok) return;
+      const cells = preview.preview.cells.flat();
+      expect(cells.find((cell) => cell.address === "A1")?.value).toBe("One");
+      expect(cells.find((cell) => cell.address === "B1")?.value).toBe("Two");
+    });
+  });
+
   test("reports not_found for an unknown sheet", async () => {
     await withTempDir(async (dir) => {
       const filePath = path.join(dir, "model.xlsx");


### PR DESCRIPTION
## Summary

Follow-up fixes from a review of the canvas-tools spreadsheet work. The headline change makes `patchSpreadsheetBatch` atomic and efficient; the rest are a small token nit and regression tests.

### 1. Batch patches are now one atomic read-modify-write
Previously `patchSpreadsheetBatch` delegated each operation to `editSpreadsheetCell` / `formatSpreadsheetRange`, and **each of those independently re-read and re-wrote the whole file** (full zip load + generate). Consequences:

- The desktop Univer canvas emits one op per changed cell (`diffUniverWorkbookPatches`), so a bulk paste meant *N* sequential full-file rewrites (limit is 2000).
- A mid-batch failure left ops `1..N-1` persisted on disk with no rollback — partial batches.
- Two concurrent batches to the same file could lose edits via read-modify-write races.

Now there's a shared in-memory editing core: the file is read/unzipped **once**, all cell and format ops apply to cached worksheet XML plus a single parsed stylesheet, then the result is validated and written **once**. Single-cell edit, range format, and batch patch all route through the same core, so the lossless/surgical behavior is unchanged — batches just become atomic and avoid redundant rewrites. A per-file write lock (`withFileLock`) serializes concurrent read-modify-write cycles against the same resolved path.

### 2. Semantic theme token
`UniverSpreadsheetCanvas` dirty save-state icon used the raw arbitrary value `text-[var(--accent)]`; switched to the semantic `text-primary` token (theme-bridge maps `--color-primary: var(--accent)`).

## Tests
Added two regression tests in `test/spreadsheetEdit.test.ts`:
- **Mid-batch atomicity** — a batch whose 2nd op is invalid leaves the file byte-identical to the original (no partial write).
- **Concurrent serialization** — two concurrent batches editing different cells both land; neither edit is lost.

## Validation
- `bun test test/spreadsheetEdit.test.ts` — 17 pass
- `bun run typecheck` (root + harness + desktop) — pass
- `bun test --max-concurrency 1` — 4307 pass (the single failure is a pre-existing, unrelated full-suite flake in `workspaces-page` that passes in isolation)

https://claude.ai/code/session_01VAPGeo1v6uzu9MG7u4DnGN

---
_Generated by [Claude Code](https://claude.ai/code/session_01VAPGeo1v6uzu9MG7u4DnGN)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how workspace XLSX/CSV files are persisted (atomic batches and locking); behavior is well-tested but file I/O semantics shifted from sequential full rewrites.
> 
> **Overview**
> **Spreadsheet batch editing** is refactored so `patchSpreadsheetBatch` (and single-cell edit/format) share one **atomic read–modify–write** path: the workbook is read/unzipped once, operations apply in memory, then the file is written once. That removes the old pattern of re-reading and re-writing the whole file per operation (which hurt Univer canvas saves with many cell ops) and **rolls back on mid-batch failure** so partial batches never hit disk. A **per-file write lock** serializes concurrent edits to the same path.
> 
> **Regression tests** cover failed-batch byte identity, concurrent batches both landing, empty batches not touching the file, and errors attributed to the failing operation index.
> 
> **Desktop polish:** Univer dirty save icon uses `text-primary`; spreadsheet formatting toolbar gets `role="toolbar"` / `role="group"`; global `box-sizing` and formula-bar height override with a Biome ignore; minor import/formatting and notarize retry-expression style only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9c908391ce41f10ab030536d85721874b5b6b28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->