### PR TITLE
fix(desktop): allow Files panel to browse global one-off chat session dirs

### DIFF
--- a/apps/desktop/electron/ipc/files.ts
+++ b/apps/desktop/electron/ipc/files.ts
@@ -66,11 +66,12 @@ export function registerFilesIpc(context: DesktopIpcModuleContext): void {
     async (_event, args: ListDirectoryInput) => {
       await workspaceRoots.ensureApprovedWorkspaceRoots();
       const input = parseWithSchema(listDirectoryInputSchema, args, "listDirectory options");
-      const approvedRoots = workspaceRoots.getApprovedWorkspaceRoots();
-      if (approvedRoots.length === 0) {
-        throw new Error("No workspace roots available for directory listing");
-      }
-      const safePath = resolveAllowedDirectoryPath(approvedRoots, input.path);
+      // resolveAllowedDirectoryPath also allows the app-managed one-off chats
+      // root, so global chat sessions list correctly even with no project roots.
+      const safePath = resolveAllowedDirectoryPath(
+        workspaceRoots.getApprovedWorkspaceRoots(),
+        input.path,
+      );
 
       const entries = await fs.readdir(safePath, { withFileTypes: true });
       const results = await Promise.all(

--- a/apps/desktop/electron/services/ipcSecurity.ts
+++ b/apps/desktop/electron/services/ipcSecurity.ts
@@ -2,6 +2,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { getOneOffChatsRoot } from "../../../../src/utils/oneOffChats";
 import { isPathEqualOrInside } from "./pathBoundary";
 import { resolveDesktopRendererUrl } from "./rendererUrl";
 import { assertPathWithinRoots } from "./validation";
@@ -55,15 +56,29 @@ export function isTrustedDesktopSenderUrl(senderUrl: string, opts: TrustedSender
   }
 }
 
+/**
+ * Workspace roots plus the app-managed one-off chats home (`~/.cowork/chats`).
+ *
+ * Global "New chat" sessions run with their cwd under `~/.cowork/chats/<session>`,
+ * which the server already trusts as a valid thread workspace (see
+ * `requireWorkspacePath` in `src/server/jsonrpc/routes/shared.ts`). Those session
+ * directories are not persisted as project workspace roots, so the Files panel
+ * must allow them explicitly; otherwise `listDirectory`/`readFile` for a global
+ * chat cwd throws "path is outside allowed workspace roots".
+ */
+function getFilePanelRoots(workspaceRoots: string[]): string[] {
+  return [...workspaceRoots, getOneOffChatsRoot()];
+}
+
 export function resolveAllowedDirectoryPath(
   workspaceRoots: string[],
   requestedPath: string,
 ): string {
-  return assertPathWithinRoots(workspaceRoots, requestedPath, "path");
+  return assertPathWithinRoots(getFilePanelRoots(workspaceRoots), requestedPath, "path");
 }
 
 export function resolveAllowedPath(workspaceRoots: string[], requestedPath: string): string {
-  return assertPathWithinRoots(workspaceRoots, requestedPath, "path");
+  return assertPathWithinRoots(getFilePanelRoots(workspaceRoots), requestedPath, "path");
 }
 
 function getSaveExportSourceRoots(workspaceRoots: string[]): string[] {

--- a/apps/desktop/test/ipc-files.test.ts
+++ b/apps/desktop/test/ipc-files.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
+import { getOneOffChatsRoot } from "../../../src/utils/oneOffChats";
 import { DESKTOP_IPC_CHANNELS } from "../src/lib/desktopApi";
 import { createElectronMock } from "./helpers/mockElectron";
 
@@ -602,6 +603,63 @@ describe("files IPC", () => {
 
     await fs.rm(tempWorkspace, { recursive: true, force: true });
     await fs.rm(outsideDir, { recursive: true, force: true });
+  });
+
+  test("listDirectory lists a global chat session dir without any approved project roots", async () => {
+    const registerFilesIpc = await loadRegisterFilesIpc();
+    const chatsRoot = getOneOffChatsRoot();
+    await fs.mkdir(chatsRoot, { recursive: true });
+    const sessionDir = await fs.mkdtemp(path.join(chatsRoot, "20260601T000000Z-research-"));
+    await fs.writeFile(path.join(sessionDir, "report.md"), "# findings\n", "utf-8");
+    await fs.mkdir(path.join(sessionDir, "assets"));
+
+    const handlers = new Map<
+      string,
+      (event: unknown, args?: unknown) => Promise<unknown> | unknown
+    >();
+    registerFilesIpc({
+      deps: {} as never,
+      workspaceRoots: {
+        async ensureApprovedWorkspaceRoots() {},
+        async refreshApprovedWorkspaceRootsFromState() {},
+        async assertApprovedWorkspacePath(workspacePath: string) {
+          return workspacePath;
+        },
+        async addApprovedWorkspacePath(workspacePath: string) {
+          return workspacePath;
+        },
+        setApprovedWorkspaceRoots() {},
+        getApprovedWorkspaceRoots() {
+          // Reproduces the reported state: only persisted project roots exist
+          // (here: none), so the chat cwd is not an approved workspace root.
+          return [];
+        },
+      },
+      handleDesktopInvoke(channel, handler) {
+        handlers.set(channel, handler as never);
+      },
+      parseWithSchema(schema, value, label) {
+        const parsed = schema.safeParse(value);
+        if (parsed.success) {
+          return parsed.data as never;
+        }
+        throw new Error(`${label} ${parsed.error.issues[0]?.message ?? "is invalid"}`);
+      },
+    });
+
+    const handler = handlers.get(DESKTOP_IPC_CHANNELS.listDirectory);
+    expect(handler).toBeDefined();
+
+    try {
+      const entries = (await handler?.(
+        { sender: {} },
+        { path: sessionDir, includeHidden: false },
+      )) as Array<{ name: string; isDirectory: boolean }>;
+      expect(entries.map((entry) => entry.name)).toEqual(["assets", "report.md"]);
+      expect(entries[0]?.isDirectory).toBe(true);
+    } finally {
+      await fs.rm(sessionDir, { recursive: true, force: true });
+    }
   });
 
   test("copyText rejects non-string payloads before touching clipboard", async () => {

--- a/apps/desktop/test/ipc-security.test.ts
+++ b/apps/desktop/test/ipc-security.test.ts
@@ -217,6 +217,30 @@ describe("desktop IPC security helpers", () => {
     }
   });
 
+  test("resolveAllowedDirectoryPath and resolveAllowedPath allow one-off chat session dirs", async () => {
+    const tempWorkspace = await fs.mkdtemp(path.join(os.tmpdir(), "cowork-desktop-ws-"));
+    const workspaceRoot = await fs.realpath(tempWorkspace);
+    const home = os.homedir();
+    try {
+      const chatDir = path.join(home, ".cowork", "chats", "20260601T000000Z-research-abc123");
+      const chatFile = path.join(chatDir, "report.md");
+      const unrelatedHomePath = path.join(home, ".cowork", "auth", "codex-cli", "auth.json");
+
+      // Global "New chat" cwd lives under ~/.cowork/chats and must be browseable
+      // even though it is not a persisted project workspace root.
+      expect(() => resolveAllowedDirectoryPath([workspaceRoot], chatDir)).not.toThrow();
+      expect(() => resolveAllowedPath([workspaceRoot], chatFile)).not.toThrow();
+      // Other ~/.cowork locations stay off-limits to the Files panel.
+      expect(() => resolveAllowedPath([workspaceRoot], unrelatedHomePath)).toThrow(
+        "outside allowed workspace roots",
+      );
+      // Chat dirs are allowed even when there are no project roots at all.
+      expect(() => resolveAllowedDirectoryPath([], chatDir)).not.toThrow();
+    } finally {
+      await fs.rm(tempWorkspace, { recursive: true, force: true });
+    }
+  });
+
   test("resolveAllowedRevealPath allows ~/.cowork and ~/.cowork paths for skill folders", async () => {
     const tempWorkspace = await fs.mkdtemp(path.join(os.tmpdir(), "cowork-desktop-ws-"));
     const workspaceRoot = await fs.realpath(tempWorkspace);

--- a/scripts/build_desktop_resources.ts
+++ b/scripts/build_desktop_resources.ts
@@ -734,7 +734,10 @@ async function pruneStaleDesktopBinaryArtifacts(desktopBinariesDir: string): Pro
       if (!entry.isFile()) {
         continue;
       }
-      if (staleNames.has(entry.name) || staleSuffixes.some((suffix) => entry.name.endsWith(suffix))) {
+      if (
+        staleNames.has(entry.name) ||
+        staleSuffixes.some((suffix) => entry.name.endsWith(suffix))
+      ) {
         await fs.rm(full, { force: true });
         removed += 1;
       }

--- a/src/server/webDesktopService.ts
+++ b/src/server/webDesktopService.ts
@@ -18,6 +18,7 @@ import { writeTextFileAtomic } from "../utils/atomicFile";
 import {
   createOneOffChatWorkspace as createOneOffChatWorkspaceDirectory,
   ensureOneOffChatWorkspacePath,
+  getOneOffChatsRoot,
   isPathInsideOneOffChatsRoot,
   normalizeWorkspaceKind,
   type WorkspaceKind,
@@ -910,7 +911,11 @@ export class WebDesktopService implements WebDesktopServiceLike {
   async getWorkspaceRoots(fallbackCwd: string): Promise<string[]> {
     const state = await this.loadState({ fallbackCwd });
     const roots = state.workspaces.map((workspace) => workspace.path);
-    return roots.length > 0 ? roots : [fallbackCwd];
+    const base = roots.length > 0 ? roots : [fallbackCwd];
+    // Global "New chat" sessions run under ~/.cowork/chats/<session> and may not
+    // be persisted as project workspace roots; the file routes must still allow
+    // browsing that app-managed location.
+    return [...base, getOneOffChatsRoot()];
   }
 
   async resolveWorkspaceDirectory(workspacePath: string): Promise<string> {

--- a/test/build-desktop-resources.test.ts
+++ b/test/build-desktop-resources.test.ts
@@ -116,7 +116,9 @@ describe("desktop resource build helpers", () => {
 
       await __internal.pruneStaleDesktopBinaryArtifacts(binariesDir);
 
-      await expect(fs.stat(path.join(binariesDir, "cowork-server-aarch64-apple-darwin"))).resolves.toBeDefined();
+      await expect(
+        fs.stat(path.join(binariesDir, "cowork-server-aarch64-apple-darwin")),
+      ).resolves.toBeDefined();
       await expect(fs.stat(path.join(binariesDir, "index.js.map"))).rejects.toThrow();
       await expect(fs.stat(path.join(binariesDir, "index.js.map.json"))).rejects.toThrow();
       await expect(fs.stat(path.join(binariesDir, "tsconfig.tsbuildinfo"))).rejects.toThrow();

--- a/test/webDesktopRoutes.test.ts
+++ b/test/webDesktopRoutes.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { PassThrough } from "node:stream";
 import { handleWebDesktopRoute } from "../src/server/webDesktopRoutes";
 import { __internal, WebDesktopService } from "../src/server/webDesktopService";
+import { getOneOffChatsRoot } from "../src/utils/oneOffChats";
 
 const cleanupPaths = new Set<string>();
 
@@ -179,6 +180,41 @@ describe("web desktop routes", () => {
     expect(state.desktopFeatureFlagOverrides).toEqual({});
 
     await service.stopAll();
+  });
+
+  test("desktop service allows fs access to global one-off chat session dirs", async () => {
+    const userDataDir = await makeTempDir("cowork-web-desktop-oneoff-userdata-");
+    const workspace = await makeTempDir("cowork-web-desktop-oneoff-ws-");
+    const service = new WebDesktopService({ userDataDir });
+
+    const chatsRoot = getOneOffChatsRoot();
+    await fs.mkdir(chatsRoot, { recursive: true });
+    const sessionDir = await fs.mkdtemp(path.join(chatsRoot, "20260601T000000Z-research-"));
+    cleanupPaths.add(sessionDir);
+    await fs.writeFile(path.join(sessionDir, "report.md"), "# findings\n", "utf8");
+
+    try {
+      const roots = await service.getWorkspaceRoots(workspace);
+      expect(roots).toContain(chatsRoot);
+
+      const listResponse = await handleWebDesktopRoute(
+        new Request(`http://localhost/cowork/fs/list?path=${encodeURIComponent(sessionDir)}`),
+        { cwd: workspace, desktopService: service },
+      );
+      expect(listResponse).not.toBeNull();
+      expect(await readJson(listResponse!)).toEqual([
+        {
+          isDirectory: false,
+          isHidden: false,
+          modifiedAtMs: expect.any(Number),
+          name: "report.md",
+          path: path.join(sessionDir, "report.md"),
+          sizeBytes: 11,
+        },
+      ]);
+    } finally {
+      await service.stopAll();
+    }
   });
 
   test("desktop service notifies watchers when persisted state changes", async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What / Why

On Windows (and everywhere), starting a top-level **New Chat** creates a *global* one-off chat session whose working directory is under `~/.cowork/chats/<session>` (e.g. `C:\Users\maxw6\.cowork\chats\20260601T215404Z-...`). The server already trusts that location as a valid thread workspace (`requireWorkspacePath` in `src/server/jsonrpc/routes/shared.ts`).

However, the desktop **Files panel** sandbox only allowed *persisted project workspace roots* (e.g. `C:\Users\maxw6\Documents\Cowork`, the only entry in `state.json`). When the Files panel called `desktop:listDirectory` for the global chat cwd, the main process ran it through `assertPathWithinRoots(...)`, which threw:

```
path is outside allowed workspace roots
```

The UI surfaced that thrown IPC error directly — the red Files-panel error in the report. The in-memory approved-roots set is also fragile: it gets reset from persisted state on `loadState`/`saveState`, so the chat root added at creation time can be dropped, leaving no way to browse the session's files.

## Fix

Always include the app-managed one-off chats root (`~/.cowork/chats`) in the file-panel allowlist — mirroring how `getSaveExportSourceRoots` already adds `~/.cowork/research` and `getRevealPathRoots` adds `~/.cowork`. This makes Files-panel browsing/file ops on a global chat cwd work regardless of approved-roots timing, while staying bounded to the app's own chat-session location.

- `apps/desktop/electron/services/ipcSecurity.ts`: new `getFilePanelRoots()` helper; `resolveAllowedDirectoryPath` / `resolveAllowedPath` now allow paths under `~/.cowork/chats`.
- `apps/desktop/electron/ipc/files.ts`: `listDirectory` no longer bails with "No workspace roots available" when there are no project roots; the boundary is enforced by `resolveAllowedDirectoryPath` (which allows chat dirs).
- `src/server/webDesktopService.ts`: `getWorkspaceRoots()` appends the chats root so the web/mobile `/cowork/fs/*` routes have the same parity.

Security is unchanged for unrelated paths: other `~/.cowork` locations (e.g. `~/.cowork/auth/...`) are still rejected by the Files panel.

## How to test

`bun test --max-concurrency 1` and `bun run typecheck`.

New regression coverage:
- `apps/desktop/test/ipc-security.test.ts`: chat-session dirs under `~/.cowork/chats` are allowed by `resolveAllowedDirectoryPath`/`resolveAllowedPath` (even with no project roots), while `~/.cowork/auth/...` is rejected.
- `apps/desktop/test/ipc-files.test.ts`: `listDirectory` lists a real global chat session dir end-to-end when `getApprovedWorkspaceRoots()` is empty (reproduces the reported state).
- `test/webDesktopRoutes.test.ts`: `getWorkspaceRoots` includes the chats root and `/cowork/fs/list` serves a chat session dir.

## Notes (out of scope)

The report also mentioned Google showing `Not connected` and `0` API-key pattern matches in diagnostics. That is a separate provider-connect concern, not the Files-panel sandbox bug fixed here, so it is intentionally not addressed in this PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c90e2023-28a9-4e03-946e-8e9a30859d1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c90e2023-28a9-4e03-946e-8e9a30859d1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

