### PR TITLE
test: recover watcher and steer coverage

### DIFF
--- a/src/server/webDesktopService.ts
+++ b/src/server/webDesktopService.ts
@@ -747,6 +747,7 @@ export class WebDesktopService implements WebDesktopServiceLike {
   private readonly stateChangeListeners = new Set<() => void>();
   private stateWatcher: fsSync.FSWatcher | null = null;
   private stateWatcherDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+  private stateWatcherLastSignature: string | null = null;
 
   constructor(
     opts: {
@@ -812,6 +813,7 @@ export class WebDesktopService implements WebDesktopServiceLike {
     await writeTextFileAtomic(this.stateFilePath, JSON.stringify(normalized, null, 2), {
       mode: PRIVATE_FILE_MODE,
     });
+    this.stateWatcherLastSignature = this.readStateFileSignature();
     this.notifyStateChangeListeners();
     return normalized;
   }
@@ -839,6 +841,7 @@ export class WebDesktopService implements WebDesktopServiceLike {
     }
 
     fsSync.mkdirSync(this.userDataDir, { recursive: true, mode: PRIVATE_DIR_MODE });
+    this.stateWatcherLastSignature = this.readStateFileSignature();
     this.stateWatcher = fsSync.watch(this.userDataDir, (eventType, filename) => {
       if (filename && filename !== "state.json") {
         return;
@@ -851,6 +854,11 @@ export class WebDesktopService implements WebDesktopServiceLike {
       }
       this.stateWatcherDebounceTimer = setTimeout(() => {
         this.stateWatcherDebounceTimer = null;
+        const signature = this.readStateFileSignature();
+        if (signature === this.stateWatcherLastSignature) {
+          return;
+        }
+        this.stateWatcherLastSignature = signature;
         this.notifyStateChangeListeners();
       }, 25);
       (this.stateWatcherDebounceTimer as { unref?: () => void }).unref?.();
@@ -864,6 +872,23 @@ export class WebDesktopService implements WebDesktopServiceLike {
     }
     this.stateWatcher?.close();
     this.stateWatcher = null;
+    this.stateWatcherLastSignature = null;
+  }
+
+  private readStateFileSignature(): string | null {
+    try {
+      const stat = fsSync.statSync(this.stateFilePath);
+      return `${stat.dev}:${stat.ino}:${stat.size}:${stat.mtimeMs}`;
+    } catch (error) {
+      const code =
+        typeof error === "object" && error !== null && "code" in error
+          ? String((error as { code?: unknown }).code)
+          : "";
+      if (code === "ENOENT") {
+        return null;
+      }
+      throw error;
+    }
   }
 
   async listWorkspaces(fallbackCwd: string): Promise<Array<{ name: string; path: string }>> {

--- a/test/providers/codex-app-server-resolver.test.ts
+++ b/test/providers/codex-app-server-resolver.test.ts
@@ -357,10 +357,7 @@ describe("codex app-server resolver", () => {
       },
     });
 
-    expect(probedCalls).toEqual([
-      `${codexCmdPath} --version`,
-      `${codexCmdPath} app-server --help`,
-    ]);
+    expect(probedCalls).toEqual([`${codexCmdPath} --version`, `${codexCmdPath} app-server --help`]);
     expect(command).toEqual({
       command: codexCmdPath,
       args: ["app-server"],

--- a/test/session/agentSession.messaging.test.ts
+++ b/test/session/agentSession.messaging.test.ts
@@ -740,6 +740,134 @@ describe("AgentSession", () => {
       expect(secondSteer).not.toContain("STEER-SKILL-A-BODY-MARKER");
     });
 
+    test("preserves separate batched skill and plugin steer reference contexts", async () => {
+      const dir = await fs.mkdtemp(path.join(os.tmpdir(), "session-steer-batched-refs-"));
+      const skillsDir = path.join(dir, "skills");
+      const skillDir = path.join(skillsDir, "batch-skill");
+      const pluginRoot = path.join(dir, ".cowork", "plugins", "batch-plugin");
+      const pluginManifestDir = path.join(pluginRoot, ".cowork-plugin");
+      const pluginSkillDir = path.join(pluginRoot, "skills", "batch-plugin-skill");
+      await fs.mkdir(skillDir, { recursive: true });
+      await fs.mkdir(pluginSkillDir, { recursive: true });
+      await fs.mkdir(pluginManifestDir, { recursive: true });
+      await fs.writeFile(
+        path.join(skillDir, "SKILL.md"),
+        [
+          "---",
+          'name: "batch-skill"',
+          'description: "Batch skill"',
+          "---",
+          "",
+          "BATCH-SKILL-BODY-MARKER",
+        ].join("\n"),
+        "utf-8",
+      );
+      await fs.writeFile(
+        path.join(pluginManifestDir, "plugin.json"),
+        JSON.stringify({
+          name: "batch-plugin",
+          description: "Batch plugin",
+          skills: "./skills",
+          interface: { displayName: "Batch Plugin" },
+        }),
+        "utf-8",
+      );
+      await fs.writeFile(
+        path.join(pluginSkillDir, "SKILL.md"),
+        [
+          "---",
+          'name: "batch-plugin-skill"',
+          'description: "Batch plugin skill"',
+          "---",
+          "",
+          "Batch plugin skill body",
+        ].join("\n"),
+        "utf-8",
+      );
+      const config = {
+        ...makeConfig(dir),
+        skillsDirs: [skillsDir],
+        workspacePluginsDir: path.join(dir, ".cowork", "plugins"),
+      };
+      const { session } = makeSession({ config });
+      const stepMessages: unknown[][] = [];
+      let referencedPluginsDuringTurn: unknown;
+      let allowSecondStep!: () => void;
+
+      mockRunTurn.mockImplementation(async (params: any) => {
+        const initialMessages = [{ role: "user", content: "go" }];
+        const stepOne = await params.prepareStep?.({ stepNumber: 1, messages: initialMessages });
+        stepMessages.push(stepOne?.messages ?? initialMessages);
+
+        await new Promise<void>((resolve) => {
+          allowSecondStep = resolve;
+        });
+
+        const stepTwo = await params.prepareStep?.({
+          stepNumber: 2,
+          messages: stepMessages[0]!,
+        });
+        stepMessages.push(stepTwo?.messages ?? stepMessages[0]!);
+        referencedPluginsDuringTurn = (
+          session as unknown as { state: { turnReferencedPlugins?: unknown } }
+        ).state.turnReferencedPlugins;
+
+        return {
+          text: "done",
+          reasoningText: undefined,
+          responseMessages: [{ role: "assistant", content: "done" }],
+        };
+      });
+
+      const turnPromise = session.sendUserMessage("go");
+      await new Promise((r) => setTimeout(r, 10));
+
+      await session.sendSteerMessage(
+        "use batched skill",
+        session.activeTurnId!,
+        "steer-batch-skill",
+        undefined,
+        undefined,
+        [{ kind: "skill", name: "batch-skill" }],
+      );
+      await session.sendSteerMessage(
+        "use batched plugin",
+        session.activeTurnId!,
+        "steer-batch-plugin",
+        undefined,
+        undefined,
+        [{ kind: "plugin", name: "batch-plugin" }],
+      );
+      allowSecondStep();
+      await turnPromise;
+
+      expect(stepMessages).toHaveLength(2);
+      const committedSteers = stepMessages[1]!
+        .filter((message) => isRecord(message) && message.role === "user")
+        .slice(-2);
+      expect(committedSteers).toHaveLength(2);
+      const firstSteer = JSON.stringify(committedSteers[0]);
+      const secondSteer = JSON.stringify(committedSteers[1]);
+      expect(firstSteer).toContain("Reference context for this steer");
+      expect(firstSteer).toContain("use batched skill");
+      expect(firstSteer).toContain("BATCH-SKILL-BODY-MARKER");
+      expect(firstSteer).not.toContain("Batch Plugin");
+      expect(firstSteer).not.toContain("batch-plugin-skill");
+      expect(secondSteer).toContain("Reference context for this steer");
+      expect(secondSteer).toContain("use batched plugin");
+      expect(secondSteer).toContain("## Referenced Plugins");
+      expect(secondSteer).toContain("Batch Plugin");
+      expect(secondSteer).toContain("batch-plugin-skill");
+      expect(secondSteer).not.toContain("BATCH-SKILL-BODY-MARKER");
+      expect(referencedPluginsDuringTurn).toEqual([
+        {
+          name: "batch-plugin",
+          displayName: "Batch Plugin",
+          skillNames: ["batch-plugin:batch-plugin-skill"],
+        },
+      ]);
+    });
+
     test("injects referenced steer plugin context into the same prepared model step", async () => {
       const dir = await fs.mkdtemp(path.join(os.tmpdir(), "session-steer-pluginref-"));
       const pluginRoot = path.join(dir, ".cowork", "plugins", "demo-plugin");

--- a/test/webDesktopRoutes.test.ts
+++ b/test/webDesktopRoutes.test.ts
@@ -196,6 +196,8 @@ describe("web desktop routes", () => {
         threads: [],
       });
       expect(changeCount).toBe(1);
+      await Bun.sleep(75);
+      expect(changeCount).toBe(1);
     } finally {
       dispose();
       await service.stopAll();
@@ -264,6 +266,46 @@ describe("web desktop routes", () => {
     } finally {
       disposeFirst();
       disposeSecond();
+      await service.stopAll();
+    }
+  });
+
+  test("desktop service watches existing state files until the listener is disposed", async () => {
+    const userDataDir = await makeTempDir("cowork-web-desktop-existing-watch-userdata-");
+    const statePath = path.join(userDataDir, "state.json");
+    await fs.writeFile(
+      statePath,
+      JSON.stringify({ version: 2, workspaces: [], threads: [] }),
+      "utf8",
+    );
+    const service = new WebDesktopService({ userDataDir });
+    let changeCount = 0;
+    const dispose = service.watchStateChanges(() => {
+      changeCount += 1;
+    });
+
+    try {
+      await fs.writeFile(path.join(userDataDir, "other.json"), "{}", "utf8");
+      await Bun.sleep(75);
+      expect(changeCount).toBe(0);
+
+      await fs.writeFile(
+        statePath,
+        JSON.stringify({ version: 2, workspaces: [], threads: [], developerMode: true }),
+        "utf8",
+      );
+      await waitForCondition(() => changeCount === 1);
+
+      dispose();
+      await fs.writeFile(
+        statePath,
+        JSON.stringify({ version: 2, workspaces: [], threads: [], developerMode: false }),
+        "utf8",
+      );
+      await Bun.sleep(75);
+      expect(changeCount).toBe(1);
+    } finally {
+      dispose();
       await service.stopAll();
     }
   });


### PR DESCRIPTION
## Summary

- Recover the missing desktop state watcher regression for pre-existing state files, unrelated directory noise, and listener disposal.
- Track the last observed state.json signature so filename-less fs.watch directory events and local saveState self-writes do not emit duplicate state-change notifications.
- Add the corrected batched steer reference regression so separate skill and plugin references stay attached to the steer that requested them.

## Verification

- bun test test/webDesktopRoutes.test.ts --max-concurrency 1
- bun test test/webDesktopRoutes.test.ts test/session/agentSession.messaging.test.ts --max-concurrency 1
- bun test --max-concurrency 1
- bun run typecheck
- bun run docs:check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to desktop persisted-state change notifications and test coverage; no auth, payments, or broad API surface.
> 
> **Overview**
> **Desktop `state.json` watchers** now track a file signature (`dev:ino:size:mtime`) and skip debounced notifications when nothing actually changed. That avoids duplicate callbacks from `saveState` self-writes and from noisy directory `fs.watch` events (including events without a filename).
> 
> **Tests** lock this in: no extra notification after `saveState`, pre-existing `state.json` still watched until dispose, unrelated files ignored. A new **agent session** test asserts that two queued steers keep **skill** vs **plugin** reference context on the correct steer message and turn plugin tracking. Minor test formatting in the Codex app-server resolver test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04adfee7c32f1de3274b1de33a326fce280b3c77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->