### PR TITLE
fix: harden task RPC authorization

### DIFF
--- a/docs/websocket-protocol.md
+++ b/docs/websocket-protocol.md
@@ -456,7 +456,10 @@ relay mode, an exact desktop-persisted workspace path. In all cases, the resolve
 must have `workspaceKind` `project`. `oneOffChat` workspaces enter Task mode only through the
 ordinary chat-to-task promotion flow, which links and locks the source chat. Task RPCs reject
 outside directories, project-local chat aliases, symlink aliases, drive-relative inputs, and task or
-artifact IDs whose stored workspace does not match the authorized request context.
+artifact IDs whose stored workspace does not match the authorized request context. Workspace-kind
+classification canonicalizes the configured home, global one-off chat root, and requested workspace
+path before applying the `~/.cowork/chats` rule, so filesystem aliases such as symlinked homes do
+not turn hidden one-off chat directories into generic project workspaces.
 
 Every mutation after creation carries `expectedRevision`. A stale revision fails with a structured conflict containing the current task revision so clients can reload rather than overwrite concurrent work.
 
@@ -511,7 +514,11 @@ Notifications:
 Task notifications are fan-out filtered by workspace subscription and task read permission. A
 recipient without conversation access for that workspace receives no task existence, ID, summary,
 question, approval, artifact, thread, checkpoint, or workspace metadata through task
-notifications.
+notifications. A successful authorized request against a project task workspace subscribes that
+connection to task notifications for that workspace; these task subscriptions are additive and
+idempotent across multiple authorized project workspaces on the same connection, and disconnecting
+removes every membership. This is separate from `cowork/control/event`, whose workspace-control
+subscription remains scoped to the latest requested workspace.
 
 ### Research JSON-RPC methods
 

--- a/docs/websocket-protocol.md
+++ b/docs/websocket-protocol.md
@@ -37,10 +37,11 @@ auth, MCP auth, backups, workspace settings, and server-request responses. Readi
 content) requires the `conversations` permission; only `thread/unsubscribe` (subscription teardown)
 stays always-allowed. Newly paired devices default to no `conversations` access until it is granted;
 devices paired before this permission existed are grandfathered to preserve their prior read access.
-Task reads (`task/list`, `task/read`, `task/artifact/read`,
-`task/artifact/version/compare`, and `task/artifact/version/preview`) also require
-`conversations`. Task mutations, lifecycle operations, task thread creation, direct task creation,
-and artifact writes require both `conversations` and `turns`. The whole `cowork/mcp/*` config
+Task reads (`task/list`, `task/read`, `task/artifact/version/compare`, and
+`task/artifact/version/preview`) also require `conversations`. Task mutations, lifecycle operations,
+task thread creation, direct task creation, and artifact writes require both `conversations` and
+`turns`. `task/artifact/read` also requires both `conversations` and `turns` because active legacy
+artifact reads can lazily materialize the immutable baseline. The whole `cowork/mcp/*` config
 surface (except `cowork/mcp/server/auth/*`, which needs the MCP-auth permission) requires the
 workspace-settings permission: `cowork/mcp/servers/read` can expose configured transport
 env/headers, and `cowork/mcp/server/validate` starts the configured stdio MCP command (spawns a
@@ -470,7 +471,7 @@ Requests:
 - `task/blocker/report` — params `{ cwd?, taskId, expectedRevision, description, blocking, workItemId? }`; result `{ task }`
 - `task/blocker/resolve` — params `{ cwd?, taskId, expectedRevision, blockerId }`; result `{ task }`
 - `task/artifact/register` — params `{ cwd?, taskId, expectedRevision, path, title, kind, artifactId?, baseVersionId?, changeSummary?, workItemId?, provenance? }`; captures immutable bytes from a workspace-contained path as a new logical artifact or version and returns `{ task }`; completed, cancelled, and failed tasks reject registration
-- `task/artifact/read` — params `{ cwd?, taskId, artifactId }`; lazily captures a baseline for legacy artifacts when necessary and returns `{ detail }`; completed, cancelled, and failed tasks remain readable but do not create new baselines
+- `task/artifact/read` — params `{ cwd?, taskId, artifactId }`; lazily captures a baseline for legacy artifacts when necessary and returns `{ detail }`; requires both `conversations` and `turns`; completed, cancelled, and failed tasks remain readable but do not create new baselines
 - `task/artifact/version/capture` — params `{ cwd?, taskId, artifactId, expectedRevision, changeSummary? }`; explicitly captures externally edited live bytes and returns `{ task, detail }`; completed, cancelled, and failed tasks reject capture
 - `task/artifact/version/compare` — params `{ cwd?, taskId, artifactId, baseVersionId, targetVersionId }`; returns `{ comparison }` with bounded text, DOCX, PPTX, XLSX, or binary changes
 - `task/artifact/version/preview` — params `{ cwd?, taskId, artifactId, versionId }`; returns `{ versionId, preview }` from immutable historical bytes

--- a/docs/websocket-protocol.md
+++ b/docs/websocket-protocol.md
@@ -36,20 +36,25 @@ auth, MCP auth, backups, workspace settings, and server-request responses. Readi
 (`thread/list`, `thread/read`, `thread/hydrate`, and `thread/resume`, which streams a thread's live
 content) requires the `conversations` permission; only `thread/unsubscribe` (subscription teardown)
 stays always-allowed. Newly paired devices default to no `conversations` access until it is granted;
-devices paired before this permission existed are grandfathered to preserve their prior read access. The whole
-`cowork/mcp/*` config surface (except `cowork/mcp/server/auth/*`, which needs the MCP-auth
-permission) requires the workspace-settings permission: `cowork/mcp/servers/read` can expose
-configured transport env/headers, and `cowork/mcp/server/validate` starts the configured stdio MCP
-command (spawns a local subprocess) while connecting. The `cowork/memory/*` surface (including the
-`cowork/memory/list` and `cowork/memory/advanced/*` reads) likewise requires the workspace-settings
-permission, because memory holds long-lived private user/project content. `cowork/plugins/install/preview` and
-`cowork/skills/install/preview` also require the workspace-settings permission, because they
-materialize an attacker-selectable local or GitHub source (only the passive plugin/skill
-catalog/list/detail reads stay always-allowed). The workspace document surface `cowork/workspace/presentation/preview` (which runs a workspace
-slide module on the host) and `cowork/workspace/spreadsheet/*` (which read bounded CSV/XLSX content
-from a caller-selected `cwd` that is not confined to the active workspace) require the
-workspace-settings permission. `cowork/session/state/read` (workspace/session config, provider
-options, userName/userProfile) also requires the workspace-settings permission, and
+devices paired before this permission existed are grandfathered to preserve their prior read access.
+Task reads (`task/list`, `task/read`, `task/artifact/read`,
+`task/artifact/version/compare`, and `task/artifact/version/preview`) also require
+`conversations`. Task mutations, lifecycle operations, task thread creation, direct task creation,
+and artifact writes require both `conversations` and `turns`. The whole `cowork/mcp/*` config
+surface (except `cowork/mcp/server/auth/*`, which needs the MCP-auth permission) requires the
+workspace-settings permission: `cowork/mcp/servers/read` can expose configured transport
+env/headers, and `cowork/mcp/server/validate` starts the configured stdio MCP command (spawns a
+local subprocess) while connecting. The `cowork/memory/*` surface (including the
+`cowork/memory/list` and `cowork/memory/advanced/*` reads) likewise requires the
+workspace-settings permission, because memory holds long-lived private user/project content.
+`cowork/plugins/install/preview` and `cowork/skills/install/preview` also require the
+workspace-settings permission, because they materialize an attacker-selectable local or GitHub
+source (only the passive plugin/skill catalog/list/detail reads stay always-allowed). The workspace
+document surface `cowork/workspace/presentation/preview` (which runs a workspace slide module on
+the host) and `cowork/workspace/spreadsheet/*` (which read bounded CSV/XLSX content from a
+caller-selected `cwd` that is not confined to the active workspace) require the workspace-settings
+permission. `cowork/session/state/read` (workspace/session config, provider options,
+userName/userProfile) also requires the workspace-settings permission, and
 `cowork/workspace/bootstrap` requires both the workspace-settings and conversations permissions
 because it returns that control state plus thread summaries. None of these are always-allowed
 defaults.
@@ -442,6 +447,13 @@ Cowork no longer injects a direct streamable HTTP MCP server at the ChatGPT Code
 
 Task mode is an explicit, project-scoped work mode alongside standard chat. Creating a task creates a dedicated root session, but task-owned sessions are omitted from `thread/list` and workspace chat bootstrap results. Clients discover and open them through `task/*`; they may still use `thread/read`, `thread/resume`, and `turn/*` after obtaining a task thread's `sessionId` from the task record. Task-owned sessions must be preserved by clients outside ordinary chat-list reconciliation. Once a task reaches `completed`, `failed`, or `cancelled`, its task threads reject `turn/start` and `turn/steer` with `task_locked` until an explicit lifecycle operation (`task/reopen` or `task/retry`) moves it back into active work. The model can create the same object with its one-shot `createTask` tool after collecting a complete brief. Successful chat promotion links the source session, locks that source chat until the task reaches `completed`, `failed`, or `cancelled`, and emits `task/created` so clients can switch to the task workspace.
 
+Task RPCs are authorized in the harness/server. Read-only task methods require the same
+conversation-history permission as `thread/list` and `thread/read`; mutating task methods require
+both conversation access and turn-start access. A provided `cwd` must resolve to the canonical
+active workspace or, in desktop relay mode, an exact desktop-persisted workspace path. Task RPCs
+reject outside directories, project-local chat aliases, symlink aliases, drive-relative inputs, and
+task or artifact IDs whose stored workspace does not match the authorized request context.
+
 Every mutation after creation carries `expectedRevision`. A stale revision fails with a structured conflict containing the current task revision so clients can reload rather than overwrite concurrent work.
 
 Requests:
@@ -491,6 +503,11 @@ Notifications:
 - `task/updated` — params `{ cwd, task }`
 - `task/activity` — params `{ cwd, taskId, activity }`
 - `task/checkpointCreated` — params `{ cwd, taskId, checkpoint }`
+
+Task notifications are fan-out filtered by workspace subscription and task read permission. A
+recipient without conversation access for that workspace receives no task existence, ID, summary,
+question, approval, artifact, thread, checkpoint, or workspace metadata through task
+notifications.
 
 ### Research JSON-RPC methods
 

--- a/docs/websocket-protocol.md
+++ b/docs/websocket-protocol.md
@@ -451,9 +451,11 @@ Task mode is an explicit, project-scoped work mode alongside standard chat. Crea
 Task RPCs are authorized in the harness/server. Read-only task methods require the same
 conversation-history permission as `thread/list` and `thread/read`; mutating task methods require
 both conversation access and turn-start access. A provided `cwd` must resolve to the canonical
-active workspace or, in desktop relay mode, an exact desktop-persisted workspace path. Task RPCs
-reject outside directories, project-local chat aliases, symlink aliases, drive-relative inputs, and
-task or artifact IDs whose stored workspace does not match the authorized request context.
+active workspace or, in desktop relay mode, an exact desktop-persisted workspace path whose
+`workspaceKind` is `project`. `oneOffChat` workspaces enter Task mode only through the ordinary
+chat-to-task promotion flow, which links and locks the source chat. Task RPCs reject outside
+directories, project-local chat aliases, symlink aliases, drive-relative inputs, and task or
+artifact IDs whose stored workspace does not match the authorized request context.
 
 Every mutation after creation carries `expectedRevision`. A stale revision fails with a structured conflict containing the current task revision so clients can reload rather than overwrite concurrent work.
 

--- a/docs/websocket-protocol.md
+++ b/docs/websocket-protocol.md
@@ -459,7 +459,10 @@ outside directories, project-local chat aliases, symlink aliases, drive-relative
 artifact IDs whose stored workspace does not match the authorized request context. Workspace-kind
 classification canonicalizes the configured home, global one-off chat root, and requested workspace
 path before applying the `~/.cowork/chats` rule, so filesystem aliases such as symlinked homes do
-not turn hidden one-off chat directories into generic project workspaces.
+not turn hidden one-off chat directories into generic project workspaces. Legacy desktop records
+whose `project` kind was defaulted from an omitted `workspaceKind` are still classified by path;
+only an explicitly persisted `workspaceKind: "project"` preserves an intentional promoted project
+under the one-off chat root.
 
 Every mutation after creation carries `expectedRevision`. A stale revision fails with a structured conflict containing the current task revision so clients can reload rather than overwrite concurrent work.
 

--- a/docs/websocket-protocol.md
+++ b/docs/websocket-protocol.md
@@ -450,11 +450,12 @@ Task mode is an explicit, project-scoped work mode alongside standard chat. Crea
 
 Task RPCs are authorized in the harness/server. Read-only task methods require the same
 conversation-history permission as `thread/list` and `thread/read`; mutating task methods require
-both conversation access and turn-start access. A provided `cwd` must resolve to the canonical
-active workspace or, in desktop relay mode, an exact desktop-persisted workspace path whose
-`workspaceKind` is `project`. `oneOffChat` workspaces enter Task mode only through the ordinary
-chat-to-task promotion flow, which links and locks the source chat. Task RPCs reject outside
-directories, project-local chat aliases, symlink aliases, drive-relative inputs, and task or
+both conversation access and turn-start access. An omitted `cwd` resolves to the canonical active
+workspace, and a provided `cwd` must resolve to that same canonical active workspace or, in desktop
+relay mode, an exact desktop-persisted workspace path. In all cases, the resolved task workspace
+must have `workspaceKind` `project`. `oneOffChat` workspaces enter Task mode only through the
+ordinary chat-to-task promotion flow, which links and locks the source chat. Task RPCs reject
+outside directories, project-local chat aliases, symlink aliases, drive-relative inputs, and task or
 artifact IDs whose stored workspace does not match the authorized request context.
 
 Every mutation after creation carries `expectedRevision`. A stale revision fails with a structured conflict containing the current task revision so clients can reload rather than overwrite concurrent work.

--- a/src/server/jsonrpc/routes/shared.ts
+++ b/src/server/jsonrpc/routes/shared.ts
@@ -30,14 +30,7 @@ export function requireWorkspacePath(
   }
 
   if (isTaskWorkspaceMethod(method)) {
-    if (!path.isAbsolute(cwd)) {
-      throw new Error(`${method} cwd must use an absolute workspace path`);
-    }
-    const resolvedInput = path.resolve(cwd);
-    const resolved = resolveExistingDirectory(cwd, `${method} cwd`);
-    if (resolvedInput !== resolved) {
-      throw new Error(`${method} cwd must use the canonical workspace path`);
-    }
+    const resolved = resolveCanonicalTaskWorkspacePath(cwd, method);
     if (resolved === fallbackRoot) {
       return resolved;
     }
@@ -54,6 +47,18 @@ export function requireWorkspacePath(
     return resolved;
   }
   throw new Error(`${method} cwd must match the server workspace or a one-off chat workspace`);
+}
+
+export function resolveCanonicalTaskWorkspacePath(cwd: string, method: string): string {
+  if (!path.isAbsolute(cwd)) {
+    throw new Error(`${method} cwd must use an absolute workspace path`);
+  }
+  const resolvedInput = path.resolve(cwd);
+  const resolved = resolveExistingDirectory(cwd, `${method} cwd`);
+  if (resolvedInput !== resolved) {
+    throw new Error(`${method} cwd must use the canonical workspace path`);
+  }
+  return resolved;
 }
 
 function isThreadWorkspaceMethod(method: string): boolean {

--- a/src/server/jsonrpc/routes/shared.ts
+++ b/src/server/jsonrpc/routes/shared.ts
@@ -29,6 +29,21 @@ export function requireWorkspacePath(
     return fallbackRoot;
   }
 
+  if (isTaskWorkspaceMethod(method)) {
+    if (!path.isAbsolute(cwd)) {
+      throw new Error(`${method} cwd must use an absolute workspace path`);
+    }
+    const resolvedInput = path.resolve(cwd);
+    const resolved = resolveExistingDirectory(cwd, `${method} cwd`);
+    if (resolvedInput !== resolved) {
+      throw new Error(`${method} cwd must use the canonical workspace path`);
+    }
+    if (resolved === fallbackRoot) {
+      return resolved;
+    }
+    throw new Error(`${method} cwd must match an authorized workspace`);
+  }
+
   const resolved = resolveExistingDirectory(cwd, `${method} cwd`);
   if (!isThreadWorkspaceMethod(method)) {
     return resolved;
@@ -43,6 +58,10 @@ export function requireWorkspacePath(
 
 function isThreadWorkspaceMethod(method: string): boolean {
   return method === "thread/start" || method === "thread/list";
+}
+
+function isTaskWorkspaceMethod(method: string): boolean {
+  return method.startsWith("task/");
 }
 
 function resolveExistingDirectory(input: string, label: string): string {

--- a/src/server/jsonrpc/routes/tasks.ts
+++ b/src/server/jsonrpc/routes/tasks.ts
@@ -6,6 +6,8 @@ import { ArtifactFingerprintConflictError } from "../../tasks/ArtifactVersionSto
 import { ArtifactConflictError, buildArtifactRevisionPrompt } from "../../tasks/TaskCoordinator";
 import { JSONRPC_ERROR_CODES } from "../protocol";
 import { jsonRpcTaskRequestSchemas } from "../schema.tasks";
+import { getTaskRpcRequiredPermissions } from "../taskPermissions";
+import { listWorkspaceSummaries } from "../workspaceCatalog";
 import type { JsonRpcRequestHandler, JsonRpcRequestHandlerMap, JsonRpcRouteContext } from "./types";
 
 type TaskRequestMethod = keyof typeof jsonRpcTaskRequestSchemas;
@@ -22,6 +24,15 @@ function createTaskHandler<M extends TaskRequestMethod>(
   run: (params: TaskRequestParams<M>) => Promise<unknown> | unknown,
 ): JsonRpcRequestHandler {
   return async (ws, message) => {
+    const deniedPermission = getDeniedTaskPermission(ws, method);
+    if (deniedPermission) {
+      context.jsonrpc.sendError(ws, message.id, {
+        code: JSONRPC_ERROR_CODES.invalidRequest,
+        message: `${method} requires ${deniedPermission} permission`,
+        data: { category: "permission_denied", permission: deniedPermission },
+      });
+      return;
+    }
     const parsed = jsonRpcTaskRequestSchemas[method].safeParse(message.params ?? {});
     if (!parsed.success) {
       context.jsonrpc.sendError(ws, message.id, {
@@ -73,18 +84,48 @@ function createTaskHandler<M extends TaskRequestMethod>(
   };
 }
 
-function resolveCwd(
+function getDeniedTaskPermission(
+  ws: Parameters<JsonRpcRequestHandler>[0],
+  method: TaskRequestMethod,
+): "conversations" | "turns" | null {
+  const requiredPermissions = getTaskRpcRequiredPermissions(method);
+  if (requiredPermissions.includes("conversations") && ws.data?.taskReadAllowed === false) {
+    return "conversations";
+  }
+  if (requiredPermissions.includes("turns") && ws.data?.taskMutationAllowed === false) {
+    return "turns";
+  }
+  return null;
+}
+
+async function resolveCwd(
   context: JsonRpcRouteContext,
   params: { cwd?: string },
   method: string,
-): string {
-  return context.utils.resolveWorkspacePath(params, method);
+): Promise<string> {
+  try {
+    return context.utils.resolveWorkspacePath(params, method);
+  } catch (error) {
+    const requestedCwd = typeof params.cwd === "string" ? params.cwd.trim() : "";
+    if (!requestedCwd || !context.desktopService) {
+      throw error;
+    }
+    const { workspaces } = await listWorkspaceSummaries({
+      workingDirectory: context.getConfig().workingDirectory,
+      desktopService: context.desktopService,
+    });
+    const workspace = workspaces.find((entry) => entry.path === requestedCwd);
+    if (!workspace) {
+      throw error;
+    }
+    return workspace.path;
+  }
 }
 
 export function createTaskRouteHandlers(context: JsonRpcRouteContext): JsonRpcRequestHandlerMap {
   return {
     "task/create": createTaskHandler(context, "task/create", async (params) => {
-      const cwd = resolveCwd(context, params, "task/create");
+      const cwd = await resolveCwd(context, params, "task/create");
       const { cwd: _cwd, provider, model, ...rawCreation } = params;
       const creation = taskCreationInputSchema.parse(rawCreation);
       const existing = context.tasks.getByCreationKey(creation.idempotencyKey, {
@@ -130,24 +171,24 @@ export function createTaskRouteHandlers(context: JsonRpcRouteContext): JsonRpcRe
         );
       return { task: result.task, thread: context.utils.buildThreadFromSession(runtime) };
     }),
-    "task/list": createTaskHandler(context, "task/list", (params) => {
-      const cwd = resolveCwd(context, params, "task/list");
+    "task/list": createTaskHandler(context, "task/list", async (params) => {
+      const cwd = await resolveCwd(context, params, "task/list");
       const tasks = context.tasks.list(cwd);
       return { tasks, total: tasks.length };
     }),
-    "task/read": createTaskHandler(context, "task/read", (params) => ({
-      task: context.tasks.get(params.taskId, resolveCwd(context, params, "task/read")),
+    "task/read": createTaskHandler(context, "task/read", async (params) => ({
+      task: context.tasks.get(params.taskId, await resolveCwd(context, params, "task/read")),
     })),
     "task/updateBrief": createTaskHandler(context, "task/updateBrief", async (params) => ({
       task: await context.tasks.updateBrief({
         ...params,
-        workspacePath: resolveCwd(context, params, "task/updateBrief"),
+        workspacePath: await resolveCwd(context, params, "task/updateBrief"),
       }),
     })),
     "task/updateGraph": createTaskHandler(context, "task/updateGraph", async (params) => ({
       task: await context.tasks.replaceWorkItems({
         taskId: params.taskId,
-        workspacePath: resolveCwd(context, params, "task/updateGraph"),
+        workspacePath: await resolveCwd(context, params, "task/updateGraph"),
         expectedRevision: params.expectedRevision,
         items: params.workItems,
       }),
@@ -155,7 +196,7 @@ export function createTaskRouteHandlers(context: JsonRpcRouteContext): JsonRpcRe
     "task/workItem/claim": createTaskHandler(context, "task/workItem/claim", async (params) => ({
       task: await context.tasks.claimWorkItem({
         taskId: params.taskId,
-        workspacePath: resolveCwd(context, params, "task/workItem/claim"),
+        workspacePath: await resolveCwd(context, params, "task/workItem/claim"),
         workItemId: params.workItemId,
         threadId: params.taskThreadId,
         expectedRevision: params.expectedRevision,
@@ -164,7 +205,7 @@ export function createTaskRouteHandlers(context: JsonRpcRouteContext): JsonRpcRe
     "task/workItem/mark": createTaskHandler(context, "task/workItem/mark", async (params) => ({
       task: await context.tasks.markWorkItem({
         taskId: params.taskId,
-        workspacePath: resolveCwd(context, params, "task/workItem/mark"),
+        workspacePath: await resolveCwd(context, params, "task/workItem/mark"),
         workItemId: params.workItemId,
         expectedRevision: params.expectedRevision,
         status: params.status,
@@ -174,7 +215,7 @@ export function createTaskRouteHandlers(context: JsonRpcRouteContext): JsonRpcRe
     "task/decision/record": createTaskHandler(context, "task/decision/record", async (params) => ({
       task: await context.tasks.recordDecision({
         taskId: params.taskId,
-        workspacePath: resolveCwd(context, params, "task/decision/record"),
+        workspacePath: await resolveCwd(context, params, "task/decision/record"),
         expectedRevision: params.expectedRevision,
         question: params.question,
         resolution: params.resolution,
@@ -190,7 +231,7 @@ export function createTaskRouteHandlers(context: JsonRpcRouteContext): JsonRpcRe
       async (params) =>
         await context.tasks.resolveQuestions({
           taskId: params.taskId,
-          workspacePath: resolveCwd(context, params, "task/questions/resolve"),
+          workspacePath: await resolveCwd(context, params, "task/questions/resolve"),
           expectedRevision: params.expectedRevision,
           answers: params.answers,
         }),
@@ -198,7 +239,7 @@ export function createTaskRouteHandlers(context: JsonRpcRouteContext): JsonRpcRe
     "task/blocker/report": createTaskHandler(context, "task/blocker/report", async (params) => ({
       task: await context.tasks.reportBlocker({
         taskId: params.taskId,
-        workspacePath: resolveCwd(context, params, "task/blocker/report"),
+        workspacePath: await resolveCwd(context, params, "task/blocker/report"),
         expectedRevision: params.expectedRevision,
         description: params.description,
         blocking: params.blocking,
@@ -208,7 +249,7 @@ export function createTaskRouteHandlers(context: JsonRpcRouteContext): JsonRpcRe
     "task/blocker/resolve": createTaskHandler(context, "task/blocker/resolve", async (params) => ({
       task: await context.tasks.resolveBlocker({
         taskId: params.taskId,
-        workspacePath: resolveCwd(context, params, "task/blocker/resolve"),
+        workspacePath: await resolveCwd(context, params, "task/blocker/resolve"),
         expectedRevision: params.expectedRevision,
         blockerId: params.blockerId,
       }),
@@ -219,7 +260,7 @@ export function createTaskRouteHandlers(context: JsonRpcRouteContext): JsonRpcRe
       async (params) => ({
         task: await context.tasks.registerArtifact({
           taskId: params.taskId,
-          workspacePath: resolveCwd(context, params, "task/artifact/register"),
+          workspacePath: await resolveCwd(context, params, "task/artifact/register"),
           expectedRevision: params.expectedRevision,
           path: params.path,
           title: params.title,
@@ -233,7 +274,7 @@ export function createTaskRouteHandlers(context: JsonRpcRouteContext): JsonRpcRe
       }),
     ),
     "task/artifact/read": createTaskHandler(context, "task/artifact/read", async (params) => {
-      const workspacePath = resolveCwd(context, params, "task/artifact/read");
+      const workspacePath = await resolveCwd(context, params, "task/artifact/read");
       let detail = context.tasks.getArtifactDetail({
         taskId: params.taskId,
         workspacePath,
@@ -275,7 +316,7 @@ export function createTaskRouteHandlers(context: JsonRpcRouteContext): JsonRpcRe
       async (params) => {
         const result = await context.tasks.captureArtifactVersion({
           taskId: params.taskId,
-          workspacePath: resolveCwd(context, params, "task/artifact/version/capture"),
+          workspacePath: await resolveCwd(context, params, "task/artifact/version/capture"),
           artifactId: params.artifactId,
           expectedRevision: params.expectedRevision,
           changeSummary: params.changeSummary,
@@ -287,7 +328,7 @@ export function createTaskRouteHandlers(context: JsonRpcRouteContext): JsonRpcRe
       context,
       "task/artifact/version/compare",
       async (params) => {
-        const workspacePath = resolveCwd(context, params, "task/artifact/version/compare");
+        const workspacePath = await resolveCwd(context, params, "task/artifact/version/compare");
         const [before, after] = await Promise.all([
           context.tasks.readArtifactVersion({
             taskId: params.taskId,
@@ -324,7 +365,7 @@ export function createTaskRouteHandlers(context: JsonRpcRouteContext): JsonRpcRe
       async (params) => {
         const source = await context.tasks.readArtifactVersion({
           taskId: params.taskId,
-          workspacePath: resolveCwd(context, params, "task/artifact/version/preview"),
+          workspacePath: await resolveCwd(context, params, "task/artifact/version/preview"),
           artifactId: params.artifactId,
           versionId: params.versionId,
         });
@@ -342,7 +383,7 @@ export function createTaskRouteHandlers(context: JsonRpcRouteContext): JsonRpcRe
       context,
       "task/artifact/version/restore",
       async (params) => {
-        const workspacePath = resolveCwd(context, params, "task/artifact/version/restore");
+        const workspacePath = await resolveCwd(context, params, "task/artifact/version/restore");
         const detail = context.tasks.getArtifactDetail({
           taskId: params.taskId,
           workspacePath,
@@ -368,7 +409,7 @@ export function createTaskRouteHandlers(context: JsonRpcRouteContext): JsonRpcRe
       async (params) => {
         return await context.tasks.acceptArtifactVersion({
           taskId: params.taskId,
-          workspacePath: resolveCwd(context, params, "task/artifact/version/accept"),
+          workspacePath: await resolveCwd(context, params, "task/artifact/version/accept"),
           artifactId: params.artifactId,
           versionId: params.versionId,
           expectedRevision: params.expectedRevision,
@@ -381,7 +422,7 @@ export function createTaskRouteHandlers(context: JsonRpcRouteContext): JsonRpcRe
       async (params) => {
         const result = await context.tasks.startArtifactRevision({
           taskId: params.taskId,
-          workspacePath: resolveCwd(context, params, "task/artifact/revision/start"),
+          workspacePath: await resolveCwd(context, params, "task/artifact/revision/start"),
           artifactId: params.artifactId,
           instruction: params.instruction,
           baseVersionId: params.baseVersionId,
@@ -415,7 +456,7 @@ export function createTaskRouteHandlers(context: JsonRpcRouteContext): JsonRpcRe
     "task/thread/create": createTaskHandler(context, "task/thread/create", async (params) => {
       const before = context.tasks.get(
         params.taskId,
-        resolveCwd(context, params, "task/thread/create"),
+        await resolveCwd(context, params, "task/thread/create"),
       );
       if (!before) throw new Error(`Unknown task: ${params.taskId}`);
       const task = await context.tasks.addThread({
@@ -441,7 +482,7 @@ export function createTaskRouteHandlers(context: JsonRpcRouteContext): JsonRpcRe
       async (params) => ({
         task: await context.tasks.proposeCompletion({
           taskId: params.taskId,
-          workspacePath: resolveCwd(context, params, "task/proposeCompletion"),
+          workspacePath: await resolveCwd(context, params, "task/proposeCompletion"),
           expectedRevision: params.expectedRevision,
           summary: params.summary,
           caveats: params.caveats,
@@ -449,7 +490,7 @@ export function createTaskRouteHandlers(context: JsonRpcRouteContext): JsonRpcRe
       }),
     ),
     "task/cancel": createTaskHandler(context, "task/cancel", async (params) => {
-      const workspacePath = resolveCwd(context, params, "task/cancel");
+      const workspacePath = await resolveCwd(context, params, "task/cancel");
       const task = await context.tasks.transition({
         taskId: params.taskId,
         workspacePath,
@@ -463,14 +504,14 @@ export function createTaskRouteHandlers(context: JsonRpcRouteContext): JsonRpcRe
     "task/accept": createTaskHandler(context, "task/accept", async (params) => ({
       task: await context.tasks.acceptTask({
         taskId: params.taskId,
-        workspacePath: resolveCwd(context, params, "task/accept"),
+        workspacePath: await resolveCwd(context, params, "task/accept"),
         expectedRevision: params.expectedRevision,
       }),
     })),
     "task/requestChanges": createTaskHandler(context, "task/requestChanges", async (params) => ({
       task: await context.tasks.requestChanges({
         taskId: params.taskId,
-        workspacePath: resolveCwd(context, params, "task/requestChanges"),
+        workspacePath: await resolveCwd(context, params, "task/requestChanges"),
         expectedRevision: params.expectedRevision,
         feedback: params.feedback,
       }),
@@ -478,7 +519,7 @@ export function createTaskRouteHandlers(context: JsonRpcRouteContext): JsonRpcRe
     "task/reopen": createTaskHandler(context, "task/reopen", async (params) => ({
       task: await context.tasks.reopenTask({
         taskId: params.taskId,
-        workspacePath: resolveCwd(context, params, "task/reopen"),
+        workspacePath: await resolveCwd(context, params, "task/reopen"),
         expectedRevision: params.expectedRevision,
         reason: params.reason,
       }),
@@ -489,7 +530,7 @@ export function createTaskRouteHandlers(context: JsonRpcRouteContext): JsonRpcRe
       async (params) =>
         await context.tasks.retryTask({
           taskId: params.taskId,
-          workspacePath: resolveCwd(context, params, "task/retry"),
+          workspacePath: await resolveCwd(context, params, "task/retry"),
           expectedRevision: params.expectedRevision,
         }),
     ),

--- a/src/server/jsonrpc/routes/tasks.ts
+++ b/src/server/jsonrpc/routes/tasks.ts
@@ -7,7 +7,7 @@ import { ArtifactConflictError, buildArtifactRevisionPrompt } from "../../tasks/
 import { JSONRPC_ERROR_CODES } from "../protocol";
 import { jsonRpcTaskRequestSchemas } from "../schema.tasks";
 import { getTaskRpcRequiredPermissions } from "../taskPermissions";
-import { listWorkspaceSummaries } from "../workspaceCatalog";
+import { classifyWorkspaceKind, listWorkspaceSummaries } from "../workspaceCatalog";
 import type { JsonRpcRequestHandler, JsonRpcRequestHandlerMap, JsonRpcRouteContext } from "./types";
 
 type TaskRequestMethod = keyof typeof jsonRpcTaskRequestSchemas;
@@ -98,13 +98,36 @@ function getDeniedTaskPermission(
   return null;
 }
 
+async function requireProjectTaskWorkspacePath(
+  context: JsonRpcRouteContext,
+  workspacePath: string,
+  method: string,
+): Promise<string> {
+  if (!context.desktopService) {
+    return workspacePath;
+  }
+  const { workspaces } = await listWorkspaceSummaries({
+    workingDirectory: context.getConfig().workingDirectory,
+    desktopService: context.desktopService,
+    homedir: context.homedir,
+  });
+  const workspace = workspaces.find((entry) => entry.path === workspacePath);
+  const workspaceKind =
+    workspace?.workspaceKind ?? classifyWorkspaceKind({ path: workspacePath }, context.homedir);
+  if (workspaceKind !== "project") {
+    throw new Error(`${method} cwd must match an authorized project workspace`);
+  }
+  return workspace?.path ?? workspacePath;
+}
+
 export async function resolveTaskWorkspacePath(
   context: JsonRpcRouteContext,
   params: { cwd?: string },
   method: string,
 ): Promise<string> {
   try {
-    return context.utils.resolveWorkspacePath(params, method);
+    const workspacePath = context.utils.resolveWorkspacePath(params, method);
+    return await requireProjectTaskWorkspacePath(context, workspacePath, method);
   } catch (error) {
     const requestedCwd = typeof params.cwd === "string" ? params.cwd.trim() : "";
     if (!requestedCwd || !context.desktopService) {
@@ -113,6 +136,7 @@ export async function resolveTaskWorkspacePath(
     const { workspaces } = await listWorkspaceSummaries({
       workingDirectory: context.getConfig().workingDirectory,
       desktopService: context.desktopService,
+      homedir: context.homedir,
     });
     const workspace = workspaces.find((entry) => entry.path === requestedCwd);
     if (!workspace) {

--- a/src/server/jsonrpc/routes/tasks.ts
+++ b/src/server/jsonrpc/routes/tasks.ts
@@ -104,6 +104,10 @@ async function requireProjectTaskWorkspacePath(
   method: string,
 ): Promise<string> {
   if (!context.desktopService) {
+    const workspaceKind = classifyWorkspaceKind({ path: workspacePath }, context.homedir);
+    if (workspaceKind !== "project") {
+      throw new Error(`${method} cwd must match an authorized project workspace`);
+    }
     return workspacePath;
   }
   const { workspaces } = await listWorkspaceSummaries({

--- a/src/server/jsonrpc/routes/tasks.ts
+++ b/src/server/jsonrpc/routes/tasks.ts
@@ -8,6 +8,7 @@ import { JSONRPC_ERROR_CODES } from "../protocol";
 import { jsonRpcTaskRequestSchemas } from "../schema.tasks";
 import { getTaskRpcRequiredPermissions } from "../taskPermissions";
 import { classifyWorkspaceKind, listWorkspaceSummaries } from "../workspaceCatalog";
+import { resolveCanonicalTaskWorkspacePath } from "./shared";
 import type { JsonRpcRequestHandler, JsonRpcRequestHandlerMap, JsonRpcRouteContext } from "./types";
 
 type TaskRequestMethod = keyof typeof jsonRpcTaskRequestSchemas;
@@ -137,12 +138,18 @@ export async function resolveTaskWorkspacePath(
     if (!requestedCwd || !context.desktopService) {
       throw error;
     }
+    let requestedWorkspacePath: string;
+    try {
+      requestedWorkspacePath = resolveCanonicalTaskWorkspacePath(requestedCwd, method);
+    } catch {
+      throw error;
+    }
     const { workspaces } = await listWorkspaceSummaries({
       workingDirectory: context.getConfig().workingDirectory,
       desktopService: context.desktopService,
       homedir: context.homedir,
     });
-    const workspace = workspaces.find((entry) => entry.path === requestedCwd);
+    const workspace = workspaces.find((entry) => entry.path === requestedWorkspacePath);
     if (!workspace) {
       throw error;
     }

--- a/src/server/jsonrpc/routes/tasks.ts
+++ b/src/server/jsonrpc/routes/tasks.ts
@@ -98,7 +98,7 @@ function getDeniedTaskPermission(
   return null;
 }
 
-async function resolveCwd(
+export async function resolveTaskWorkspacePath(
   context: JsonRpcRouteContext,
   params: { cwd?: string },
   method: string,
@@ -125,7 +125,7 @@ async function resolveCwd(
 export function createTaskRouteHandlers(context: JsonRpcRouteContext): JsonRpcRequestHandlerMap {
   return {
     "task/create": createTaskHandler(context, "task/create", async (params) => {
-      const cwd = await resolveCwd(context, params, "task/create");
+      const cwd = await resolveTaskWorkspacePath(context, params, "task/create");
       const { cwd: _cwd, provider, model, ...rawCreation } = params;
       const creation = taskCreationInputSchema.parse(rawCreation);
       const existing = context.tasks.getByCreationKey(creation.idempotencyKey, {
@@ -172,23 +172,26 @@ export function createTaskRouteHandlers(context: JsonRpcRouteContext): JsonRpcRe
       return { task: result.task, thread: context.utils.buildThreadFromSession(runtime) };
     }),
     "task/list": createTaskHandler(context, "task/list", async (params) => {
-      const cwd = await resolveCwd(context, params, "task/list");
+      const cwd = await resolveTaskWorkspacePath(context, params, "task/list");
       const tasks = context.tasks.list(cwd);
       return { tasks, total: tasks.length };
     }),
     "task/read": createTaskHandler(context, "task/read", async (params) => ({
-      task: context.tasks.get(params.taskId, await resolveCwd(context, params, "task/read")),
+      task: context.tasks.get(
+        params.taskId,
+        await resolveTaskWorkspacePath(context, params, "task/read"),
+      ),
     })),
     "task/updateBrief": createTaskHandler(context, "task/updateBrief", async (params) => ({
       task: await context.tasks.updateBrief({
         ...params,
-        workspacePath: await resolveCwd(context, params, "task/updateBrief"),
+        workspacePath: await resolveTaskWorkspacePath(context, params, "task/updateBrief"),
       }),
     })),
     "task/updateGraph": createTaskHandler(context, "task/updateGraph", async (params) => ({
       task: await context.tasks.replaceWorkItems({
         taskId: params.taskId,
-        workspacePath: await resolveCwd(context, params, "task/updateGraph"),
+        workspacePath: await resolveTaskWorkspacePath(context, params, "task/updateGraph"),
         expectedRevision: params.expectedRevision,
         items: params.workItems,
       }),
@@ -196,7 +199,7 @@ export function createTaskRouteHandlers(context: JsonRpcRouteContext): JsonRpcRe
     "task/workItem/claim": createTaskHandler(context, "task/workItem/claim", async (params) => ({
       task: await context.tasks.claimWorkItem({
         taskId: params.taskId,
-        workspacePath: await resolveCwd(context, params, "task/workItem/claim"),
+        workspacePath: await resolveTaskWorkspacePath(context, params, "task/workItem/claim"),
         workItemId: params.workItemId,
         threadId: params.taskThreadId,
         expectedRevision: params.expectedRevision,
@@ -205,7 +208,7 @@ export function createTaskRouteHandlers(context: JsonRpcRouteContext): JsonRpcRe
     "task/workItem/mark": createTaskHandler(context, "task/workItem/mark", async (params) => ({
       task: await context.tasks.markWorkItem({
         taskId: params.taskId,
-        workspacePath: await resolveCwd(context, params, "task/workItem/mark"),
+        workspacePath: await resolveTaskWorkspacePath(context, params, "task/workItem/mark"),
         workItemId: params.workItemId,
         expectedRevision: params.expectedRevision,
         status: params.status,
@@ -215,7 +218,7 @@ export function createTaskRouteHandlers(context: JsonRpcRouteContext): JsonRpcRe
     "task/decision/record": createTaskHandler(context, "task/decision/record", async (params) => ({
       task: await context.tasks.recordDecision({
         taskId: params.taskId,
-        workspacePath: await resolveCwd(context, params, "task/decision/record"),
+        workspacePath: await resolveTaskWorkspacePath(context, params, "task/decision/record"),
         expectedRevision: params.expectedRevision,
         question: params.question,
         resolution: params.resolution,
@@ -231,7 +234,7 @@ export function createTaskRouteHandlers(context: JsonRpcRouteContext): JsonRpcRe
       async (params) =>
         await context.tasks.resolveQuestions({
           taskId: params.taskId,
-          workspacePath: await resolveCwd(context, params, "task/questions/resolve"),
+          workspacePath: await resolveTaskWorkspacePath(context, params, "task/questions/resolve"),
           expectedRevision: params.expectedRevision,
           answers: params.answers,
         }),
@@ -239,7 +242,7 @@ export function createTaskRouteHandlers(context: JsonRpcRouteContext): JsonRpcRe
     "task/blocker/report": createTaskHandler(context, "task/blocker/report", async (params) => ({
       task: await context.tasks.reportBlocker({
         taskId: params.taskId,
-        workspacePath: await resolveCwd(context, params, "task/blocker/report"),
+        workspacePath: await resolveTaskWorkspacePath(context, params, "task/blocker/report"),
         expectedRevision: params.expectedRevision,
         description: params.description,
         blocking: params.blocking,
@@ -249,7 +252,7 @@ export function createTaskRouteHandlers(context: JsonRpcRouteContext): JsonRpcRe
     "task/blocker/resolve": createTaskHandler(context, "task/blocker/resolve", async (params) => ({
       task: await context.tasks.resolveBlocker({
         taskId: params.taskId,
-        workspacePath: await resolveCwd(context, params, "task/blocker/resolve"),
+        workspacePath: await resolveTaskWorkspacePath(context, params, "task/blocker/resolve"),
         expectedRevision: params.expectedRevision,
         blockerId: params.blockerId,
       }),
@@ -260,7 +263,7 @@ export function createTaskRouteHandlers(context: JsonRpcRouteContext): JsonRpcRe
       async (params) => ({
         task: await context.tasks.registerArtifact({
           taskId: params.taskId,
-          workspacePath: await resolveCwd(context, params, "task/artifact/register"),
+          workspacePath: await resolveTaskWorkspacePath(context, params, "task/artifact/register"),
           expectedRevision: params.expectedRevision,
           path: params.path,
           title: params.title,
@@ -274,7 +277,7 @@ export function createTaskRouteHandlers(context: JsonRpcRouteContext): JsonRpcRe
       }),
     ),
     "task/artifact/read": createTaskHandler(context, "task/artifact/read", async (params) => {
-      const workspacePath = await resolveCwd(context, params, "task/artifact/read");
+      const workspacePath = await resolveTaskWorkspacePath(context, params, "task/artifact/read");
       let detail = context.tasks.getArtifactDetail({
         taskId: params.taskId,
         workspacePath,
@@ -316,7 +319,11 @@ export function createTaskRouteHandlers(context: JsonRpcRouteContext): JsonRpcRe
       async (params) => {
         const result = await context.tasks.captureArtifactVersion({
           taskId: params.taskId,
-          workspacePath: await resolveCwd(context, params, "task/artifact/version/capture"),
+          workspacePath: await resolveTaskWorkspacePath(
+            context,
+            params,
+            "task/artifact/version/capture",
+          ),
           artifactId: params.artifactId,
           expectedRevision: params.expectedRevision,
           changeSummary: params.changeSummary,
@@ -328,7 +335,11 @@ export function createTaskRouteHandlers(context: JsonRpcRouteContext): JsonRpcRe
       context,
       "task/artifact/version/compare",
       async (params) => {
-        const workspacePath = await resolveCwd(context, params, "task/artifact/version/compare");
+        const workspacePath = await resolveTaskWorkspacePath(
+          context,
+          params,
+          "task/artifact/version/compare",
+        );
         const [before, after] = await Promise.all([
           context.tasks.readArtifactVersion({
             taskId: params.taskId,
@@ -365,7 +376,11 @@ export function createTaskRouteHandlers(context: JsonRpcRouteContext): JsonRpcRe
       async (params) => {
         const source = await context.tasks.readArtifactVersion({
           taskId: params.taskId,
-          workspacePath: await resolveCwd(context, params, "task/artifact/version/preview"),
+          workspacePath: await resolveTaskWorkspacePath(
+            context,
+            params,
+            "task/artifact/version/preview",
+          ),
           artifactId: params.artifactId,
           versionId: params.versionId,
         });
@@ -383,7 +398,11 @@ export function createTaskRouteHandlers(context: JsonRpcRouteContext): JsonRpcRe
       context,
       "task/artifact/version/restore",
       async (params) => {
-        const workspacePath = await resolveCwd(context, params, "task/artifact/version/restore");
+        const workspacePath = await resolveTaskWorkspacePath(
+          context,
+          params,
+          "task/artifact/version/restore",
+        );
         const detail = context.tasks.getArtifactDetail({
           taskId: params.taskId,
           workspacePath,
@@ -409,7 +428,11 @@ export function createTaskRouteHandlers(context: JsonRpcRouteContext): JsonRpcRe
       async (params) => {
         return await context.tasks.acceptArtifactVersion({
           taskId: params.taskId,
-          workspacePath: await resolveCwd(context, params, "task/artifact/version/accept"),
+          workspacePath: await resolveTaskWorkspacePath(
+            context,
+            params,
+            "task/artifact/version/accept",
+          ),
           artifactId: params.artifactId,
           versionId: params.versionId,
           expectedRevision: params.expectedRevision,
@@ -422,7 +445,11 @@ export function createTaskRouteHandlers(context: JsonRpcRouteContext): JsonRpcRe
       async (params) => {
         const result = await context.tasks.startArtifactRevision({
           taskId: params.taskId,
-          workspacePath: await resolveCwd(context, params, "task/artifact/revision/start"),
+          workspacePath: await resolveTaskWorkspacePath(
+            context,
+            params,
+            "task/artifact/revision/start",
+          ),
           artifactId: params.artifactId,
           instruction: params.instruction,
           baseVersionId: params.baseVersionId,
@@ -456,7 +483,7 @@ export function createTaskRouteHandlers(context: JsonRpcRouteContext): JsonRpcRe
     "task/thread/create": createTaskHandler(context, "task/thread/create", async (params) => {
       const before = context.tasks.get(
         params.taskId,
-        await resolveCwd(context, params, "task/thread/create"),
+        await resolveTaskWorkspacePath(context, params, "task/thread/create"),
       );
       if (!before) throw new Error(`Unknown task: ${params.taskId}`);
       const task = await context.tasks.addThread({
@@ -482,7 +509,7 @@ export function createTaskRouteHandlers(context: JsonRpcRouteContext): JsonRpcRe
       async (params) => ({
         task: await context.tasks.proposeCompletion({
           taskId: params.taskId,
-          workspacePath: await resolveCwd(context, params, "task/proposeCompletion"),
+          workspacePath: await resolveTaskWorkspacePath(context, params, "task/proposeCompletion"),
           expectedRevision: params.expectedRevision,
           summary: params.summary,
           caveats: params.caveats,
@@ -490,7 +517,7 @@ export function createTaskRouteHandlers(context: JsonRpcRouteContext): JsonRpcRe
       }),
     ),
     "task/cancel": createTaskHandler(context, "task/cancel", async (params) => {
-      const workspacePath = await resolveCwd(context, params, "task/cancel");
+      const workspacePath = await resolveTaskWorkspacePath(context, params, "task/cancel");
       const task = await context.tasks.transition({
         taskId: params.taskId,
         workspacePath,
@@ -504,14 +531,14 @@ export function createTaskRouteHandlers(context: JsonRpcRouteContext): JsonRpcRe
     "task/accept": createTaskHandler(context, "task/accept", async (params) => ({
       task: await context.tasks.acceptTask({
         taskId: params.taskId,
-        workspacePath: await resolveCwd(context, params, "task/accept"),
+        workspacePath: await resolveTaskWorkspacePath(context, params, "task/accept"),
         expectedRevision: params.expectedRevision,
       }),
     })),
     "task/requestChanges": createTaskHandler(context, "task/requestChanges", async (params) => ({
       task: await context.tasks.requestChanges({
         taskId: params.taskId,
-        workspacePath: await resolveCwd(context, params, "task/requestChanges"),
+        workspacePath: await resolveTaskWorkspacePath(context, params, "task/requestChanges"),
         expectedRevision: params.expectedRevision,
         feedback: params.feedback,
       }),
@@ -519,7 +546,7 @@ export function createTaskRouteHandlers(context: JsonRpcRouteContext): JsonRpcRe
     "task/reopen": createTaskHandler(context, "task/reopen", async (params) => ({
       task: await context.tasks.reopenTask({
         taskId: params.taskId,
-        workspacePath: await resolveCwd(context, params, "task/reopen"),
+        workspacePath: await resolveTaskWorkspacePath(context, params, "task/reopen"),
         expectedRevision: params.expectedRevision,
         reason: params.reason,
       }),
@@ -530,7 +557,7 @@ export function createTaskRouteHandlers(context: JsonRpcRouteContext): JsonRpcRe
       async (params) =>
         await context.tasks.retryTask({
           taskId: params.taskId,
-          workspacePath: await resolveCwd(context, params, "task/retry"),
+          workspacePath: await resolveTaskWorkspacePath(context, params, "task/retry"),
           expectedRevision: params.expectedRevision,
         }),
     ),

--- a/src/server/jsonrpc/routes/tasks.ts
+++ b/src/server/jsonrpc/routes/tasks.ts
@@ -118,6 +118,9 @@ export async function resolveTaskWorkspacePath(
     if (!workspace) {
       throw error;
     }
+    if (workspace.workspaceKind !== "project") {
+      throw new Error(`${method} cwd must match an authorized project workspace`);
+    }
     return workspace.path;
   }
 }

--- a/src/server/jsonrpc/routes/thread.ts
+++ b/src/server/jsonrpc/routes/thread.ts
@@ -29,6 +29,7 @@ async function resolveThreadListWorkspacePath(
     const { workspaces } = await listWorkspaceSummaries({
       workingDirectory: context.getConfig().workingDirectory,
       desktopService: context.desktopService,
+      homedir: context.homedir,
     });
     const workspace = workspaces.find((entry) => entry.path === requestedCwd);
     if (!workspace) {

--- a/src/server/jsonrpc/routes/types.ts
+++ b/src/server/jsonrpc/routes/types.ts
@@ -54,6 +54,7 @@ export type JsonRpcRequestHandlerMap = Record<string, JsonRpcRequestHandler>;
 
 export interface JsonRpcRouteContext {
   getConfig(): AgentConfig;
+  homedir?: string;
   research: ResearchService;
   tasks: TaskCoordinator;
   threads: {

--- a/src/server/jsonrpc/routes/workspace.ts
+++ b/src/server/jsonrpc/routes/workspace.ts
@@ -28,6 +28,7 @@ export function createWorkspaceRouteHandlers(
       const result = await listWorkspaceSummaries({
         workingDirectory: context.getConfig().workingDirectory,
         desktopService: context.desktopService,
+        homedir: context.homedir,
       });
       context.jsonrpc.sendResult(ws, message.id, result);
     },

--- a/src/server/jsonrpc/taskPermissions.ts
+++ b/src/server/jsonrpc/taskPermissions.ts
@@ -1,0 +1,14 @@
+const TASK_READ_METHODS = new Set([
+  "task/list",
+  "task/read",
+  "task/artifact/read",
+  "task/artifact/version/compare",
+  "task/artifact/version/preview",
+]);
+
+export type TaskRpcPermission = "conversations" | "turns";
+
+export function getTaskRpcRequiredPermissions(method: string): TaskRpcPermission[] {
+  if (!method.startsWith("task/")) return [];
+  return TASK_READ_METHODS.has(method) ? ["conversations"] : ["conversations", "turns"];
+}

--- a/src/server/jsonrpc/taskPermissions.ts
+++ b/src/server/jsonrpc/taskPermissions.ts
@@ -1,7 +1,6 @@
 const TASK_READ_METHODS = new Set([
   "task/list",
   "task/read",
-  "task/artifact/read",
   "task/artifact/version/compare",
   "task/artifact/version/preview",
 ]);

--- a/src/server/jsonrpc/workspaceCatalog.ts
+++ b/src/server/jsonrpc/workspaceCatalog.ts
@@ -30,13 +30,16 @@ function hashWorkspaceId(value: string): string {
   return (hash >>> 0).toString(16).padStart(8, "0");
 }
 
-function buildFallbackWorkspaceSummary(cwd: string): JsonRpcWorkspaceSummary {
+function buildFallbackWorkspaceSummary(
+  cwd: string,
+  homedir?: string | null,
+): JsonRpcWorkspaceSummary {
   const now = new Date().toISOString();
   return {
     id: `server-${hashWorkspaceId(cwd)}`,
     name: path.basename(cwd) || cwd,
     path: cwd,
-    workspaceKind: "project",
+    workspaceKind: classifyWorkspaceKind({ path: cwd }, homedir),
     createdAt: now,
     lastOpenedAt: now,
   };
@@ -100,7 +103,7 @@ export async function listWorkspaceSummaries(opts: {
   homedir?: string | null;
 }): Promise<{ workspaces: JsonRpcWorkspaceSummary[]; activeWorkspaceId: string | null }> {
   if (!opts.desktopService) {
-    const fallback = buildFallbackWorkspaceSummary(opts.workingDirectory);
+    const fallback = buildFallbackWorkspaceSummary(opts.workingDirectory, opts.homedir);
     return {
       workspaces: [fallback],
       activeWorkspaceId: fallback.id,

--- a/src/server/jsonrpc/workspaceCatalog.ts
+++ b/src/server/jsonrpc/workspaceCatalog.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 
 import {
+  getWorkspaceKindSource,
   isPathInsideOneOffChatsRoot,
   normalizeWorkspaceKind,
   type WorkspaceKind,
@@ -45,7 +46,8 @@ export function classifyWorkspaceKind(
   record: { path: string; workspaceKind?: unknown },
   homedir?: string | null,
 ): WorkspaceKind {
-  if (record.workspaceKind === "project") {
+  const kindSource = getWorkspaceKindSource(record);
+  if (record.workspaceKind === "project" && kindSource !== "default") {
     return "project";
   }
   if (

--- a/src/server/jsonrpc/workspaceCatalog.ts
+++ b/src/server/jsonrpc/workspaceCatalog.ts
@@ -41,15 +41,27 @@ function buildFallbackWorkspaceSummary(cwd: string): JsonRpcWorkspaceSummary {
   };
 }
 
+export function classifyWorkspaceKind(
+  record: { path: string; workspaceKind?: unknown },
+  homedir?: string | null,
+): WorkspaceKind {
+  if (record.workspaceKind === "project") {
+    return "project";
+  }
+  if (
+    record.workspaceKind === "oneOffChat" ||
+    isPathInsideOneOffChatsRoot(record.path, homedir ?? undefined)
+  ) {
+    return "oneOffChat";
+  }
+  return normalizeWorkspaceKind(record.workspaceKind);
+}
+
 function toWorkspaceSummary(
   record: Awaited<ReturnType<WebDesktopServiceLike["loadState"]>>["workspaces"][number],
+  homedir?: string | null,
 ): JsonRpcWorkspaceSummary {
-  const workspaceKind =
-    record.workspaceKind === "project"
-      ? "project"
-      : record.workspaceKind === "oneOffChat" || isPathInsideOneOffChatsRoot(record.path)
-        ? "oneOffChat"
-        : normalizeWorkspaceKind(record.workspaceKind);
+  const workspaceKind = classifyWorkspaceKind(record, homedir);
   return {
     id: record.id,
     name: record.name,
@@ -83,6 +95,7 @@ function resolveActiveWorkspaceId(
 export async function listWorkspaceSummaries(opts: {
   workingDirectory: string;
   desktopService?: WebDesktopServiceLike | null;
+  homedir?: string | null;
 }): Promise<{ workspaces: JsonRpcWorkspaceSummary[]; activeWorkspaceId: string | null }> {
   if (!opts.desktopService) {
     const fallback = buildFallbackWorkspaceSummary(opts.workingDirectory);
@@ -93,7 +106,7 @@ export async function listWorkspaceSummaries(opts: {
   }
 
   const state = await opts.desktopService.loadState({ fallbackCwd: opts.workingDirectory });
-  const workspaces = state.workspaces.map(toWorkspaceSummary);
+  const workspaces = state.workspaces.map((record) => toWorkspaceSummary(record, opts.homedir));
   return {
     workspaces,
     activeWorkspaceId: resolveActiveWorkspaceId(workspaces, opts.workingDirectory),

--- a/src/server/runtime/ServerRuntime.ts
+++ b/src/server/runtime/ServerRuntime.ts
@@ -45,6 +45,7 @@ import {
   requireWorkspacePath,
   shouldIncludeJsonRpcThreadSummary,
 } from "../jsonrpc/routes/shared";
+import { resolveTaskWorkspacePath } from "../jsonrpc/routes/tasks";
 import { createJsonRpcTransportAdapter } from "../jsonrpc/transportAdapter";
 import { ResearchService } from "../research/ResearchService";
 import { type PersistedSessionRecord, SessionDb } from "../sessionDb";
@@ -473,12 +474,14 @@ export async function createAgentServerRuntime(
     const params = isPlainObject(message.params) ? message.params : undefined;
     if (params || message.method.startsWith("task/")) {
       try {
-        const cwd = requireWorkspacePath(
-          params ?? {},
-          message.method,
-          config.workingDirectory,
-          opts.homedir,
-        );
+        const cwd = message.method.startsWith("task/")
+          ? await resolveTaskWorkspacePath(jsonRpcRouteContext, params ?? {}, message.method)
+          : requireWorkspacePath(
+              params ?? {},
+              message.method,
+              config.workingDirectory,
+              opts.homedir,
+            );
         workspaceControl.registerSubscriber(ws, cwd);
         taskSubscribers.register(ws, cwd);
       } catch {

--- a/src/server/runtime/ServerRuntime.ts
+++ b/src/server/runtime/ServerRuntime.ts
@@ -399,6 +399,7 @@ export async function createAgentServerRuntime(
 
   const jsonRpcRouteContext: JsonRpcRouteContext = {
     getConfig: () => config,
+    homedir: opts.homedir,
     research,
     tasks,
     threads: {

--- a/src/server/runtime/ServerRuntime.ts
+++ b/src/server/runtime/ServerRuntime.ts
@@ -79,6 +79,10 @@ const loadPromptModule = async (): Promise<typeof import("../../prompt")> => {
 const lazyLoadAgentPrompt: typeof loadAgentPromptFn = async (...args) =>
   await (await loadPromptModule()).loadAgentPrompt(...args);
 
+function shouldRegisterTaskSubscriber(method: string): boolean {
+  return method === "task/list" || method === "task/read";
+}
+
 const lazyLoadSystemPromptWithSkills: typeof loadSystemPromptWithSkillsFn = async (...args) =>
   await (await loadPromptModule()).loadSystemPromptWithSkills(...args);
 
@@ -475,7 +479,8 @@ export async function createAgentServerRuntime(
     const params = isPlainObject(message.params) ? message.params : undefined;
     if (params || message.method.startsWith("task/")) {
       try {
-        const cwd = message.method.startsWith("task/")
+        const isTaskMethod = message.method.startsWith("task/");
+        const cwd = isTaskMethod
           ? await resolveTaskWorkspacePath(jsonRpcRouteContext, params ?? {}, message.method)
           : requireWorkspacePath(
               params ?? {},
@@ -484,7 +489,9 @@ export async function createAgentServerRuntime(
               opts.homedir,
             );
         workspaceControl.registerSubscriber(ws, cwd);
-        taskSubscribers.register(ws, cwd);
+        if (isTaskMethod && shouldRegisterTaskSubscriber(message.method)) {
+          taskSubscribers.register(ws, cwd);
+        }
       } catch {
         // Ignore non-workspace-control requests that do not resolve a cwd.
       }

--- a/src/server/runtime/ServerRuntime.ts
+++ b/src/server/runtime/ServerRuntime.ts
@@ -46,6 +46,8 @@ import {
   shouldIncludeJsonRpcThreadSummary,
 } from "../jsonrpc/routes/shared";
 import { resolveTaskWorkspacePath } from "../jsonrpc/routes/tasks";
+import { jsonRpcTaskRequestSchemas } from "../jsonrpc/schema.tasks";
+import { getTaskRpcRequiredPermissions } from "../jsonrpc/taskPermissions";
 import { createJsonRpcTransportAdapter } from "../jsonrpc/transportAdapter";
 import { ResearchService } from "../research/ResearchService";
 import { type PersistedSessionRecord, SessionDb } from "../sessionDb";
@@ -79,8 +81,18 @@ const loadPromptModule = async (): Promise<typeof import("../../prompt")> => {
 const lazyLoadAgentPrompt: typeof loadAgentPromptFn = async (...args) =>
   await (await loadPromptModule()).loadAgentPrompt(...args);
 
-function shouldRegisterTaskSubscriber(method: string): boolean {
-  return method === "task/list" || method === "task/read";
+function shouldRegisterTaskSubscriber(method: string, ws: StartServerSocket): boolean {
+  if (!Object.hasOwn(jsonRpcTaskRequestSchemas, method)) {
+    return false;
+  }
+  const requiredPermissions = getTaskRpcRequiredPermissions(method);
+  if (requiredPermissions.includes("conversations") && ws.data.taskReadAllowed === false) {
+    return false;
+  }
+  if (requiredPermissions.includes("turns") && ws.data.taskMutationAllowed === false) {
+    return false;
+  }
+  return true;
 }
 
 const lazyLoadSystemPromptWithSkills: typeof loadSystemPromptWithSkillsFn = async (...args) =>
@@ -241,7 +253,54 @@ export async function createAgentServerRuntime(
   const sendQueue = new SocketSendQueue();
   const taskSubscribers = new WorkspaceJsonRpcSubscribers(sendQueue);
   const jsonRpcConnections = new Set<StartServerSocket>();
+  const threadSubscribers = new Map<string, Map<string, StartServerSocket>>();
+  const threadSubscriptionsByConnectionId = new Map<string, Set<string>>();
   let workspaceListRevision = 0;
+  const rememberThreadSubscriber = (ws: StartServerSocket, threadId: string): void => {
+    const connectionId = ws.data.connectionId;
+    if (!connectionId) return;
+    const subscribers = threadSubscribers.get(threadId) ?? new Map<string, StartServerSocket>();
+    subscribers.set(connectionId, ws);
+    threadSubscribers.set(threadId, subscribers);
+
+    const threadIds = threadSubscriptionsByConnectionId.get(connectionId) ?? new Set<string>();
+    threadIds.add(threadId);
+    threadSubscriptionsByConnectionId.set(connectionId, threadIds);
+  };
+  const forgetThreadSubscriber = (ws: StartServerSocket, threadId: string): void => {
+    const connectionId = ws.data.connectionId;
+    if (!connectionId) return;
+    const subscribers = threadSubscribers.get(threadId);
+    subscribers?.delete(connectionId);
+    if (subscribers?.size === 0) threadSubscribers.delete(threadId);
+
+    const threadIds = threadSubscriptionsByConnectionId.get(connectionId);
+    threadIds?.delete(threadId);
+    if (threadIds?.size === 0) threadSubscriptionsByConnectionId.delete(connectionId);
+  };
+  const forgetAllThreadSubscribers = (ws: StartServerSocket): void => {
+    const connectionId = ws.data.connectionId;
+    if (!connectionId) return;
+    const threadIds = threadSubscriptionsByConnectionId.get(connectionId);
+    if (!threadIds) return;
+    for (const threadId of threadIds) {
+      const subscribers = threadSubscribers.get(threadId);
+      subscribers?.delete(connectionId);
+      if (subscribers?.size === 0) threadSubscribers.delete(threadId);
+    }
+    threadSubscriptionsByConnectionId.delete(connectionId);
+  };
+  const subscribeSourceChatToTaskWorkspace = (input: {
+    sourceSessionId: string;
+    workspacePath: string;
+  }): void => {
+    const subscribers = threadSubscribers.get(input.sourceSessionId);
+    if (!subscribers) return;
+    for (const ws of subscribers.values()) {
+      if (ws.data.taskReadAllowed === false) continue;
+      taskSubscribers.register(ws, input.workspacePath);
+    }
+  };
   const broadcastJsonRpcNotification = (method: string, params: unknown) => {
     for (const connection of jsonRpcConnections) {
       if (!connection.data.rpc || !sendQueue.shouldSendNotification(connection, method)) {
@@ -326,6 +385,7 @@ export async function createAgentServerRuntime(
         await skillMutationBus.publish();
       }
     },
+    onTaskCreatedFromChat: subscribeSourceChatToTaskWorkspace,
   });
   tasks.setThreadFactory(async ({ task, provider, model }) => {
     const runtime = registry.createJsonRpcThreadSession(
@@ -420,9 +480,16 @@ export async function createAgentServerRuntime(
           .filter((record): record is PersistedSessionRecord => record !== null),
       listLiveRoot: ({ cwd } = {}) =>
         registry.listLiveRoot({ cwd }).filter((runtime) => !tasks.isTaskThread(runtime.id)),
-      subscribe: (ws, threadId, subscribeOpts) =>
-        jsonRpcTransport.subscribeThread(ws, threadId, subscribeOpts),
-      unsubscribe: (ws, threadId) => jsonRpcTransport.unsubscribeThread(ws, threadId),
+      subscribe: (ws, threadId, subscribeOpts) => {
+        const binding = jsonRpcTransport.subscribeThread(ws, threadId, subscribeOpts);
+        if (binding?.runtime) rememberThreadSubscriber(ws, threadId);
+        return binding;
+      },
+      unsubscribe: (ws, threadId) => {
+        const result = jsonRpcTransport.unsubscribeThread(ws, threadId);
+        if (result === "unsubscribed") forgetThreadSubscriber(ws, threadId);
+        return result;
+      },
       readSnapshot: (threadId) => registry.readThreadSnapshot(threadId),
     },
     workspaceControl: {
@@ -489,7 +556,7 @@ export async function createAgentServerRuntime(
               opts.homedir,
             );
         workspaceControl.registerSubscriber(ws, cwd);
-        if (isTaskMethod && shouldRegisterTaskSubscriber(message.method)) {
+        if (isTaskMethod && shouldRegisterTaskSubscriber(message.method, ws)) {
           taskSubscribers.register(ws, cwd);
         }
       } catch {
@@ -534,6 +601,7 @@ export async function createAgentServerRuntime(
       jsonRpcConnections.delete(ws);
       workspaceControl.removeSubscriber(ws);
       taskSubscribers.remove(ws);
+      forgetAllThreadSubscribers(ws);
       research.unsubscribeAll(ws);
       jsonRpcTransport.closeConnection(ws);
       sendQueue.deleteConnection(ws.data.connectionId);
@@ -553,6 +621,8 @@ export async function createAgentServerRuntime(
       skillMutationBus.stop();
       workspaceControl.clearSubscribers();
       taskSubscribers.clear();
+      threadSubscribers.clear();
+      threadSubscriptionsByConnectionId.clear();
       await registry.disposeAll("server stopping");
       try {
         sessionDb.close();

--- a/src/server/runtime/SessionRegistry.ts
+++ b/src/server/runtime/SessionRegistry.ts
@@ -85,6 +85,7 @@ export type SessionRegistryOptions = {
     allWorkspaces?: boolean;
   }) => Promise<void>;
   onThreadListChanged?: () => void;
+  onTaskCreatedFromChat?: (input: { sourceSessionId: string; workspacePath: string }) => void;
 };
 
 function shouldInvalidateThreadList(evt: SessionEvent): boolean {
@@ -305,6 +306,7 @@ export class SessionRegistry {
     );
     await taskRuntime.lifecycle.waitForPersistenceIdle();
     try {
+      this.options.onTaskCreatedFromChat?.({ sourceSessionId, workspacePath: cwd });
       const result = await this.options.taskCoordinator.createPlanned({
         workspacePath: cwd,
         sessionId: taskRuntime.id,

--- a/src/server/runtime/WorkspaceJsonRpcSubscribers.ts
+++ b/src/server/runtime/WorkspaceJsonRpcSubscribers.ts
@@ -34,6 +34,7 @@ export class WorkspaceJsonRpcSubscribers {
     const subscribers = this.subscribers.get(canonicalWorkspacePath(cwd));
     if (!subscribers) return;
     for (const ws of subscribers.values()) {
+      if (ws.data.taskReadAllowed === false) continue;
       if (!this.sendQueue.shouldSendNotification(ws, method)) continue;
       this.sendQueue.send(ws, { method, params });
     }

--- a/src/server/runtime/WorkspaceJsonRpcSubscribers.ts
+++ b/src/server/runtime/WorkspaceJsonRpcSubscribers.ts
@@ -11,11 +11,6 @@ export class WorkspaceJsonRpcSubscribers {
     const connectionId = ws.data.connectionId;
     if (!connectionId) return;
     const workspacePath = canonicalWorkspacePath(cwd);
-    for (const [registeredPath, subscribers] of this.subscribers) {
-      if (registeredPath === workspacePath) continue;
-      subscribers.delete(connectionId);
-      if (subscribers.size === 0) this.subscribers.delete(registeredPath);
-    }
     const subscribers = this.subscribers.get(workspacePath) ?? new Map<string, StartServerSocket>();
     subscribers.set(connectionId, ws);
     this.subscribers.set(workspacePath, subscribers);

--- a/src/server/startServer/types.ts
+++ b/src/server/startServer/types.ts
@@ -29,6 +29,8 @@ type ServerTransportData = {
   selectedSubprotocol?: string | null;
   connectionId?: string;
   workspaceControlEventsAllowed?: boolean;
+  taskReadAllowed?: boolean;
+  taskMutationAllowed?: boolean;
   rpc?: JsonRpcConnectionState;
 };
 

--- a/src/server/transport/h3/server.ts
+++ b/src/server/transport/h3/server.ts
@@ -9,6 +9,7 @@ import type {
   JsonRpcLiteNotification,
   JsonRpcLiteRequest,
 } from "../../jsonrpc/protocol";
+import { getTaskRpcRequiredPermissions } from "../../jsonrpc/taskPermissions";
 import type { AgentServerRuntime } from "../../runtime/ServerRuntime";
 import type { StartServerSocketData } from "../../startServer/types";
 import {
@@ -138,6 +139,9 @@ function applyTrustedDevicePermissionsToConnection(
 ): void {
   connection.data.workspaceControlEventsAllowed =
     trustedDevice.permissions.workspaceSettings === true;
+  connection.data.taskReadAllowed = trustedDevice.permissions.conversations === true;
+  connection.data.taskMutationAllowed =
+    trustedDevice.permissions.conversations === true && trustedDevice.permissions.turns === true;
 }
 
 function requireAdminToken(req: Request, adminToken: string): Response | null {
@@ -298,7 +302,8 @@ function getRequiredH3Permission(
     return "conversations";
   }
   if (method.startsWith("task/")) {
-    return "conversations";
+    const permissions = getTaskRpcRequiredPermissions(method);
+    return permissions.length === 1 ? (permissions[0] ?? null) : permissions;
   }
   if (method.startsWith("cowork/provider/auth/")) {
     return "providerAuth";

--- a/src/server/webDesktopService.ts
+++ b/src/server/webDesktopService.ts
@@ -22,6 +22,8 @@ import {
   isPathInsideOneOffChatsRoot,
   normalizeWorkspaceKind,
   type WorkspaceKind,
+  type WorkspaceKindSource,
+  withWorkspaceKindSource,
 } from "../utils/oneOffChats";
 
 const SAFE_ID = /^[A-Za-z0-9_-]{1,256}$/;
@@ -204,6 +206,7 @@ function workspaceBasename(workspacePath: string): string {
 async function resolveWorkspacePath(
   value: unknown,
   workspaceKind: WorkspaceKind = "project",
+  opts: { homedir?: string } = {},
 ): Promise<string | null> {
   const candidate = asNonEmptyString(value);
   if (!candidate) {
@@ -211,11 +214,11 @@ async function resolveWorkspacePath(
   }
   const resolved = path.resolve(candidate);
   if (workspaceKind === "oneOffChat") {
-    if (!isPathInsideOneOffChatsRoot(resolved)) {
+    if (!isPathInsideOneOffChatsRoot(resolved, opts.homedir)) {
       return null;
     }
     try {
-      return await ensureOneOffChatWorkspacePath(resolved);
+      return await ensureOneOffChatWorkspacePath(resolved, { homedir: opts.homedir });
     } catch {
       return null;
     }
@@ -263,21 +266,41 @@ function defaultState(): DesktopPersistedState {
 
 function buildFallbackWorkspace(cwd: string): DesktopWorkspaceRecord {
   const now = new Date().toISOString();
-  return {
-    id: `${FALLBACK_WORKSPACE_ID_PREFIX}-${hashValue(cwd)}`,
-    name: workspaceBasename(cwd),
-    path: cwd,
-    createdAt: now,
-    lastOpenedAt: now,
-    wsProtocol: "jsonrpc",
-    workspaceKind: "project",
-    defaultEnableMcp: true,
-    defaultBackupsEnabled: false,
-    yolo: false,
-  };
+  return withWorkspaceKindSource(
+    {
+      id: `${FALLBACK_WORKSPACE_ID_PREFIX}-${hashValue(cwd)}`,
+      name: workspaceBasename(cwd),
+      path: cwd,
+      createdAt: now,
+      lastOpenedAt: now,
+      wsProtocol: "jsonrpc",
+      workspaceKind: "project",
+      defaultEnableMcp: true,
+      defaultBackupsEnabled: false,
+      yolo: false,
+    },
+    "default",
+  );
 }
 
-async function normalizeState(raw: unknown): Promise<DesktopPersistedState> {
+function normalizeWorkspaceKindWithSource(
+  item: Record<string, unknown>,
+  rawWorkspacePath: string | null,
+  homedir?: string,
+): { workspaceKind: WorkspaceKind; source: WorkspaceKindSource } {
+  if (item.workspaceKind === "project" || item.workspaceKind === "oneOffChat") {
+    return { workspaceKind: item.workspaceKind, source: "explicit" };
+  }
+  if (rawWorkspacePath && isPathInsideOneOffChatsRoot(rawWorkspacePath, homedir)) {
+    return { workspaceKind: "oneOffChat", source: "path" };
+  }
+  return { workspaceKind: normalizeWorkspaceKind(item.workspaceKind), source: "default" };
+}
+
+async function normalizeState(
+  raw: unknown,
+  opts: { homedir?: string } = {},
+): Promise<DesktopPersistedState> {
   if (!isRecord(raw)) {
     return defaultState();
   }
@@ -294,30 +317,36 @@ async function normalizeState(raw: unknown): Promise<DesktopPersistedState> {
     const createdAt = asTimestamp(item.createdAt);
     const lastOpenedAt = asTimestamp(item.lastOpenedAt);
     const rawWorkspacePath = asNonEmptyString(item.path);
-    const workspaceKind: WorkspaceKind =
-      item.workspaceKind === "project"
-        ? "project"
-        : rawWorkspacePath && isPathInsideOneOffChatsRoot(rawWorkspacePath)
-          ? "oneOffChat"
-          : normalizeWorkspaceKind(item.workspaceKind);
-    const workspacePath = await resolveWorkspacePath(item.path, workspaceKind);
+    const { workspaceKind, source: workspaceKindSource } = normalizeWorkspaceKindWithSource(
+      item,
+      rawWorkspacePath,
+      opts.homedir,
+    );
+    const workspacePath = await resolveWorkspacePath(item.path, workspaceKind, {
+      homedir: opts.homedir,
+    });
     if (!id || !name || !createdAt || !lastOpenedAt || !workspacePath || seenWorkspaceIds.has(id)) {
       continue;
     }
 
-    workspaces.push({
-      ...item,
-      id,
-      name,
-      path: workspacePath,
-      workspaceKind,
-      createdAt,
-      lastOpenedAt,
-      wsProtocol: "jsonrpc",
-      defaultEnableMcp: asBoolean(item.defaultEnableMcp, true),
-      defaultBackupsEnabled: asBoolean(item.defaultBackupsEnabled, false),
-      yolo: false,
-    });
+    workspaces.push(
+      withWorkspaceKindSource(
+        {
+          ...item,
+          id,
+          name,
+          path: workspacePath,
+          workspaceKind,
+          createdAt,
+          lastOpenedAt,
+          wsProtocol: "jsonrpc",
+          defaultEnableMcp: asBoolean(item.defaultEnableMcp, true),
+          defaultBackupsEnabled: asBoolean(item.defaultBackupsEnabled, false),
+          yolo: false,
+        },
+        workspaceKindSource,
+      ),
+    );
     seenWorkspaceIds.add(id);
   }
 
@@ -773,6 +802,7 @@ async function launchWorkspaceServer(opts: {
 
 export class WebDesktopService implements WebDesktopServiceLike {
   private readonly userDataDir: string;
+  private readonly homedir?: string;
   private readonly serverManagerFactory: () => SourceWorkspaceServerManager;
   private serverManager: SourceWorkspaceServerManager | null;
   private readonly stateChangeListeners = new Set<() => void>();
@@ -789,6 +819,7 @@ export class WebDesktopService implements WebDesktopServiceLike {
     } = {},
   ) {
     this.userDataDir = resolveDesktopUserDataDir(opts.userDataDir, opts.homedir);
+    this.homedir = opts.homedir;
     this.serverManager = opts.serverManager ?? null;
     this.serverManagerFactory =
       opts.serverManagerFactory ?? (() => new SourceWorkspaceServerManager());
@@ -814,7 +845,7 @@ export class WebDesktopService implements WebDesktopServiceLike {
     let state = defaultState();
     try {
       const raw = await fs.readFile(this.stateFilePath, "utf8");
-      state = await normalizeState(JSON.parse(raw));
+      state = await normalizeState(JSON.parse(raw), { homedir: this.homedir });
     } catch (error) {
       const code =
         typeof error === "object" && error !== null && "code" in error
@@ -826,7 +857,9 @@ export class WebDesktopService implements WebDesktopServiceLike {
     }
 
     if (state.workspaces.length === 0 && opts.fallbackCwd) {
-      const fallbackWorkspacePath = await resolveWorkspacePath(opts.fallbackCwd);
+      const fallbackWorkspacePath = await resolveWorkspacePath(opts.fallbackCwd, "project", {
+        homedir: this.homedir,
+      });
       if (fallbackWorkspacePath) {
         state = {
           ...state,
@@ -839,7 +872,7 @@ export class WebDesktopService implements WebDesktopServiceLike {
   }
 
   async saveState(state: unknown): Promise<DesktopPersistedState> {
-    const normalized = await normalizeState(state);
+    const normalized = await normalizeState(state, { homedir: this.homedir });
     await fs.mkdir(this.userDataDir, { recursive: true, mode: PRIVATE_DIR_MODE });
     await writeTextFileAtomic(this.stateFilePath, JSON.stringify(normalized, null, 2), {
       mode: PRIVATE_FILE_MODE,

--- a/src/server/webDesktopService.ts
+++ b/src/server/webDesktopService.ts
@@ -264,7 +264,11 @@ function defaultState(): DesktopPersistedState {
   };
 }
 
-function buildFallbackWorkspace(cwd: string): DesktopWorkspaceRecord {
+function isFallbackWorkspaceId(id: string | null): boolean {
+  return typeof id === "string" && id.startsWith(`${FALLBACK_WORKSPACE_ID_PREFIX}-`);
+}
+
+function buildFallbackWorkspace(cwd: string, workspaceKind: WorkspaceKind): DesktopWorkspaceRecord {
   const now = new Date().toISOString();
   return withWorkspaceKindSource(
     {
@@ -274,24 +278,30 @@ function buildFallbackWorkspace(cwd: string): DesktopWorkspaceRecord {
       createdAt: now,
       lastOpenedAt: now,
       wsProtocol: "jsonrpc",
-      workspaceKind: "project",
+      workspaceKind,
       defaultEnableMcp: true,
       defaultBackupsEnabled: false,
       yolo: false,
     },
-    "default",
+    workspaceKind === "oneOffChat" ? "path" : "default",
   );
 }
 
 function normalizeWorkspaceKindWithSource(
   item: Record<string, unknown>,
+  id: string | null,
   rawWorkspacePath: string | null,
   homedir?: string,
 ): { workspaceKind: WorkspaceKind; source: WorkspaceKindSource } {
+  const isOneOffPath =
+    rawWorkspacePath !== null && isPathInsideOneOffChatsRoot(rawWorkspacePath, homedir);
+  if (item.workspaceKind === "project" && isFallbackWorkspaceId(id) && isOneOffPath) {
+    return { workspaceKind: "oneOffChat", source: "path" };
+  }
   if (item.workspaceKind === "project" || item.workspaceKind === "oneOffChat") {
     return { workspaceKind: item.workspaceKind, source: "explicit" };
   }
-  if (rawWorkspacePath && isPathInsideOneOffChatsRoot(rawWorkspacePath, homedir)) {
+  if (isOneOffPath) {
     return { workspaceKind: "oneOffChat", source: "path" };
   }
   return { workspaceKind: normalizeWorkspaceKind(item.workspaceKind), source: "default" };
@@ -319,6 +329,7 @@ async function normalizeState(
     const rawWorkspacePath = asNonEmptyString(item.path);
     const { workspaceKind, source: workspaceKindSource } = normalizeWorkspaceKindWithSource(
       item,
+      id,
       rawWorkspacePath,
       opts.homedir,
     );
@@ -857,13 +868,20 @@ export class WebDesktopService implements WebDesktopServiceLike {
     }
 
     if (state.workspaces.length === 0 && opts.fallbackCwd) {
-      const fallbackWorkspacePath = await resolveWorkspacePath(opts.fallbackCwd, "project", {
-        homedir: this.homedir,
-      });
+      const fallbackWorkspaceKind = isPathInsideOneOffChatsRoot(opts.fallbackCwd, this.homedir)
+        ? "oneOffChat"
+        : "project";
+      const fallbackWorkspacePath = await resolveWorkspacePath(
+        opts.fallbackCwd,
+        fallbackWorkspaceKind,
+        {
+          homedir: this.homedir,
+        },
+      );
       if (fallbackWorkspacePath) {
         state = {
           ...state,
-          workspaces: [buildFallbackWorkspace(fallbackWorkspacePath)],
+          workspaces: [buildFallbackWorkspace(fallbackWorkspacePath, fallbackWorkspaceKind)],
         };
       }
     }
@@ -968,7 +986,7 @@ export class WebDesktopService implements WebDesktopServiceLike {
   async createOneOffChatWorkspace(
     opts: { titleHint?: string } = {},
   ): Promise<{ name: string; path: string }> {
-    return await createOneOffChatWorkspaceDirectory(opts);
+    return await createOneOffChatWorkspaceDirectory({ ...opts, homedir: this.homedir });
   }
 
   async getWorkspaceRoots(fallbackCwd: string): Promise<string[]> {
@@ -978,7 +996,7 @@ export class WebDesktopService implements WebDesktopServiceLike {
     // Global "New chat" sessions run under ~/.cowork/chats/<session> and may not
     // be persisted as project workspace roots; the file routes must still allow
     // browsing that app-managed location.
-    return [...base, getOneOffChatsRoot()];
+    return [...base, getOneOffChatsRoot(this.homedir)];
   }
 
   async resolveWorkspaceDirectory(workspacePath: string): Promise<string> {

--- a/src/utils/oneOffChats.ts
+++ b/src/utils/oneOffChats.ts
@@ -3,6 +3,8 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
+import { canonicalizePathForBoundaryCheckSync, isPathInside } from "./paths";
+
 const PRIVATE_DIR_MODE = 0o700;
 
 const ONE_OFF_CHAT_WORKSPACE_KIND = "oneOffChat";
@@ -25,15 +27,16 @@ export function getOneOffChatsRoot(homedir = os.homedir()): string {
   return path.join(homedir, ".cowork", "chats");
 }
 
-function pathContains(parent: string, child: string): boolean {
-  const relative = path.relative(parent, child);
-  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
-}
-
 export function isPathInsideOneOffChatsRoot(targetPath: string, homedir = os.homedir()): boolean {
-  const root = path.resolve(getOneOffChatsRoot(homedir));
-  const target = path.resolve(targetPath);
-  return pathContains(root, target);
+  const root = getOneOffChatsRoot(homedir);
+  try {
+    return isPathInside(
+      canonicalizePathForBoundaryCheckSync(root),
+      canonicalizePathForBoundaryCheckSync(targetPath),
+    );
+  } catch {
+    return isPathInside(root, targetPath);
+  }
 }
 
 function slugifyTitle(value: string | undefined): string {

--- a/src/utils/oneOffChats.ts
+++ b/src/utils/oneOffChats.ts
@@ -11,6 +11,29 @@ const ONE_OFF_CHAT_WORKSPACE_KIND = "oneOffChat";
 const PROJECT_WORKSPACE_KIND = "project";
 
 export type WorkspaceKind = typeof PROJECT_WORKSPACE_KIND | typeof ONE_OFF_CHAT_WORKSPACE_KIND;
+export type WorkspaceKindSource = "explicit" | "path" | "default";
+
+const WORKSPACE_KIND_SOURCE: unique symbol = Symbol("workspaceKindSource");
+
+type WorkspaceKindSourceCarrier = {
+  [WORKSPACE_KIND_SOURCE]?: WorkspaceKindSource;
+};
+
+export function getWorkspaceKindSource(record: unknown): WorkspaceKindSource | null {
+  const source = (record as WorkspaceKindSourceCarrier | null)?.[WORKSPACE_KIND_SOURCE];
+  return source === "explicit" || source === "path" || source === "default" ? source : null;
+}
+
+export function withWorkspaceKindSource<T extends object>(
+  record: T,
+  source: WorkspaceKindSource,
+): T {
+  Object.defineProperty(record, WORKSPACE_KIND_SOURCE, {
+    value: source,
+    enumerable: false,
+  });
+  return record;
+}
 
 export type OneOffChatWorkspace = {
   name: string;

--- a/test/h3.mobile-http-jsonrpc.test.ts
+++ b/test/h3.mobile-http-jsonrpc.test.ts
@@ -821,6 +821,84 @@ describe("H3 mobile HTTP JSON-RPC connection", () => {
     connection.close();
   });
 
+  test("splits task reads from task mutations for mobile permissions", async () => {
+    const dispatchedMethods: string[] = [];
+    const runtime = {
+      openHttpConnection() {},
+      handleDecodedMessage(
+        conn: { send(message: string): number },
+        message: JsonRpcLiteRequest | JsonRpcLiteNotification,
+      ) {
+        if ("method" in message) {
+          dispatchedMethods.push(message.method);
+        }
+        if ("id" in message) {
+          conn.send(JSON.stringify({ jsonrpc: "2.0", id: message.id, result: { ok: true } }));
+        }
+      },
+      closeConnection() {},
+    };
+    const connection = __internal.createHttpJsonRpcConnection(runtime as never);
+
+    const defaultRead = await __internal.dispatchHttpRpcPayload(
+      { id: 1, method: "task/list", params: {} },
+      connection,
+      trustedDevice(),
+    );
+    expect(defaultRead.status).toBe(403);
+    await expect(defaultRead.json()).resolves.toEqual({
+      error: "Mobile device permission required: conversations.",
+      permission: "conversations",
+    });
+
+    const readOnly = await __internal.dispatchHttpRpcPayload(
+      { id: 2, method: "task/read", params: { taskId: "task-1" } },
+      connection,
+      trustedDevice({ conversations: true }),
+    );
+    expect(readOnly.status).toBe(200);
+    await expect(readOnly.json()).resolves.toMatchObject({ id: 2, result: { ok: true } });
+
+    const deniedMutation = await __internal.dispatchHttpRpcPayload(
+      {
+        id: 3,
+        method: "task/updateBrief",
+        params: { taskId: "task-1", expectedRevision: 1, title: "Updated" },
+      },
+      connection,
+      trustedDevice({ conversations: true }),
+    );
+    expect(deniedMutation.status).toBe(403);
+    await expect(deniedMutation.json()).resolves.toEqual({
+      error: "Mobile device permission required: turns.",
+      permission: "turns",
+    });
+
+    const allowedMutation = await __internal.dispatchHttpRpcPayload(
+      {
+        id: 4,
+        method: "task/updateBrief",
+        params: { taskId: "task-1", expectedRevision: 1, title: "Updated" },
+      },
+      connection,
+      trustedDevice({ conversations: true, turns: true }),
+    );
+    expect(allowedMutation.status).toBe(200);
+    await expect(allowedMutation.json()).resolves.toMatchObject({ id: 4, result: { ok: true } });
+    expect(dispatchedMethods).toEqual(["task/read", "task/updateBrief"]);
+    expect(__internal.getRequiredH3Permission({ id: 5, method: "task/list", params: {} })).toBe(
+      "conversations",
+    );
+    expect(
+      __internal.getRequiredH3Permission({
+        id: 6,
+        method: "task/updateBrief",
+        params: {},
+      }),
+    ).toEqual(["conversations", "turns"]);
+    connection.close();
+  });
+
   test("blocks workspace state/config reads for default-permission devices before dispatch", async () => {
     const runtime = {
       openHttpConnection() {},

--- a/test/h3.mobile-http-jsonrpc.test.ts
+++ b/test/h3.mobile-http-jsonrpc.test.ts
@@ -874,9 +874,24 @@ describe("H3 mobile HTTP JSON-RPC connection", () => {
       permission: "turns",
     });
 
-    const allowedMutation = await __internal.dispatchHttpRpcPayload(
+    const artifactRead = await __internal.dispatchHttpRpcPayload(
       {
         id: 4,
+        method: "task/artifact/read",
+        params: { taskId: "task-1", artifactId: "artifact-1" },
+      },
+      connection,
+      trustedDevice({ conversations: true }),
+    );
+    expect(artifactRead.status).toBe(403);
+    await expect(artifactRead.json()).resolves.toEqual({
+      error: "Mobile device permission required: turns.",
+      permission: "turns",
+    });
+
+    const allowedMutation = await __internal.dispatchHttpRpcPayload(
+      {
+        id: 5,
         method: "task/updateBrief",
         params: { taskId: "task-1", expectedRevision: 1, title: "Updated" },
       },
@@ -884,14 +899,21 @@ describe("H3 mobile HTTP JSON-RPC connection", () => {
       trustedDevice({ conversations: true, turns: true }),
     );
     expect(allowedMutation.status).toBe(200);
-    await expect(allowedMutation.json()).resolves.toMatchObject({ id: 4, result: { ok: true } });
+    await expect(allowedMutation.json()).resolves.toMatchObject({ id: 5, result: { ok: true } });
     expect(dispatchedMethods).toEqual(["task/read", "task/updateBrief"]);
-    expect(__internal.getRequiredH3Permission({ id: 5, method: "task/list", params: {} })).toBe(
+    expect(__internal.getRequiredH3Permission({ id: 6, method: "task/list", params: {} })).toBe(
       "conversations",
     );
     expect(
       __internal.getRequiredH3Permission({
-        id: 6,
+        id: 7,
+        method: "task/artifact/read",
+        params: {},
+      }),
+    ).toEqual(["conversations", "turns"]);
+    expect(
+      __internal.getRequiredH3Permission({
+        id: 8,
         method: "task/updateBrief",
         params: {},
       }),

--- a/test/jsonrpc.router.test.ts
+++ b/test/jsonrpc.router.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, test } from "bun:test";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 
 import {
   __internal as citationMetadataInternal,
@@ -7,6 +10,7 @@ import {
 import { JSONRPC_ERROR_CODES } from "../src/server/jsonrpc/protocol";
 import { createJsonRpcRequestRouter, type JsonRpcRouteContext } from "../src/server/jsonrpc/routes";
 import { jsonRpcNotificationSchemas } from "../src/server/jsonrpc/schema";
+import { getOneOffChatsRoot } from "../src/utils/oneOffChats";
 
 function createRuntime(session: any) {
   return {
@@ -30,6 +34,7 @@ function createRuntime(session: any) {
 function createRouterHarness(
   opts: {
     workingDirectory?: string;
+    homedir?: string;
     desktopService?: JsonRpcRouteContext["desktopService"];
     resolveWorkspacePath?: JsonRpcRouteContext["utils"]["resolveWorkspacePath"];
     persistedRecords?: Array<{
@@ -75,6 +80,7 @@ function createRouterHarness(
 
   const context: JsonRpcRouteContext = {
     getConfig: () => ({ workingDirectory }) as any,
+    homedir: opts.homedir,
     threads: {
       create: ({ cwd, provider, model }) => {
         created.push({ cwd, provider, model });
@@ -927,6 +933,42 @@ describe("JSON-RPC request router", () => {
         },
       },
     ]);
+  });
+
+  test("workspace/list classifies no-desktop fallback one-off cwd with configured home", async () => {
+    const homedir = await fs.mkdtemp(path.join(os.tmpdir(), "workspace-list-home-"));
+    try {
+      const chatDir = path.join(getOneOffChatsRoot(homedir), "20260620-chat");
+      await fs.mkdir(chatDir, { recursive: true });
+      const chatCwd = await fs.realpath(chatDir);
+      const harness = createRouterHarness({
+        workingDirectory: chatCwd,
+        homedir,
+      });
+
+      await harness.router({} as any, {
+        id: 100,
+        method: "workspace/list",
+        params: {},
+      });
+
+      expect(harness.sent).toEqual([
+        {
+          id: 100,
+          result: {
+            activeWorkspaceId: expect.any(String),
+            workspaces: [
+              expect.objectContaining({
+                path: chatCwd,
+                workspaceKind: "oneOffChat",
+              }),
+            ],
+          },
+        },
+      ]);
+    } finally {
+      await fs.rm(homedir, { recursive: true, force: true });
+    }
   });
 
   test("thread/list applies limit after sorting by updatedAt", async () => {

--- a/test/jsonrpc.task-artifacts-route.test.ts
+++ b/test/jsonrpc.task-artifacts-route.test.ts
@@ -196,11 +196,16 @@ function makeHarness() {
   return { context, results, errors, sentMessages, getBaselineCalls: () => baselineCalls, ...data };
 }
 
-async function invoke(context: JsonRpcRouteContext, method: string, params: unknown) {
+async function invoke(
+  context: JsonRpcRouteContext,
+  method: string,
+  params: unknown,
+  ws: Parameters<ReturnType<typeof createTaskRouteHandlers>[string]>[0] = {} as never,
+) {
   const handler = createTaskRouteHandlers(context)[method];
   if (!handler) throw new Error(`Missing handler: ${method}`);
   const request: JsonRpcLiteRequest = { id: 1, method, params };
-  await handler({} as never, request);
+  await handler(ws, request);
 }
 
 describe("task artifact JSON-RPC routes", () => {
@@ -227,6 +232,71 @@ describe("task artifact JSON-RPC routes", () => {
         acceptedVersionId: null,
       }),
     });
+  });
+
+  test("rejects baseline-producing artifact reads for read-only task callers", async () => {
+    const harness = makeHarness();
+    harness.task.status = "working";
+    harness.detail.versions = [];
+    harness.detail.latestVersionId = null;
+    harness.detail.acceptedVersionId = null;
+
+    await invoke(
+      harness.context,
+      "task/artifact/read",
+      {
+        cwd: "C:\\workspace",
+        taskId: "task-1",
+        artifactId: "artifact-1",
+      },
+      {
+        data: {
+          taskReadAllowed: true,
+          taskMutationAllowed: false,
+        },
+      } as never,
+    );
+
+    expect(harness.results).toEqual([]);
+    expect(harness.getBaselineCalls()).toBe(0);
+    expect(harness.errors).toEqual([
+      {
+        id: 1,
+        error: {
+          code: -32600,
+          message: "task/artifact/read requires turns permission",
+          data: { category: "permission_denied", permission: "turns" },
+        },
+      },
+    ]);
+  });
+
+  test("allows baseline-producing artifact reads for task mutation callers", async () => {
+    const harness = makeHarness();
+    harness.task.status = "working";
+    harness.detail.versions = [];
+    harness.detail.latestVersionId = null;
+    harness.detail.acceptedVersionId = null;
+
+    await invoke(
+      harness.context,
+      "task/artifact/read",
+      {
+        cwd: "C:\\workspace",
+        taskId: "task-1",
+        artifactId: "artifact-1",
+      },
+      {
+        data: {
+          taskReadAllowed: true,
+          taskMutationAllowed: true,
+        },
+      } as never,
+    );
+
+    expect(harness.errors).toEqual([]);
+    expect(harness.getBaselineCalls()).toBe(1);
+    expect(harness.results[0]?.result).toEqual({ detail: harness.detail });
   });
 
   test("compares immutable text versions through the harness", async () => {

--- a/test/jsonrpc.task-workspace-subscription.test.ts
+++ b/test/jsonrpc.task-workspace-subscription.test.ts
@@ -212,6 +212,16 @@ describe("task workspace subscription routing", () => {
       await initializeConnection(runtime, reader);
       await initializeConnection(runtime, mutator);
 
+      const activeListResponse = await sendRequest(runtime, reader, "task/list");
+      expect(activeListResponse.error).toBeUndefined();
+      expect(activeListResponse.result).toEqual({ tasks: [], total: 0 });
+
+      const activeExactListResponse = await sendRequest(runtime, reader, "task/list", {
+        cwd: activePath,
+      });
+      expect(activeExactListResponse.error).toBeUndefined();
+      expect(activeExactListResponse.result).toEqual({ tasks: [], total: 0 });
+
       const listResponse = await sendRequest(runtime, reader, "task/list", {
         cwd: catalogPath,
       });
@@ -328,6 +338,182 @@ describe("task workspace subscription routing", () => {
       expect(secondCreateResponse.error).toBeUndefined();
       await expectNoMessage(aliasReader, (message) => message.method === "task/created");
       await expectNoMessage(outsideReader, (message) => message.method === "task/created");
+    } finally {
+      await runtime?.stop();
+      await fs.rm(home, { recursive: true, force: true });
+    }
+  }, 15_000);
+
+  test("rejects generic task RPCs when the active desktop workspace is a one-off chat", async () => {
+    const home = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "task-active-oneoff-")));
+    const activeOneOffWorkspace = path.join(home, ".cowork", "chats", "20260620-active-oneoff");
+    let runtime: Awaited<ReturnType<typeof createAgentServerRuntime>> | null = null;
+    try {
+      await fs.mkdir(activeOneOffWorkspace, { recursive: true });
+      const activeOneOffPath = await fs.realpath(activeOneOffWorkspace);
+      const desktopService = {
+        loadState: async () => ({
+          version: 2,
+          workspaces: [
+            {
+              id: "active-one-off",
+              name: "Active one-off chat",
+              path: activeOneOffPath,
+              createdAt: "2026-06-20T00:00:00.000Z",
+              lastOpenedAt: "2026-06-20T00:00:00.000Z",
+            },
+          ],
+        }),
+      } as Partial<WebDesktopServiceLike> as WebDesktopServiceLike;
+      const runTurnImpl = createRunTurn({
+        createRuntime: () => ({
+          name: "pi",
+          runTurn: async () => ({
+            text: "done",
+            responseMessages: [],
+          }),
+        }),
+      });
+      runtime = await createAgentServerRuntime({
+        cwd: activeOneOffPath,
+        homedir: home,
+        env: {
+          AGENT_WORKING_DIR: activeOneOffPath,
+          AGENT_PROVIDER: "google",
+          AGENT_OBSERVABILITY_ENABLED: "false",
+          COWORK_SKIP_DEFAULT_SKILLS_BOOTSTRAP: "1",
+        },
+        desktopService,
+        runTurnImpl,
+      });
+
+      const reader = makeSocket("active-one-off-reader");
+      const mutator = makeSocket("active-one-off-mutator");
+      await initializeConnection(runtime, reader);
+      await initializeConnection(runtime, mutator);
+
+      const omittedListResponse = await sendRequest(runtime, reader, "task/list");
+      expect(omittedListResponse.error?.message ?? "").toContain(
+        "cwd must match an authorized project workspace",
+      );
+
+      const exactListResponse = await sendRequest(runtime, reader, "task/list", {
+        cwd: activeOneOffPath,
+      });
+      expect(exactListResponse.error?.message ?? "").toContain(
+        "cwd must match an authorized project workspace",
+      );
+
+      const { cwd: _omittedCreateCwd, ...omittedCreateParams } = createTaskParams(
+        activeOneOffPath,
+        "active-one-off-create-omitted",
+      );
+      const omittedCreateResponse = await sendRequest(
+        runtime,
+        mutator,
+        "task/create",
+        omittedCreateParams,
+      );
+      expect(omittedCreateResponse.error?.message ?? "").toContain(
+        "cwd must match an authorized project workspace",
+      );
+
+      const exactCreateResponse = await sendRequest(
+        runtime,
+        mutator,
+        "task/create",
+        createTaskParams(activeOneOffPath, "active-one-off-create-exact"),
+      );
+      expect(exactCreateResponse.error?.message ?? "").toContain(
+        "cwd must match an authorized project workspace",
+      );
+      await expectNoMessage(reader, (message) => message.method === "task/created");
+
+      const omittedMutationResponse = await sendRequest(runtime, mutator, "task/updateBrief", {
+        taskId: "task-one-off",
+        expectedRevision: 1,
+        title: "Should stay rejected",
+      });
+      expect(omittedMutationResponse.error?.message ?? "").toContain(
+        "cwd must match an authorized project workspace",
+      );
+
+      const exactMutationResponse = await sendRequest(runtime, mutator, "task/updateBrief", {
+        cwd: activeOneOffPath,
+        taskId: "task-one-off",
+        expectedRevision: 1,
+        title: "Should stay rejected",
+      });
+      expect(exactMutationResponse.error?.message ?? "").toContain(
+        "cwd must match an authorized project workspace",
+      );
+      await expectNoMessage(reader, (message) => message.method === "task/updated");
+    } finally {
+      await runtime?.stop();
+      await fs.rm(home, { recursive: true, force: true });
+    }
+  }, 15_000);
+
+  test("non-desktop active project cwd remains authorized for task RPCs", async () => {
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), "task-cli-project-"));
+    const projectWorkspace = path.join(home, "project");
+    let runtime: Awaited<ReturnType<typeof createAgentServerRuntime>> | null = null;
+    try {
+      await fs.mkdir(projectWorkspace, { recursive: true });
+      const projectPath = await fs.realpath(projectWorkspace);
+      const runTurnImpl = createRunTurn({
+        createRuntime: () => ({
+          name: "pi",
+          runTurn: async () => ({
+            text: "done",
+            responseMessages: [],
+          }),
+        }),
+      });
+      runtime = await createAgentServerRuntime({
+        cwd: projectPath,
+        homedir: home,
+        env: {
+          AGENT_WORKING_DIR: projectPath,
+          AGENT_PROVIDER: "google",
+          AGENT_OBSERVABILITY_ENABLED: "false",
+          COWORK_SKIP_DEFAULT_SKILLS_BOOTSTRAP: "1",
+        },
+        runTurnImpl,
+      });
+
+      const reader = makeSocket("cli-project-reader");
+      const mutator = makeSocket("cli-project-mutator");
+      await initializeConnection(runtime, reader);
+      await initializeConnection(runtime, mutator);
+
+      const omittedListResponse = await sendRequest(runtime, reader, "task/list");
+      expect(omittedListResponse.error).toBeUndefined();
+      expect(omittedListResponse.result).toEqual({ tasks: [], total: 0 });
+
+      const exactListResponse = await sendRequest(runtime, reader, "task/list", {
+        cwd: projectPath,
+      });
+      expect(exactListResponse.error).toBeUndefined();
+      expect(exactListResponse.result).toEqual({ tasks: [], total: 0 });
+
+      const { cwd: _omittedCreateCwd, ...omittedCreateParams } = createTaskParams(
+        projectPath,
+        "cli-project-create-omitted",
+      );
+      const createResponse = await sendRequest(
+        runtime,
+        mutator,
+        "task/create",
+        omittedCreateParams,
+      );
+      expect(createResponse.error).toBeUndefined();
+      const createdResult = createResponse.result as {
+        task?: { id?: unknown; revision?: unknown; sourceSessionId?: unknown };
+      };
+      expect(createdResult.task?.sourceSessionId).toBeNull();
+      expect(typeof createdResult.task?.id).toBe("string");
+      expect(typeof createdResult.task?.revision).toBe("number");
     } finally {
       await runtime?.stop();
       await fs.rm(home, { recursive: true, force: true });

--- a/test/jsonrpc.task-workspace-subscription.test.ts
+++ b/test/jsonrpc.task-workspace-subscription.test.ts
@@ -454,6 +454,101 @@ describe("task workspace subscription routing", () => {
     }
   }, 15_000);
 
+  test("rejects generic task RPCs when the non-desktop active workspace is a one-off chat", async () => {
+    const home = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "task-cli-oneoff-")));
+    const activeOneOffWorkspace = path.join(home, ".cowork", "chats", "20260620-cli-oneoff");
+    let runtime: Awaited<ReturnType<typeof createAgentServerRuntime>> | null = null;
+    try {
+      await fs.mkdir(activeOneOffWorkspace, { recursive: true });
+      const activeOneOffPath = await fs.realpath(activeOneOffWorkspace);
+      const runTurnImpl = createRunTurn({
+        createRuntime: () => ({
+          name: "pi",
+          runTurn: async () => ({
+            text: "done",
+            responseMessages: [],
+          }),
+        }),
+      });
+      runtime = await createAgentServerRuntime({
+        cwd: activeOneOffPath,
+        homedir: home,
+        env: {
+          AGENT_WORKING_DIR: activeOneOffPath,
+          AGENT_PROVIDER: "google",
+          AGENT_OBSERVABILITY_ENABLED: "false",
+          COWORK_SKIP_DEFAULT_SKILLS_BOOTSTRAP: "1",
+        },
+        runTurnImpl,
+      });
+
+      const reader = makeSocket("cli-one-off-reader");
+      const mutator = makeSocket("cli-one-off-mutator");
+      await initializeConnection(runtime, reader);
+      await initializeConnection(runtime, mutator);
+
+      const omittedListResponse = await sendRequest(runtime, reader, "task/list");
+      expect(omittedListResponse.error?.message ?? "").toContain(
+        "cwd must match an authorized project workspace",
+      );
+
+      const exactListResponse = await sendRequest(runtime, reader, "task/list", {
+        cwd: activeOneOffPath,
+      });
+      expect(exactListResponse.error?.message ?? "").toContain(
+        "cwd must match an authorized project workspace",
+      );
+
+      const { cwd: _omittedCreateCwd, ...omittedCreateParams } = createTaskParams(
+        activeOneOffPath,
+        "cli-one-off-create-omitted",
+      );
+      const omittedCreateResponse = await sendRequest(
+        runtime,
+        mutator,
+        "task/create",
+        omittedCreateParams,
+      );
+      expect(omittedCreateResponse.error?.message ?? "").toContain(
+        "cwd must match an authorized project workspace",
+      );
+
+      const exactCreateResponse = await sendRequest(
+        runtime,
+        mutator,
+        "task/create",
+        createTaskParams(activeOneOffPath, "cli-one-off-create-exact"),
+      );
+      expect(exactCreateResponse.error?.message ?? "").toContain(
+        "cwd must match an authorized project workspace",
+      );
+      await expectNoMessage(reader, (message) => message.method === "task/created");
+
+      const omittedMutationResponse = await sendRequest(runtime, mutator, "task/updateBrief", {
+        taskId: "task-one-off",
+        expectedRevision: 1,
+        title: "Should stay rejected",
+      });
+      expect(omittedMutationResponse.error?.message ?? "").toContain(
+        "cwd must match an authorized project workspace",
+      );
+
+      const exactMutationResponse = await sendRequest(runtime, mutator, "task/updateBrief", {
+        cwd: activeOneOffPath,
+        taskId: "task-one-off",
+        expectedRevision: 1,
+        title: "Should stay rejected",
+      });
+      expect(exactMutationResponse.error?.message ?? "").toContain(
+        "cwd must match an authorized project workspace",
+      );
+      await expectNoMessage(reader, (message) => message.method === "task/updated");
+    } finally {
+      await runtime?.stop();
+      await fs.rm(home, { recursive: true, force: true });
+    }
+  }, 15_000);
+
   test("non-desktop active project cwd remains authorized for task RPCs", async () => {
     const home = await fs.mkdtemp(path.join(os.tmpdir(), "task-cli-project-"));
     const projectWorkspace = path.join(home, "project");

--- a/test/jsonrpc.task-workspace-subscription.test.ts
+++ b/test/jsonrpc.task-workspace-subscription.test.ts
@@ -135,6 +135,79 @@ function createTaskParams(cwd: string, idempotencyKey: string) {
   };
 }
 
+function createTestRunTurnImpl(): ReturnType<typeof createRunTurn> {
+  return createRunTurn({
+    createRuntime: () => ({
+      name: "pi",
+      runTurn: async () => ({
+        text: "done",
+        responseMessages: [],
+      }),
+    }),
+  });
+}
+
+async function createTaskTestRuntime(opts: {
+  cwd: string;
+  homedir: string;
+  desktopService?: WebDesktopServiceLike;
+}): Promise<Awaited<ReturnType<typeof createAgentServerRuntime>>> {
+  return await createAgentServerRuntime({
+    cwd: opts.cwd,
+    homedir: opts.homedir,
+    env: {
+      AGENT_WORKING_DIR: opts.cwd,
+      AGENT_PROVIDER: "google",
+      AGENT_OBSERVABILITY_ENABLED: "false",
+      COWORK_SKIP_DEFAULT_SKILLS_BOOTSTRAP: "1",
+    },
+    ...(opts.desktopService ? { desktopService: opts.desktopService } : {}),
+    runTurnImpl: createTestRunTurnImpl(),
+  });
+}
+
+function requireCreatedTask(response: JsonRpcMessage): { id: string; revision: number } {
+  expect(response.error).toBeUndefined();
+  const result = response.result as {
+    task?: { id?: unknown; revision?: unknown };
+  };
+  expect(typeof result.task?.id).toBe("string");
+  expect(typeof result.task?.revision).toBe("number");
+  if (typeof result.task?.id !== "string" || typeof result.task.revision !== "number") {
+    throw new Error("task/create did not return a task id and revision");
+  }
+  return { id: result.task.id, revision: result.task.revision };
+}
+
+function taskNotificationPredicate(
+  method: string,
+  taskId: string,
+  workspacePath: string,
+): (message: JsonRpcMessage) => boolean {
+  return (message) => {
+    if (message.method !== method) return false;
+    const params = message.params as { task?: { id?: unknown; workspacePath?: unknown } };
+    return params.task?.id === taskId && params.task.workspacePath === workspacePath;
+  };
+}
+
+async function createAliasedHome(prefix: string): Promise<{
+  cleanupRoot: string;
+  aliasHome: string;
+  realHome: string;
+}> {
+  const cleanupRoot = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  const realHomeRoot = path.join(cleanupRoot, "real-home");
+  const aliasHome = path.join(cleanupRoot, "home-alias");
+  await fs.mkdir(realHomeRoot, { recursive: true });
+  await fs.symlink(realHomeRoot, aliasHome, process.platform === "win32" ? "junction" : "dir");
+  return {
+    cleanupRoot,
+    aliasHome,
+    realHome: await fs.realpath(realHomeRoot),
+  };
+}
+
 describe("task workspace subscription routing", () => {
   test("catalog-authorized task reads subscribe the socket to subsequent task updates", async () => {
     const home = await fs.mkdtemp(path.join(os.tmpdir(), "task-workspace-subscription-"));
@@ -341,6 +414,370 @@ describe("task workspace subscription routing", () => {
     } finally {
       await runtime?.stop();
       await fs.rm(home, { recursive: true, force: true });
+    }
+  }, 15_000);
+
+  test("task subscriptions remain additive across authorized catalog workspaces", async () => {
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), "task-multi-subscription-"));
+    const workspaceA = path.join(home, "project-a");
+    const workspaceB = path.join(home, "project-b");
+    const workspaceC = path.join(home, "project-c");
+    const workspaceAliasA = path.join(home, "project-a-alias");
+    const oneOffWorkspace = path.join(home, ".cowork", "chats", "20260620-multi-oneoff");
+    const outsideWorkspace = path.join(home, "outside");
+    let runtime: Awaited<ReturnType<typeof createAgentServerRuntime>> | null = null;
+    try {
+      await fs.mkdir(path.join(workspaceA, ".cowork"), { recursive: true });
+      await fs.mkdir(path.join(workspaceB, ".cowork"), { recursive: true });
+      await fs.mkdir(path.join(workspaceC, ".cowork"), { recursive: true });
+      await fs.mkdir(oneOffWorkspace, { recursive: true });
+      await fs.mkdir(outsideWorkspace, { recursive: true });
+      await fs.symlink(
+        workspaceA,
+        workspaceAliasA,
+        process.platform === "win32" ? "junction" : "dir",
+      );
+      const workspacePathA = await fs.realpath(workspaceA);
+      const workspacePathB = await fs.realpath(workspaceB);
+      const workspacePathC = await fs.realpath(workspaceC);
+      const oneOffPath = await fs.realpath(oneOffWorkspace);
+      const outsidePath = await fs.realpath(outsideWorkspace);
+      const desktopService = {
+        loadState: async () => ({
+          version: 2,
+          workspaces: [
+            {
+              id: "project-a",
+              name: "Project A",
+              path: workspacePathA,
+              workspaceKind: "project",
+              createdAt: "2026-06-20T00:00:00.000Z",
+              lastOpenedAt: "2026-06-20T00:00:00.000Z",
+            },
+            {
+              id: "project-b",
+              name: "Project B",
+              path: workspacePathB,
+              workspaceKind: "project",
+              createdAt: "2026-06-20T00:00:00.000Z",
+              lastOpenedAt: "2026-06-20T00:00:00.000Z",
+            },
+            {
+              id: "project-c",
+              name: "Project C",
+              path: workspacePathC,
+              workspaceKind: "project",
+              createdAt: "2026-06-20T00:00:00.000Z",
+              lastOpenedAt: "2026-06-20T00:00:00.000Z",
+            },
+            {
+              id: "one-off",
+              name: "One-off chat",
+              path: oneOffPath,
+              workspaceKind: "oneOffChat",
+              createdAt: "2026-06-20T00:00:00.000Z",
+              lastOpenedAt: "2026-06-20T00:00:00.000Z",
+            },
+          ],
+        }),
+      } as Partial<WebDesktopServiceLike> as WebDesktopServiceLike;
+      runtime = await createTaskTestRuntime({
+        cwd: workspacePathA,
+        homedir: home,
+        desktopService,
+      });
+
+      const reader = makeSocket("multi-reader");
+      const mutator = makeSocket("multi-mutator");
+      const rejectedReader = makeSocket("multi-rejected-reader");
+      await initializeConnection(runtime, reader);
+      await initializeConnection(runtime, mutator);
+      await initializeConnection(runtime, rejectedReader);
+
+      for (const cwd of [workspacePathA, workspacePathB, workspacePathB]) {
+        const listResponse = await sendRequest(runtime, reader, "task/list", { cwd });
+        expect(listResponse.error).toBeUndefined();
+        expect(listResponse.result).toEqual({ tasks: [], total: 0 });
+      }
+
+      const oneOffListResponse = await sendRequest(runtime, rejectedReader, "task/list", {
+        cwd: oneOffPath,
+      });
+      expect(oneOffListResponse.error?.message ?? "").toContain(
+        "cwd must match an authorized project workspace",
+      );
+      const outsideListResponse = await sendRequest(runtime, rejectedReader, "task/list", {
+        cwd: outsidePath,
+      });
+      expect(outsideListResponse.error?.message ?? "").toContain(
+        "cwd must match an authorized workspace",
+      );
+      const aliasListResponse = await sendRequest(runtime, rejectedReader, "task/list", {
+        cwd: workspaceAliasA,
+      });
+      expect(aliasListResponse.error?.message ?? "").toContain(
+        "cwd must use the canonical workspace path",
+      );
+
+      const createdA = requireCreatedTask(
+        await sendRequest(runtime, mutator, "task/create", createTaskParams(workspacePathA, "a-1")),
+      );
+      await waitForMessage(
+        reader,
+        taskNotificationPredicate("task/created", createdA.id, workspacePathA),
+        "task/created for project A",
+      );
+      await expectNoMessage(
+        reader,
+        taskNotificationPredicate("task/created", createdA.id, workspacePathA),
+      );
+
+      const createdB = requireCreatedTask(
+        await sendRequest(runtime, mutator, "task/create", createTaskParams(workspacePathB, "b-1")),
+      );
+      await waitForMessage(
+        reader,
+        taskNotificationPredicate("task/created", createdB.id, workspacePathB),
+        "task/created for project B",
+      );
+
+      await sendRequest(runtime, mutator, "task/updateBrief", {
+        cwd: workspacePathA,
+        taskId: createdA.id,
+        expectedRevision: createdA.revision,
+        title: "Project A task updated",
+      });
+      await waitForMessage(
+        reader,
+        taskNotificationPredicate("task/updated", createdA.id, workspacePathA),
+        "task/updated for project A",
+      );
+
+      await sendRequest(runtime, mutator, "task/updateBrief", {
+        cwd: workspacePathB,
+        taskId: createdB.id,
+        expectedRevision: createdB.revision,
+        title: "Project B task updated",
+      });
+      await waitForMessage(
+        reader,
+        taskNotificationPredicate("task/updated", createdB.id, workspacePathB),
+        "task/updated for project B",
+      );
+
+      const createdC = requireCreatedTask(
+        await sendRequest(runtime, mutator, "task/create", createTaskParams(workspacePathC, "c-1")),
+      );
+      await expectNoMessage(
+        reader,
+        taskNotificationPredicate("task/created", createdC.id, workspacePathC),
+      );
+      await expectNoMessage(rejectedReader, (message) => message.method?.startsWith("task/"));
+
+      runtime.closeConnection(reader);
+      reader.sentMessages.length = 0;
+      requireCreatedTask(
+        await sendRequest(runtime, mutator, "task/create", createTaskParams(workspacePathA, "a-2")),
+      );
+      requireCreatedTask(
+        await sendRequest(runtime, mutator, "task/create", createTaskParams(workspacePathB, "b-2")),
+      );
+      await expectNoMessage(reader, (message) => message.method?.startsWith("task/"));
+    } finally {
+      await runtime?.stop();
+      await fs.rm(home, { recursive: true, force: true });
+    }
+  }, 20_000);
+
+  test("rejects active one-off task RPCs when configured home is a canonical alias", async () => {
+    const { cleanupRoot, aliasHome } = await createAliasedHome("task-alias-cli-home-");
+    const activeOneOffWorkspace = path.join(
+      aliasHome,
+      ".cowork",
+      "chats",
+      "20260620-alias-cli-oneoff",
+    );
+    let runtime: Awaited<ReturnType<typeof createAgentServerRuntime>> | null = null;
+    try {
+      await fs.mkdir(activeOneOffWorkspace, { recursive: true });
+      const activeOneOffPath = await fs.realpath(activeOneOffWorkspace);
+      runtime = await createTaskTestRuntime({
+        cwd: activeOneOffPath,
+        homedir: aliasHome,
+      });
+
+      const reader = makeSocket("alias-cli-reader");
+      const mutator = makeSocket("alias-cli-mutator");
+      await initializeConnection(runtime, reader);
+      await initializeConnection(runtime, mutator);
+
+      const omittedListResponse = await sendRequest(runtime, reader, "task/list");
+      expect(omittedListResponse.error?.message ?? "").toContain(
+        "cwd must match an authorized project workspace",
+      );
+      const exactListResponse = await sendRequest(runtime, reader, "task/list", {
+        cwd: activeOneOffPath,
+      });
+      expect(exactListResponse.error?.message ?? "").toContain(
+        "cwd must match an authorized project workspace",
+      );
+
+      const { cwd: _omittedCreateCwd, ...omittedCreateParams } = createTaskParams(
+        activeOneOffPath,
+        "alias-cli-create-omitted",
+      );
+      const omittedCreateResponse = await sendRequest(
+        runtime,
+        mutator,
+        "task/create",
+        omittedCreateParams,
+      );
+      expect(omittedCreateResponse.error?.message ?? "").toContain(
+        "cwd must match an authorized project workspace",
+      );
+      const exactCreateResponse = await sendRequest(
+        runtime,
+        mutator,
+        "task/create",
+        createTaskParams(activeOneOffPath, "alias-cli-create-exact"),
+      );
+      expect(exactCreateResponse.error?.message ?? "").toContain(
+        "cwd must match an authorized project workspace",
+      );
+      await expectNoMessage(reader, (message) => message.method === "task/created");
+
+      const omittedMutationResponse = await sendRequest(runtime, mutator, "task/updateBrief", {
+        taskId: "task-one-off",
+        expectedRevision: 1,
+        title: "Should stay rejected",
+      });
+      expect(omittedMutationResponse.error?.message ?? "").toContain(
+        "cwd must match an authorized project workspace",
+      );
+      const exactMutationResponse = await sendRequest(runtime, mutator, "task/updateBrief", {
+        cwd: activeOneOffPath,
+        taskId: "task-one-off",
+        expectedRevision: 1,
+        title: "Should stay rejected",
+      });
+      expect(exactMutationResponse.error?.message ?? "").toContain(
+        "cwd must match an authorized project workspace",
+      );
+      await expectNoMessage(reader, (message) => message.method === "task/updated");
+    } finally {
+      await runtime?.stop();
+      await fs.rm(cleanupRoot, { recursive: true, force: true });
+    }
+  }, 15_000);
+
+  test("rejects desktop catalog one-off task RPCs through canonical home aliases", async () => {
+    const { cleanupRoot, aliasHome } = await createAliasedHome("task-alias-desktop-home-");
+    const activeOneOffWorkspace = path.join(
+      aliasHome,
+      ".cowork",
+      "chats",
+      "20260620-alias-desktop-oneoff",
+    );
+    const promotedProjectWorkspace = path.join(
+      aliasHome,
+      ".cowork",
+      "chats",
+      "20260620-promoted-project",
+    );
+    let runtime: Awaited<ReturnType<typeof createAgentServerRuntime>> | null = null;
+    try {
+      await fs.mkdir(activeOneOffWorkspace, { recursive: true });
+      await fs.mkdir(promotedProjectWorkspace, { recursive: true });
+      const activeOneOffPath = await fs.realpath(activeOneOffWorkspace);
+      const promotedProjectPath = await fs.realpath(promotedProjectWorkspace);
+      const desktopService = {
+        loadState: async () => ({
+          version: 2,
+          workspaces: [
+            {
+              id: "active-one-off",
+              name: "Active one-off chat",
+              path: activeOneOffPath,
+              createdAt: "2026-06-20T00:00:00.000Z",
+              lastOpenedAt: "2026-06-20T00:00:00.000Z",
+            },
+            {
+              id: "promoted-project",
+              name: "Promoted project",
+              path: promotedProjectPath,
+              workspaceKind: "project",
+              createdAt: "2026-06-20T00:00:00.000Z",
+              lastOpenedAt: "2026-06-20T00:00:00.000Z",
+            },
+          ],
+        }),
+      } as Partial<WebDesktopServiceLike> as WebDesktopServiceLike;
+      runtime = await createTaskTestRuntime({
+        cwd: activeOneOffPath,
+        homedir: aliasHome,
+        desktopService,
+      });
+
+      const oneOffReader = makeSocket("alias-desktop-one-off-reader");
+      const mutator = makeSocket("alias-desktop-mutator");
+      const projectReader = makeSocket("alias-desktop-project-reader");
+      await initializeConnection(runtime, oneOffReader);
+      await initializeConnection(runtime, mutator);
+      await initializeConnection(runtime, projectReader);
+
+      const omittedListResponse = await sendRequest(runtime, oneOffReader, "task/list");
+      expect(omittedListResponse.error?.message ?? "").toContain(
+        "cwd must match an authorized project workspace",
+      );
+      const exactListResponse = await sendRequest(runtime, oneOffReader, "task/list", {
+        cwd: activeOneOffPath,
+      });
+      expect(exactListResponse.error?.message ?? "").toContain(
+        "cwd must match an authorized project workspace",
+      );
+      const exactCreateResponse = await sendRequest(
+        runtime,
+        mutator,
+        "task/create",
+        createTaskParams(activeOneOffPath, "alias-desktop-oneoff-create"),
+      );
+      expect(exactCreateResponse.error?.message ?? "").toContain(
+        "cwd must match an authorized project workspace",
+      );
+      await expectNoMessage(oneOffReader, (message) => message.method === "task/created");
+      const exactMutationResponse = await sendRequest(runtime, mutator, "task/updateBrief", {
+        cwd: activeOneOffPath,
+        taskId: "task-one-off",
+        expectedRevision: 1,
+        title: "Should stay rejected",
+      });
+      expect(exactMutationResponse.error?.message ?? "").toContain(
+        "cwd must match an authorized project workspace",
+      );
+      await expectNoMessage(oneOffReader, (message) => message.method === "task/updated");
+
+      const promotedListResponse = await sendRequest(runtime, projectReader, "task/list", {
+        cwd: promotedProjectPath,
+      });
+      expect(promotedListResponse.error).toBeUndefined();
+      expect(promotedListResponse.result).toEqual({ tasks: [], total: 0 });
+      const promotedTask = requireCreatedTask(
+        await sendRequest(
+          runtime,
+          mutator,
+          "task/create",
+          createTaskParams(promotedProjectPath, "alias-promoted-project-create"),
+        ),
+      );
+      await waitForMessage(
+        projectReader,
+        taskNotificationPredicate("task/created", promotedTask.id, promotedProjectPath),
+        "task/created for promoted project workspace",
+      );
+      await expectNoMessage(oneOffReader, (message) => message.method === "task/created");
+    } finally {
+      await runtime?.stop();
+      await fs.rm(cleanupRoot, { recursive: true, force: true });
     }
   }, 15_000);
 

--- a/test/jsonrpc.task-workspace-subscription.test.ts
+++ b/test/jsonrpc.task-workspace-subscription.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { createRunTurn } from "../src/agent";
 import { createAgentServerRuntime } from "../src/server/runtime/ServerRuntime";
 import type { StartServerSocket } from "../src/server/startServer/types";
-import type { WebDesktopServiceLike } from "../src/server/webDesktopService";
+import { WebDesktopService, type WebDesktopServiceLike } from "../src/server/webDesktopService";
 
 type JsonRpcMessage = {
   id?: string | number;
@@ -780,6 +780,177 @@ describe("task workspace subscription routing", () => {
       await fs.rm(cleanupRoot, { recursive: true, force: true });
     }
   }, 15_000);
+
+  test("rejects legacy persisted desktop one-off records normalized with a configured home", async () => {
+    const { cleanupRoot, aliasHome } = await createAliasedHome("task-legacy-desktop-home-");
+    const userDataDir = path.join(cleanupRoot, "user-data");
+    const activeOneOffWorkspace = path.join(
+      aliasHome,
+      ".cowork",
+      "chats",
+      "20260620-legacy-oneoff",
+    );
+    const promotedProjectWorkspace = path.join(
+      aliasHome,
+      ".cowork",
+      "chats",
+      "20260620-promoted-project",
+    );
+    const ordinaryProjectWorkspace = path.join(cleanupRoot, "ordinary-project");
+    let runtime: Awaited<ReturnType<typeof createAgentServerRuntime>> | null = null;
+    try {
+      await fs.mkdir(activeOneOffWorkspace, { recursive: true });
+      await fs.mkdir(promotedProjectWorkspace, { recursive: true });
+      await fs.mkdir(ordinaryProjectWorkspace, { recursive: true });
+      await fs.mkdir(userDataDir, { recursive: true });
+      const activeOneOffPath = await fs.realpath(activeOneOffWorkspace);
+      const promotedProjectPath = await fs.realpath(promotedProjectWorkspace);
+      const ordinaryProjectPath = await fs.realpath(ordinaryProjectWorkspace);
+      const timestamp = "2026-06-20T00:00:00.000Z";
+      await fs.writeFile(
+        path.join(userDataDir, "state.json"),
+        JSON.stringify({
+          version: 2,
+          workspaces: [
+            {
+              id: "legacy-one-off",
+              name: "Legacy one-off chat",
+              path: activeOneOffWorkspace,
+              createdAt: timestamp,
+              lastOpenedAt: timestamp,
+            },
+            {
+              id: "promoted-project",
+              name: "Promoted project",
+              path: promotedProjectWorkspace,
+              workspaceKind: "project",
+              createdAt: timestamp,
+              lastOpenedAt: timestamp,
+            },
+            {
+              id: "ordinary-project",
+              name: "Ordinary project",
+              path: ordinaryProjectWorkspace,
+              createdAt: timestamp,
+              lastOpenedAt: timestamp,
+            },
+          ],
+          threads: [],
+        }),
+      );
+      const desktopService = new WebDesktopService({ userDataDir, homedir: aliasHome });
+      runtime = await createTaskTestRuntime({
+        cwd: activeOneOffPath,
+        homedir: aliasHome,
+        desktopService,
+      });
+
+      const oneOffReader = makeSocket("legacy-one-off-reader");
+      const mutator = makeSocket("legacy-one-off-mutator");
+      const promotedReader = makeSocket("legacy-promoted-reader");
+      const ordinaryReader = makeSocket("legacy-ordinary-reader");
+      await initializeConnection(runtime, oneOffReader);
+      await initializeConnection(runtime, mutator);
+      await initializeConnection(runtime, promotedReader);
+      await initializeConnection(runtime, ordinaryReader);
+
+      const omittedListResponse = await sendRequest(runtime, oneOffReader, "task/list");
+      expect(omittedListResponse.error?.message ?? "").toContain(
+        "cwd must match an authorized project workspace",
+      );
+      const exactListResponse = await sendRequest(runtime, oneOffReader, "task/list", {
+        cwd: activeOneOffPath,
+      });
+      expect(exactListResponse.error?.message ?? "").toContain(
+        "cwd must match an authorized project workspace",
+      );
+
+      const { cwd: _omittedCreateCwd, ...omittedCreateParams } = createTaskParams(
+        activeOneOffPath,
+        "legacy-one-off-create-omitted",
+      );
+      const omittedCreateResponse = await sendRequest(
+        runtime,
+        mutator,
+        "task/create",
+        omittedCreateParams,
+      );
+      expect(omittedCreateResponse.error?.message ?? "").toContain(
+        "cwd must match an authorized project workspace",
+      );
+      const exactCreateResponse = await sendRequest(
+        runtime,
+        mutator,
+        "task/create",
+        createTaskParams(activeOneOffPath, "legacy-one-off-create-exact"),
+      );
+      expect(exactCreateResponse.error?.message ?? "").toContain(
+        "cwd must match an authorized project workspace",
+      );
+      await expectNoMessage(oneOffReader, (message) => message.method === "task/created");
+
+      const omittedMutationResponse = await sendRequest(runtime, mutator, "task/updateBrief", {
+        taskId: "task-one-off",
+        expectedRevision: 1,
+        title: "Should stay rejected",
+      });
+      expect(omittedMutationResponse.error?.message ?? "").toContain(
+        "cwd must match an authorized project workspace",
+      );
+      const exactMutationResponse = await sendRequest(runtime, mutator, "task/updateBrief", {
+        cwd: activeOneOffPath,
+        taskId: "task-one-off",
+        expectedRevision: 1,
+        title: "Should stay rejected",
+      });
+      expect(exactMutationResponse.error?.message ?? "").toContain(
+        "cwd must match an authorized project workspace",
+      );
+      await expectNoMessage(oneOffReader, (message) => message.method === "task/updated");
+
+      const promotedListResponse = await sendRequest(runtime, promotedReader, "task/list", {
+        cwd: promotedProjectPath,
+      });
+      expect(promotedListResponse.error).toBeUndefined();
+      expect(promotedListResponse.result).toEqual({ tasks: [], total: 0 });
+      const promotedTask = requireCreatedTask(
+        await sendRequest(
+          runtime,
+          mutator,
+          "task/create",
+          createTaskParams(promotedProjectPath, "legacy-promoted-project-create"),
+        ),
+      );
+      await waitForMessage(
+        promotedReader,
+        taskNotificationPredicate("task/created", promotedTask.id, promotedProjectPath),
+        "task/created for legacy promoted project workspace",
+      );
+
+      const ordinaryListResponse = await sendRequest(runtime, ordinaryReader, "task/list", {
+        cwd: ordinaryProjectPath,
+      });
+      expect(ordinaryListResponse.error).toBeUndefined();
+      expect(ordinaryListResponse.result).toEqual({ tasks: [], total: 0 });
+      const ordinaryTask = requireCreatedTask(
+        await sendRequest(
+          runtime,
+          mutator,
+          "task/create",
+          createTaskParams(ordinaryProjectPath, "legacy-ordinary-project-create"),
+        ),
+      );
+      await waitForMessage(
+        ordinaryReader,
+        taskNotificationPredicate("task/created", ordinaryTask.id, ordinaryProjectPath),
+        "task/created for legacy ordinary project workspace",
+      );
+      await expectNoMessage(oneOffReader, (message) => message.method === "task/created");
+    } finally {
+      await runtime?.stop();
+      await fs.rm(cleanupRoot, { recursive: true, force: true });
+    }
+  }, 20_000);
 
   test("rejects generic task RPCs when the active desktop workspace is a one-off chat", async () => {
     const home = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "task-active-oneoff-")));

--- a/test/jsonrpc.task-workspace-subscription.test.ts
+++ b/test/jsonrpc.task-workspace-subscription.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { createRunTurn } from "../src/agent";
 import { createAgentServerRuntime } from "../src/server/runtime/ServerRuntime";
 import type { StartServerSocket } from "../src/server/startServer/types";
+import { handleWebDesktopRoute } from "../src/server/webDesktopRoutes";
 import { WebDesktopService, type WebDesktopServiceLike } from "../src/server/webDesktopService";
 
 type JsonRpcMessage = {
@@ -949,6 +950,226 @@ describe("task workspace subscription routing", () => {
     } finally {
       await runtime?.stop();
       await fs.rm(cleanupRoot, { recursive: true, force: true });
+    }
+  }, 20_000);
+
+  test("rejects fallback one-off desktop state after HTTP roundtrip", async () => {
+    const { cleanupRoot, aliasHome } = await createAliasedHome("task-fallback-oneoff-home-");
+    const userDataDir = path.join(cleanupRoot, "user-data");
+    const activeOneOffWorkspace = path.join(
+      aliasHome,
+      ".cowork",
+      "chats",
+      "20260620-fallback-oneoff",
+    );
+    const projectWorkspace = path.join(cleanupRoot, "project");
+    let runtime: Awaited<ReturnType<typeof createAgentServerRuntime>> | null = null;
+    try {
+      await fs.mkdir(activeOneOffWorkspace, { recursive: true });
+      await fs.mkdir(projectWorkspace, { recursive: true });
+      const activeOneOffPath = await fs.realpath(activeOneOffWorkspace);
+      const projectPath = await fs.realpath(projectWorkspace);
+      const desktopService = new WebDesktopService({ userDataDir, homedir: aliasHome });
+
+      const stateResponse = await handleWebDesktopRoute(
+        new Request("http://localhost/cowork/desktop/state"),
+        { cwd: activeOneOffPath, desktopService },
+      );
+      expect(stateResponse).not.toBeNull();
+      const roundtripState = await stateResponse!.json();
+      const saveResponse = await handleWebDesktopRoute(
+        new Request("http://localhost/cowork/desktop/state", {
+          method: "POST",
+          body: JSON.stringify(roundtripState),
+        }),
+        { cwd: activeOneOffPath, desktopService },
+      );
+      expect(saveResponse).not.toBeNull();
+
+      runtime = await createTaskTestRuntime({
+        cwd: activeOneOffPath,
+        homedir: aliasHome,
+        desktopService,
+      });
+
+      const oneOffReader = makeSocket("fallback-oneoff-reader");
+      const mutator = makeSocket("fallback-oneoff-mutator");
+      await initializeConnection(runtime, oneOffReader);
+      await initializeConnection(runtime, mutator);
+
+      const omittedListResponse = await sendRequest(runtime, oneOffReader, "task/list");
+      expect(omittedListResponse.error?.message ?? "").toContain(
+        "cwd must match an authorized project workspace",
+      );
+      const exactListResponse = await sendRequest(runtime, oneOffReader, "task/list", {
+        cwd: activeOneOffPath,
+      });
+      expect(exactListResponse.error?.message ?? "").toContain(
+        "cwd must match an authorized project workspace",
+      );
+
+      const { cwd: _omittedCreateCwd, ...omittedCreateParams } = createTaskParams(
+        activeOneOffPath,
+        "fallback-oneoff-create-omitted",
+      );
+      const omittedCreateResponse = await sendRequest(
+        runtime,
+        mutator,
+        "task/create",
+        omittedCreateParams,
+      );
+      expect(omittedCreateResponse.error?.message ?? "").toContain(
+        "cwd must match an authorized project workspace",
+      );
+      const exactCreateResponse = await sendRequest(
+        runtime,
+        mutator,
+        "task/create",
+        createTaskParams(activeOneOffPath, "fallback-oneoff-create-exact"),
+      );
+      expect(exactCreateResponse.error?.message ?? "").toContain(
+        "cwd must match an authorized project workspace",
+      );
+      await expectNoMessage(oneOffReader, (message) => message.method === "task/created");
+
+      const mutationResponse = await sendRequest(runtime, mutator, "task/updateBrief", {
+        cwd: activeOneOffPath,
+        taskId: "task-fallback-oneoff",
+        expectedRevision: 1,
+        title: "Should remain rejected",
+      });
+      expect(mutationResponse.error?.message ?? "").toContain(
+        "cwd must match an authorized project workspace",
+      );
+      await expectNoMessage(oneOffReader, (message) => message.method === "task/updated");
+
+      const projectService = new WebDesktopService({
+        userDataDir: path.join(cleanupRoot, "project-user-data"),
+        homedir: aliasHome,
+      });
+      await projectService.loadState({ fallbackCwd: projectPath });
+      await projectService.saveState(await projectService.loadState({ fallbackCwd: projectPath }));
+      const projectRuntime = await createTaskTestRuntime({
+        cwd: projectPath,
+        homedir: aliasHome,
+        desktopService: projectService,
+      });
+      try {
+        const projectReader = makeSocket("fallback-project-reader");
+        await initializeConnection(projectRuntime, projectReader);
+        const projectListResponse = await sendRequest(projectRuntime, projectReader, "task/list");
+        expect(projectListResponse.error).toBeUndefined();
+        expect(projectListResponse.result).toEqual({ tasks: [], total: 0 });
+      } finally {
+        await projectRuntime.stop();
+      }
+    } finally {
+      await runtime?.stop();
+      await fs.rm(cleanupRoot, { recursive: true, force: true });
+    }
+  }, 20_000);
+
+  test("non-task workspace reads do not establish task subscriptions", async () => {
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), "task-nontask-subscription-"));
+    const activeWorkspace = path.join(home, "active");
+    const targetWorkspace = path.join(home, "target");
+    let includeTargetWorkspace = false;
+    let runtime: Awaited<ReturnType<typeof createAgentServerRuntime>> | null = null;
+    try {
+      await fs.mkdir(path.join(activeWorkspace, ".cowork"), { recursive: true });
+      await fs.mkdir(path.join(targetWorkspace, ".cowork"), { recursive: true });
+      const activePath = await fs.realpath(activeWorkspace);
+      const targetPath = await fs.realpath(targetWorkspace);
+      const desktopService = {
+        loadState: async () => ({
+          version: 2,
+          workspaces: [
+            {
+              id: "active",
+              name: "Active",
+              path: activePath,
+              workspaceKind: "project",
+              createdAt: "2026-06-20T00:00:00.000Z",
+              lastOpenedAt: "2026-06-20T00:00:00.000Z",
+            },
+            ...(includeTargetWorkspace
+              ? [
+                  {
+                    id: "target",
+                    name: "Target",
+                    path: targetPath,
+                    workspaceKind: "project" as const,
+                    createdAt: "2026-06-20T00:00:00.000Z",
+                    lastOpenedAt: "2026-06-20T00:00:00.000Z",
+                  },
+                ]
+              : []),
+          ],
+        }),
+      } as Partial<WebDesktopServiceLike> as WebDesktopServiceLike;
+      runtime = await createTaskTestRuntime({
+        cwd: activePath,
+        homedir: home,
+        desktopService,
+      });
+
+      const genericReader = makeSocket("generic-reader");
+      const taskReader = makeSocket("authorized-task-reader");
+      const mutator = makeSocket("generic-mutator");
+      await initializeConnection(runtime, genericReader);
+      await initializeConnection(runtime, taskReader);
+      await initializeConnection(runtime, mutator);
+
+      const rejectedListResponse = await sendRequest(runtime, genericReader, "task/list", {
+        cwd: targetPath,
+      });
+      expect(rejectedListResponse.error?.message ?? "").toContain(
+        "cwd must match an authorized workspace",
+      );
+      const providerCatalogResponse = await sendRequest(
+        runtime,
+        genericReader,
+        "cowork/provider/catalog/read",
+        { cwd: targetPath },
+      );
+      expect(providerCatalogResponse.error).toBeUndefined();
+
+      includeTargetWorkspace = true;
+      const createdBeforeSubscription = requireCreatedTask(
+        await sendRequest(
+          runtime,
+          mutator,
+          "task/create",
+          createTaskParams(targetPath, "generic-nontask-subscription-before"),
+        ),
+      );
+      await expectNoMessage(
+        genericReader,
+        taskNotificationPredicate("task/created", createdBeforeSubscription.id, targetPath),
+      );
+
+      const listResponse = await sendRequest(runtime, taskReader, "task/list", { cwd: targetPath });
+      expect(listResponse.error).toBeUndefined();
+      const createdAfterSubscription = requireCreatedTask(
+        await sendRequest(
+          runtime,
+          mutator,
+          "task/create",
+          createTaskParams(targetPath, "generic-nontask-subscription-after"),
+        ),
+      );
+      await waitForMessage(
+        taskReader,
+        taskNotificationPredicate("task/created", createdAfterSubscription.id, targetPath),
+        "task/created after explicit task subscription",
+      );
+      await expectNoMessage(
+        genericReader,
+        taskNotificationPredicate("task/created", createdAfterSubscription.id, targetPath),
+      );
+    } finally {
+      await runtime?.stop();
+      await fs.rm(home, { recursive: true, force: true });
     }
   }, 20_000);
 

--- a/test/jsonrpc.task-workspace-subscription.test.ts
+++ b/test/jsonrpc.task-workspace-subscription.test.ts
@@ -342,6 +342,20 @@ describe("task workspace subscription routing", () => {
       expect(listResponse.error).toBeUndefined();
       expect(listResponse.result).toEqual({ tasks: [], total: 0 });
 
+      const normalizedCatalogReader = makeSocket("normalized-catalog-reader");
+      await initializeConnection(runtime, normalizedCatalogReader);
+      const normalizedCatalogCwd = `${catalogPath}${path.sep}.`;
+      const normalizedCatalogListResponse = await sendRequest(
+        runtime,
+        normalizedCatalogReader,
+        "task/list",
+        {
+          cwd: normalizedCatalogCwd,
+        },
+      );
+      expect(normalizedCatalogListResponse.error).toBeUndefined();
+      expect(normalizedCatalogListResponse.result).toEqual({ tasks: [], total: 0 });
+
       const createResponse = await sendRequest(
         runtime,
         mutator,
@@ -365,6 +379,18 @@ describe("task workspace subscription routing", () => {
         "task/created notification for catalog workspace",
       );
       expect(createdNotification.params).toMatchObject({
+        cwd: catalogPath,
+        task: {
+          title: "Catalog workspace task",
+          workspacePath: catalogPath,
+        },
+      });
+      const normalizedCreatedNotification = await waitForMessage(
+        normalizedCatalogReader,
+        (message) => message.method === "task/created",
+        "task/created notification for normalized catalog workspace",
+      );
+      expect(normalizedCreatedNotification.params).toMatchObject({
         cwd: catalogPath,
         task: {
           title: "Catalog workspace task",

--- a/test/jsonrpc.task-workspace-subscription.test.ts
+++ b/test/jsonrpc.task-workspace-subscription.test.ts
@@ -1,0 +1,294 @@
+import { describe, expect, test } from "bun:test";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { createRunTurn } from "../src/agent";
+import { createAgentServerRuntime } from "../src/server/runtime/ServerRuntime";
+import type { StartServerSocket } from "../src/server/startServer/types";
+import type { WebDesktopServiceLike } from "../src/server/webDesktopService";
+
+type JsonRpcMessage = {
+  id?: string | number;
+  method?: string;
+  result?: unknown;
+  error?: {
+    code?: number;
+    message?: string;
+    data?: unknown;
+  };
+  params?: unknown;
+};
+
+type CapturedSocket = StartServerSocket & {
+  sentMessages: JsonRpcMessage[];
+};
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function makeSocket(connectionId: string): CapturedSocket {
+  const sentMessages: JsonRpcMessage[] = [];
+  const socket = {
+    data: {
+      connectionId,
+      selectedSubprotocol: "cowork.jsonrpc.v1",
+    },
+    sentMessages,
+    send(raw: string) {
+      sentMessages.push(JSON.parse(raw) as JsonRpcMessage);
+      return 1;
+    },
+  };
+  return socket as unknown as CapturedSocket;
+}
+
+async function waitForMessage(
+  socket: CapturedSocket,
+  predicate: (message: JsonRpcMessage) => boolean,
+  label: string,
+  timeoutMs = 2_000,
+): Promise<JsonRpcMessage> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    const index = socket.sentMessages.findIndex(predicate);
+    if (index >= 0) {
+      const [message] = socket.sentMessages.splice(index, 1);
+      if (message) return message;
+    }
+    await delay(5);
+  }
+  throw new Error(`Timed out waiting for ${label}`);
+}
+
+async function expectNoMessage(
+  socket: CapturedSocket,
+  predicate: (message: JsonRpcMessage) => boolean,
+): Promise<void> {
+  await delay(100);
+  expect(socket.sentMessages.some(predicate)).toBe(false);
+}
+
+async function initializeConnection(
+  runtime: Awaited<ReturnType<typeof createAgentServerRuntime>>,
+  socket: CapturedSocket,
+): Promise<void> {
+  runtime.openConnection(socket);
+  runtime.handleDecodedMessage(socket, {
+    id: 1,
+    method: "initialize",
+    params: {
+      clientInfo: {
+        name: "task-workspace-subscription-test",
+        version: "1.0.0",
+      },
+    },
+  });
+  const initialized = await waitForMessage(
+    socket,
+    (message) => message.id === 1,
+    "initialize response",
+  );
+  expect(initialized.error).toBeUndefined();
+  runtime.handleDecodedMessage(socket, { method: "initialized" });
+}
+
+let nextRequestId = 10;
+
+async function sendRequest(
+  runtime: Awaited<ReturnType<typeof createAgentServerRuntime>>,
+  socket: CapturedSocket,
+  method: string,
+  params?: unknown,
+): Promise<JsonRpcMessage> {
+  const id = nextRequestId++;
+  runtime.handleDecodedMessage(socket, {
+    id,
+    method,
+    ...(params !== undefined ? { params } : {}),
+  });
+  return await waitForMessage(socket, (message) => message.id === id, `${method} response`);
+}
+
+function createTaskParams(cwd: string, idempotencyKey: string) {
+  return {
+    cwd,
+    idempotencyKey,
+    title: "Catalog workspace task",
+    objective: "Prove task notifications are scoped to the authorized workspace.",
+    context: "Regression test fixture.",
+    requirements: [
+      {
+        kind: "acceptance_criterion",
+        text: "The task notification reaches subscribed catalog-workspace clients.",
+      },
+    ],
+    workItems: [
+      {
+        key: "deliver",
+        title: "Deliver",
+        expectedOutputs: ["A task notification"],
+      },
+    ],
+    reviewRequired: false,
+    reviewRounds: 0,
+  };
+}
+
+describe("task workspace subscription routing", () => {
+  test("catalog-authorized task reads subscribe the socket to subsequent task updates", async () => {
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), "task-workspace-subscription-"));
+    const activeWorkspace = path.join(home, "active");
+    const catalogWorkspace = path.join(home, "catalog");
+    const catalogAlias = path.join(home, "catalog-alias");
+    const outsideWorkspace = path.join(home, "outside");
+    let runtime: Awaited<ReturnType<typeof createAgentServerRuntime>> | null = null;
+    try {
+      await fs.mkdir(path.join(activeWorkspace, ".cowork"), { recursive: true });
+      await fs.mkdir(catalogWorkspace, { recursive: true });
+      await fs.mkdir(outsideWorkspace, { recursive: true });
+      await fs.symlink(catalogWorkspace, catalogAlias, "dir");
+      const activePath = await fs.realpath(activeWorkspace);
+      const catalogPath = await fs.realpath(catalogWorkspace);
+      const outsidePath = await fs.realpath(outsideWorkspace);
+      const desktopService = {
+        loadState: async () => ({
+          version: 2,
+          workspaces: [
+            {
+              id: "active",
+              name: "Active",
+              path: activePath,
+              workspaceKind: "project",
+              createdAt: "2026-06-20T00:00:00.000Z",
+              lastOpenedAt: "2026-06-20T00:00:00.000Z",
+            },
+            {
+              id: "catalog",
+              name: "Catalog",
+              path: catalogPath,
+              workspaceKind: "project",
+              createdAt: "2026-06-20T00:00:00.000Z",
+              lastOpenedAt: "2026-06-20T00:00:00.000Z",
+            },
+          ],
+        }),
+      } as Partial<WebDesktopServiceLike> as WebDesktopServiceLike;
+      const runTurnImpl = createRunTurn({
+        createRuntime: () => ({
+          name: "pi",
+          runTurn: async () => ({
+            text: "done",
+            responseMessages: [],
+          }),
+        }),
+      });
+      runtime = await createAgentServerRuntime({
+        cwd: activePath,
+        homedir: home,
+        env: {
+          AGENT_WORKING_DIR: activePath,
+          AGENT_PROVIDER: "google",
+          AGENT_OBSERVABILITY_ENABLED: "false",
+          COWORK_SKIP_DEFAULT_SKILLS_BOOTSTRAP: "1",
+        },
+        desktopService,
+        runTurnImpl,
+      });
+
+      const reader = makeSocket("reader");
+      const mutator = makeSocket("mutator");
+      await initializeConnection(runtime, reader);
+      await initializeConnection(runtime, mutator);
+
+      const listResponse = await sendRequest(runtime, reader, "task/list", {
+        cwd: catalogPath,
+      });
+      expect(listResponse.error).toBeUndefined();
+      expect(listResponse.result).toEqual({ tasks: [], total: 0 });
+
+      const createResponse = await sendRequest(
+        runtime,
+        mutator,
+        "task/create",
+        createTaskParams(catalogPath, "catalog-notify"),
+      );
+      expect(createResponse.error).toBeUndefined();
+      const createdResult = createResponse.result as {
+        task?: { id?: unknown; revision?: unknown };
+      };
+      const createdTaskId = createdResult.task?.id;
+      const createdRevision = createdResult.task?.revision;
+      expect(typeof createdTaskId).toBe("string");
+      expect(typeof createdRevision).toBe("number");
+      if (typeof createdTaskId !== "string" || typeof createdRevision !== "number") {
+        throw new Error("task/create did not return a task id and revision");
+      }
+      const createdNotification = await waitForMessage(
+        reader,
+        (message) => message.method === "task/created",
+        "task/created notification for catalog workspace",
+      );
+      expect(createdNotification.params).toMatchObject({
+        cwd: catalogPath,
+        task: {
+          title: "Catalog workspace task",
+          workspacePath: catalogPath,
+        },
+      });
+      const updateResponse = await sendRequest(runtime, mutator, "task/updateBrief", {
+        cwd: catalogPath,
+        taskId: createdTaskId,
+        expectedRevision: createdRevision,
+        title: "Catalog workspace task updated",
+      });
+      expect(updateResponse.error).toBeUndefined();
+      const updatedNotification = await waitForMessage(
+        reader,
+        (message) => {
+          if (message.method !== "task/updated") return false;
+          const params = message.params as { task?: { title?: unknown; workspacePath?: unknown } };
+          return (
+            params.task?.title === "Catalog workspace task updated" &&
+            params.task.workspacePath === catalogPath
+          );
+        },
+        "task/updated notification for catalog workspace",
+      );
+      expect(updatedNotification.params).toMatchObject({
+        cwd: catalogPath,
+        task: {
+          title: "Catalog workspace task updated",
+          workspacePath: catalogPath,
+        },
+      });
+
+      const aliasReader = makeSocket("alias-reader");
+      await initializeConnection(runtime, aliasReader);
+      const aliasResponse = await sendRequest(runtime, aliasReader, "task/list", {
+        cwd: catalogAlias,
+      });
+      expect(aliasResponse.error?.message).toContain("cwd must use the canonical workspace path");
+
+      const outsideReader = makeSocket("outside-reader");
+      await initializeConnection(runtime, outsideReader);
+      const outsideResponse = await sendRequest(runtime, outsideReader, "task/list", {
+        cwd: outsidePath,
+      });
+      expect(outsideResponse.error?.message).toContain("cwd must match an authorized workspace");
+
+      const secondCreateResponse = await sendRequest(
+        runtime,
+        mutator,
+        "task/create",
+        createTaskParams(catalogPath, "catalog-notify-second"),
+      );
+      expect(secondCreateResponse.error).toBeUndefined();
+      await expectNoMessage(aliasReader, (message) => message.method === "task/created");
+      await expectNoMessage(outsideReader, (message) => message.method === "task/created");
+    } finally {
+      await runtime?.stop();
+      await fs.rm(home, { recursive: true, force: true });
+    }
+  }, 15_000);
+});

--- a/test/jsonrpc.task-workspace-subscription.test.ts
+++ b/test/jsonrpc.task-workspace-subscription.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { createRunTurn } from "../src/agent";
+import type { RuntimeRunTurnParams } from "../src/runtime";
 import { createAgentServerRuntime } from "../src/server/runtime/ServerRuntime";
 import type { StartServerSocket } from "../src/server/startServer/types";
 import { handleWebDesktopRoute } from "../src/server/webDesktopRoutes";
@@ -144,6 +145,45 @@ function createTestRunTurnImpl(): ReturnType<typeof createRunTurn> {
         text: "done",
         responseMessages: [],
       }),
+    }),
+  });
+}
+
+function createTaskToolRunTurnImpl(): ReturnType<typeof createRunTurn> {
+  let invocation = 0;
+  return createRunTurn({
+    createRuntime: () => ({
+      name: "pi",
+      runTurn: async (params: RuntimeRunTurnParams) => {
+        invocation += 1;
+        const tool = params.tools.createTask;
+        if (!tool) throw new Error("createTask tool was not registered");
+        await tool.execute({
+          idempotencyKey: `chat-tool-create-${invocation}`,
+          title: "Chat-created task",
+          objective: "Prove chat task creation subscribes the source socket.",
+          context: "Regression test fixture.",
+          requirements: [
+            {
+              kind: "acceptance_criterion",
+              text: "The source chat socket receives task takeover notifications.",
+            },
+          ],
+          workItems: [
+            {
+              key: "deliver",
+              title: "Deliver",
+              expectedOutputs: ["A task takeover notification"],
+            },
+          ],
+          reviewRequired: false,
+          reviewRounds: 0,
+        });
+        return {
+          text: "",
+          responseMessages: [],
+        };
+      },
     }),
   });
 }
@@ -1173,6 +1213,66 @@ describe("task workspace subscription routing", () => {
     }
   }, 20_000);
 
+  test("successful task mutations subscribe the socket to task notifications", async () => {
+    const home = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "task-mutation-sub-")));
+    const projectWorkspace = path.join(home, "project");
+    let runtime: Awaited<ReturnType<typeof createAgentServerRuntime>> | null = null;
+    try {
+      await fs.mkdir(projectWorkspace, { recursive: true });
+      const projectPath = await fs.realpath(projectWorkspace);
+      runtime = await createTaskTestRuntime({
+        cwd: projectPath,
+        homedir: home,
+      });
+
+      const creator = makeSocket("task-mutation-subscriber");
+      const deniedMutator = makeSocket("task-mutation-denied");
+      const secondCreator = makeSocket("task-mutation-second-creator");
+      await initializeConnection(runtime, creator);
+      await initializeConnection(runtime, deniedMutator);
+      await initializeConnection(runtime, secondCreator);
+      deniedMutator.data.taskMutationAllowed = false;
+
+      const createdByMutationOnlySocket = requireCreatedTask(
+        await sendRequest(
+          runtime,
+          creator,
+          "task/create",
+          createTaskParams(projectPath, "mutation-only-subscription"),
+        ),
+      );
+      await waitForMessage(
+        creator,
+        taskNotificationPredicate("task/created", createdByMutationOnlySocket.id, projectPath),
+        "task/created for successful task/create subscriber",
+      );
+
+      const deniedCreateResponse = await sendRequest(
+        runtime,
+        deniedMutator,
+        "task/create",
+        createTaskParams(projectPath, "denied-mutation-subscription"),
+      );
+      expect(deniedCreateResponse.error?.message ?? "").toContain("requires turns permission");
+
+      const createdAfterDeniedAttempt = requireCreatedTask(
+        await sendRequest(
+          runtime,
+          secondCreator,
+          "task/create",
+          createTaskParams(projectPath, "after-denied-mutation-subscription"),
+        ),
+      );
+      await expectNoMessage(
+        deniedMutator,
+        taskNotificationPredicate("task/created", createdAfterDeniedAttempt.id, projectPath),
+      );
+    } finally {
+      await runtime?.stop();
+      await fs.rm(home, { recursive: true, force: true });
+    }
+  }, 20_000);
+
   test("rejects generic task RPCs when the active desktop workspace is a one-off chat", async () => {
     const home = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "task-active-oneoff-")));
     const activeOneOffWorkspace = path.join(home, ".cowork", "chats", "20260620-active-oneoff");
@@ -1372,6 +1472,108 @@ describe("task workspace subscription routing", () => {
         "cwd must match an authorized project workspace",
       );
       await expectNoMessage(reader, (message) => message.method === "task/updated");
+    } finally {
+      await runtime?.stop();
+      await fs.rm(home, { recursive: true, force: true });
+    }
+  }, 15_000);
+
+  test("ordinary chat createTask tool subscribes the source socket for takeover notifications", async () => {
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), "task-chat-tool-subscription-"));
+    const projectWorkspace = path.join(home, "project");
+    let runtime: Awaited<ReturnType<typeof createAgentServerRuntime>> | null = null;
+    try {
+      await fs.mkdir(projectWorkspace, { recursive: true });
+      const projectPath = await fs.realpath(projectWorkspace);
+      runtime = await createAgentServerRuntime({
+        cwd: projectPath,
+        homedir: home,
+        env: {
+          AGENT_WORKING_DIR: projectPath,
+          AGENT_PROVIDER: "google",
+          AGENT_OBSERVABILITY_ENABLED: "false",
+          COWORK_SKIP_DEFAULT_SKILLS_BOOTSTRAP: "1",
+        },
+        runTurnImpl: createTaskToolRunTurnImpl(),
+      });
+
+      const origin = makeSocket("chat-task-origin");
+      const unrelatedChat = makeSocket("chat-task-unrelated");
+      await initializeConnection(runtime, origin);
+      await initializeConnection(runtime, unrelatedChat);
+
+      const originStarted = await sendRequest(runtime, origin, "thread/start", {
+        cwd: projectPath,
+      });
+      expect(originStarted.error).toBeUndefined();
+      const originThread = originStarted.result as { thread?: { id?: unknown } };
+      expect(typeof originThread.thread?.id).toBe("string");
+      if (typeof originThread.thread?.id !== "string") {
+        throw new Error("thread/start did not return a source thread id");
+      }
+      await waitForMessage(
+        origin,
+        (message) =>
+          message.method === "thread/started" &&
+          (message.params as { thread?: { id?: unknown } }).thread?.id === originThread.thread?.id,
+        "source thread/started notification",
+      );
+
+      const unrelatedStarted = await sendRequest(runtime, unrelatedChat, "thread/start", {
+        cwd: projectPath,
+      });
+      expect(unrelatedStarted.error).toBeUndefined();
+      await waitForMessage(
+        unrelatedChat,
+        (message) => message.method === "thread/started",
+        "unrelated thread/started notification",
+      );
+
+      const turnResponse = await sendRequest(runtime, origin, "turn/start", {
+        threadId: originThread.thread.id,
+        input: [{ type: "text", text: "create the task" }],
+      });
+      expect(turnResponse.error).toBeUndefined();
+
+      const createdNotification = await waitForMessage(
+        origin,
+        (message) => message.method === "task/created",
+        "task/created takeover notification for source chat",
+      );
+      const createdParams = createdNotification.params as {
+        cwd?: unknown;
+        takeover?: unknown;
+        sourceSessionId?: unknown;
+        workspaceDisposition?: unknown;
+        task?: {
+          id?: unknown;
+          workspacePath?: unknown;
+          sourceSessionId?: unknown;
+          creationOrigin?: unknown;
+        };
+      };
+      expect(createdParams).toMatchObject({
+        cwd: projectPath,
+        takeover: true,
+        sourceSessionId: originThread.thread.id,
+        workspaceDisposition: "existing_project",
+        task: {
+          workspacePath: projectPath,
+          sourceSessionId: originThread.thread.id,
+          creationOrigin: "chat_tool",
+        },
+      });
+      expect(typeof createdParams.task?.id).toBe("string");
+      await waitForMessage(
+        origin,
+        (message) => {
+          if (message.method !== "task/updated") return false;
+          const params = message.params as { task?: { id?: unknown } };
+          return params.task?.id === createdParams.task?.id;
+        },
+        "task/updated takeover follow-up notification for source chat",
+      );
+      await expectNoMessage(unrelatedChat, (message) => message.method?.startsWith("task/"));
     } finally {
       await runtime?.stop();
       await fs.rm(home, { recursive: true, force: true });

--- a/test/jsonrpc.task-workspace-subscription.test.ts
+++ b/test/jsonrpc.task-workspace-subscription.test.ts
@@ -141,15 +141,18 @@ describe("task workspace subscription routing", () => {
     const activeWorkspace = path.join(home, "active");
     const catalogWorkspace = path.join(home, "catalog");
     const catalogAlias = path.join(home, "catalog-alias");
+    const oneOffWorkspace = path.join(home, ".cowork", "chats", "20260620-chat-oneoff");
     const outsideWorkspace = path.join(home, "outside");
     let runtime: Awaited<ReturnType<typeof createAgentServerRuntime>> | null = null;
     try {
       await fs.mkdir(path.join(activeWorkspace, ".cowork"), { recursive: true });
       await fs.mkdir(catalogWorkspace, { recursive: true });
+      await fs.mkdir(oneOffWorkspace, { recursive: true });
       await fs.mkdir(outsideWorkspace, { recursive: true });
       await fs.symlink(catalogWorkspace, catalogAlias, "dir");
       const activePath = await fs.realpath(activeWorkspace);
       const catalogPath = await fs.realpath(catalogWorkspace);
+      const oneOffPath = await fs.realpath(oneOffWorkspace);
       const outsidePath = await fs.realpath(outsideWorkspace);
       const desktopService = {
         loadState: async () => ({
@@ -168,6 +171,14 @@ describe("task workspace subscription routing", () => {
               name: "Catalog",
               path: catalogPath,
               workspaceKind: "project",
+              createdAt: "2026-06-20T00:00:00.000Z",
+              lastOpenedAt: "2026-06-20T00:00:00.000Z",
+            },
+            {
+              id: "one-off",
+              name: "One-off chat",
+              path: oneOffPath,
+              workspaceKind: "oneOffChat",
               createdAt: "2026-06-20T00:00:00.000Z",
               lastOpenedAt: "2026-06-20T00:00:00.000Z",
             },
@@ -262,6 +273,37 @@ describe("task workspace subscription routing", () => {
           workspacePath: catalogPath,
         },
       });
+
+      const oneOffReader = makeSocket("one-off-reader");
+      await initializeConnection(runtime, oneOffReader);
+      const oneOffListResponse = await sendRequest(runtime, oneOffReader, "task/list", {
+        cwd: oneOffPath,
+      });
+      expect(oneOffListResponse.error?.message ?? "").toContain(
+        "cwd must match an authorized project workspace",
+      );
+
+      const oneOffCreateResponse = await sendRequest(
+        runtime,
+        mutator,
+        "task/create",
+        createTaskParams(oneOffPath, "one-off-task-create"),
+      );
+      expect(oneOffCreateResponse.error?.message ?? "").toContain(
+        "cwd must match an authorized project workspace",
+      );
+      await expectNoMessage(oneOffReader, (message) => message.method === "task/created");
+
+      const oneOffMutationResponse = await sendRequest(runtime, mutator, "task/updateBrief", {
+        cwd: oneOffPath,
+        taskId: "task-one-off",
+        expectedRevision: 1,
+        title: "Should stay rejected",
+      });
+      expect(oneOffMutationResponse.error?.message ?? "").toContain(
+        "cwd must match an authorized project workspace",
+      );
+      await expectNoMessage(oneOffReader, (message) => message.method === "task/updated");
 
       const aliasReader = makeSocket("alias-reader");
       await initializeConnection(runtime, aliasReader);

--- a/test/jsonrpc.tasks-route.test.ts
+++ b/test/jsonrpc.tasks-route.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, test } from "bun:test";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import type {
   JsonRpcLiteError,
   JsonRpcLiteId,
@@ -325,41 +328,52 @@ describe("task JSON-RPC routes", () => {
   });
 
   test("allows task reads for a desktop-persisted workspace from the workspace catalog", async () => {
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), "task-route-catalog-"));
     const harness = makeHarness();
     const calls: string[] = [];
-    (harness.context as unknown as { desktopService: unknown }).desktopService = {
-      loadState: async () => ({
-        version: 2,
-        workspaces: [
-          {
-            id: "project-b",
-            name: "Project B",
-            path: "C:\\workspace-b",
-            workspaceKind: "project",
-            createdAt: "2026-06-01T00:00:00.000Z",
-          },
-        ],
-      }),
-    };
-    (harness.context as unknown as { getConfig: () => { workingDirectory: string } }).getConfig =
-      () => ({ workingDirectory: "C:\\workspace-a" });
-    (
-      harness.context as unknown as { utils: { resolveWorkspacePath: () => string } }
-    ).utils.resolveWorkspacePath = () => {
-      throw new Error("task/list cwd must match an authorized workspace");
-    };
-    (
-      harness.context as unknown as { tasks: { list: (workspacePath: string) => unknown[] } }
-    ).tasks.list = (workspacePath: string) => {
-      calls.push(workspacePath);
-      return [];
-    };
+    try {
+      const activeWorkspace = path.join(home, "workspace-a");
+      const catalogWorkspace = path.join(home, "workspace-b");
+      await fs.mkdir(activeWorkspace, { recursive: true });
+      await fs.mkdir(catalogWorkspace, { recursive: true });
+      const activePath = await fs.realpath(activeWorkspace);
+      const catalogPath = await fs.realpath(catalogWorkspace);
+      (harness.context as unknown as { desktopService: unknown }).desktopService = {
+        loadState: async () => ({
+          version: 2,
+          workspaces: [
+            {
+              id: "project-b",
+              name: "Project B",
+              path: catalogPath,
+              workspaceKind: "project",
+              createdAt: "2026-06-01T00:00:00.000Z",
+            },
+          ],
+        }),
+      };
+      (harness.context as unknown as { getConfig: () => { workingDirectory: string } }).getConfig =
+        () => ({ workingDirectory: activePath });
+      (
+        harness.context as unknown as { utils: { resolveWorkspacePath: () => string } }
+      ).utils.resolveWorkspacePath = () => {
+        throw new Error("task/list cwd must match an authorized workspace");
+      };
+      (
+        harness.context as unknown as { tasks: { list: (workspacePath: string) => unknown[] } }
+      ).tasks.list = (workspacePath: string) => {
+        calls.push(workspacePath);
+        return [];
+      };
 
-    await invoke(harness.context, "task/list", { cwd: "C:\\workspace-b" });
+      await invoke(harness.context, "task/list", { cwd: `${catalogPath}${path.sep}.` });
 
-    expect(harness.errors).toEqual([]);
-    expect(harness.results[0]?.result).toEqual({ tasks: [], total: 0 });
-    expect(calls).toEqual(["C:\\workspace-b"]);
+      expect(harness.errors).toEqual([]);
+      expect(harness.results[0]?.result).toEqual({ tasks: [], total: 0 });
+      expect(calls).toEqual([catalogPath]);
+    } finally {
+      await fs.rm(home, { recursive: true, force: true });
+    }
   });
 
   test("retries a failed task through the coordinator", async () => {

--- a/test/jsonrpc.tasks-route.test.ts
+++ b/test/jsonrpc.tasks-route.test.ts
@@ -174,6 +174,87 @@ async function invoke(context: JsonRpcRouteContext, method: string, params: unkn
 }
 
 describe("task JSON-RPC routes", () => {
+  test("rejects task reads and mutations for explicitly underprivileged sockets", async () => {
+    const harness = makeHarness();
+    const handlers = createTaskRouteHandlers(harness.context);
+    const underprivilegedSocket = {
+      data: {
+        taskReadAllowed: false,
+        taskMutationAllowed: false,
+      },
+    } as never;
+
+    await handlers["task/list"]?.(underprivilegedSocket, {
+      id: 1,
+      method: "task/list",
+      params: { cwd: "C:\\workspace" },
+    });
+    await handlers["task/updateBrief"]?.(underprivilegedSocket, {
+      id: 2,
+      method: "task/updateBrief",
+      params: {
+        cwd: "C:\\workspace",
+        taskId: "task-1",
+        expectedRevision: 1,
+        title: "Updated",
+      },
+    });
+
+    expect(harness.results).toEqual([]);
+    expect(harness.errors).toEqual([
+      {
+        id: 1,
+        error: {
+          code: -32600,
+          message: "task/list requires conversations permission",
+          data: { category: "permission_denied", permission: "conversations" },
+        },
+      },
+      {
+        id: 2,
+        error: {
+          code: -32600,
+          message: "task/updateBrief requires conversations permission",
+          data: { category: "permission_denied", permission: "conversations" },
+        },
+      },
+    ]);
+  });
+
+  test("rejects task mutations for sockets with read-only task permission", async () => {
+    const harness = makeHarness();
+    const handlers = createTaskRouteHandlers(harness.context);
+    const readOnlySocket = {
+      data: {
+        taskReadAllowed: true,
+        taskMutationAllowed: false,
+      },
+    } as never;
+
+    await handlers["task/updateBrief"]?.(readOnlySocket, {
+      id: 1,
+      method: "task/updateBrief",
+      params: {
+        cwd: "C:\\workspace",
+        taskId: "task-1",
+        expectedRevision: 1,
+        title: "Updated",
+      },
+    });
+
+    expect(harness.results).toEqual([]);
+    expect(harness.errors).toEqual([
+      {
+        id: 1,
+        error: {
+          code: -32600,
+          message: "task/updateBrief requires turns permission",
+          data: { category: "permission_denied", permission: "turns" },
+        },
+      },
+    ]);
+  });
+
   test("creates an isolated task thread and waits for session persistence", async () => {
     const harness = makeHarness();
     await invoke(harness.context, "task/create", {
@@ -241,6 +322,44 @@ describe("task JSON-RPC routes", () => {
     expect(
       jsonRpcTaskResultSchemas["task/list"].safeParse(harness.results[0]?.result).success,
     ).toBe(true);
+  });
+
+  test("allows task reads for a desktop-persisted workspace from the workspace catalog", async () => {
+    const harness = makeHarness();
+    const calls: string[] = [];
+    (harness.context as unknown as { desktopService: unknown }).desktopService = {
+      loadState: async () => ({
+        version: 2,
+        workspaces: [
+          {
+            id: "project-b",
+            name: "Project B",
+            path: "C:\\workspace-b",
+            workspaceKind: "project",
+            createdAt: "2026-06-01T00:00:00.000Z",
+          },
+        ],
+      }),
+    };
+    (harness.context as unknown as { getConfig: () => { workingDirectory: string } }).getConfig =
+      () => ({ workingDirectory: "C:\\workspace-a" });
+    (
+      harness.context as unknown as { utils: { resolveWorkspacePath: () => string } }
+    ).utils.resolveWorkspacePath = () => {
+      throw new Error("task/list cwd must match an authorized workspace");
+    };
+    (
+      harness.context as unknown as { tasks: { list: (workspacePath: string) => unknown[] } }
+    ).tasks.list = (workspacePath: string) => {
+      calls.push(workspacePath);
+      return [];
+    };
+
+    await invoke(harness.context, "task/list", { cwd: "C:\\workspace-b" });
+
+    expect(harness.errors).toEqual([]);
+    expect(harness.results[0]?.result).toEqual({ tasks: [], total: 0 });
+    expect(calls).toEqual(["C:\\workspace-b"]);
   });
 
   test("retries a failed task through the coordinator", async () => {

--- a/test/server/runtime/workspaceJsonRpcSubscribers.test.ts
+++ b/test/server/runtime/workspaceJsonRpcSubscribers.test.ts
@@ -49,4 +49,35 @@ describe("WorkspaceJsonRpcSubscribers", () => {
       },
     ]);
   });
+
+  test("filters task notifications for sockets without task read permission", () => {
+    const sent: Array<{ connectionId: string | undefined; payload: unknown }> = [];
+    const subscribers = new WorkspaceJsonRpcSubscribers({
+      shouldSendNotification: () => true,
+      send: (ws: StartServerSocket, payload: unknown) => {
+        sent.push({ connectionId: ws.data.connectionId, payload });
+        return true;
+      },
+    } as never);
+    const allowed = socket("allowed");
+    const denied = socket("denied");
+    denied.data.taskReadAllowed = false;
+    const workspace = path.join(os.tmpdir(), "task-subscriber-authz");
+    subscribers.register(allowed, workspace);
+    subscribers.register(denied, workspace);
+
+    subscribers.notify(workspace, "task/created", {
+      task: { id: "task-1", title: "Secret task" },
+    });
+
+    expect(sent).toEqual([
+      {
+        connectionId: "allowed",
+        payload: {
+          method: "task/created",
+          params: { task: { id: "task-1", title: "Secret task" } },
+        },
+      },
+    ]);
+  });
 });

--- a/test/server/runtime/workspaceJsonRpcSubscribers.test.ts
+++ b/test/server/runtime/workspaceJsonRpcSubscribers.test.ts
@@ -80,4 +80,63 @@ describe("WorkspaceJsonRpcSubscribers", () => {
       },
     ]);
   });
+
+  test("keeps a connection subscribed to every requested task workspace idempotently", () => {
+    const sent: Array<{ connectionId: string | undefined; payload: unknown }> = [];
+    const subscribers = new WorkspaceJsonRpcSubscribers({
+      shouldSendNotification: () => true,
+      send: (ws: StartServerSocket, payload: unknown) => {
+        sent.push({ connectionId: ws.data.connectionId, payload });
+        return true;
+      },
+    } as never);
+    const client = socket("client");
+    const firstWorkspace = path.join(os.tmpdir(), "task-subscriber-additive-one");
+    const secondWorkspace = path.join(os.tmpdir(), "task-subscriber-additive-two");
+
+    subscribers.register(client, firstWorkspace);
+    subscribers.register(client, secondWorkspace);
+    subscribers.register(client, secondWorkspace);
+
+    subscribers.notify(firstWorkspace, "task/created", {
+      cwd: firstWorkspace,
+      task: { id: "task-1" },
+    });
+    subscribers.notify(secondWorkspace, "task/updated", {
+      cwd: secondWorkspace,
+      task: { id: "task-2" },
+    });
+    subscribers.notify(path.join(os.tmpdir(), "task-subscriber-additive-three"), "task/created", {
+      task: { id: "task-3" },
+    });
+
+    expect(sent).toEqual([
+      {
+        connectionId: "client",
+        payload: {
+          method: "task/created",
+          params: { cwd: firstWorkspace, task: { id: "task-1" } },
+        },
+      },
+      {
+        connectionId: "client",
+        payload: {
+          method: "task/updated",
+          params: { cwd: secondWorkspace, task: { id: "task-2" } },
+        },
+      },
+    ]);
+
+    sent.length = 0;
+    subscribers.remove(client);
+    subscribers.notify(firstWorkspace, "task/created", {
+      cwd: firstWorkspace,
+      task: { id: "task-4" },
+    });
+    subscribers.notify(secondWorkspace, "task/updated", {
+      cwd: secondWorkspace,
+      task: { id: "task-5" },
+    });
+    expect(sent).toEqual([]);
+  });
 });

--- a/test/task-mode.persistence.test.ts
+++ b/test/task-mode.persistence.test.ts
@@ -130,6 +130,28 @@ async function createWorkingTask(harness: Awaited<ReturnType<typeof createHarnes
   });
 }
 
+test("task coordinator rejects task IDs outside the requested workspace context", async () => {
+  const harness = await createHarness();
+  try {
+    const { task } = await createWorkingTask(harness);
+    const otherWorkspace = path.join(harness.home, "other-project");
+
+    expect(() => harness.coordinator.get(task.id, otherWorkspace)).toThrow(
+      "Task is outside the active workspace",
+    );
+    await expect(
+      harness.coordinator.updateBrief({
+        taskId: task.id,
+        workspacePath: otherWorkspace,
+        expectedRevision: task.revision,
+        title: "Wrong workspace update",
+      }),
+    ).rejects.toThrow("Task is outside the active workspace");
+  } finally {
+    await fs.rm(harness.home, { recursive: true, force: true });
+  }
+});
+
 async function createReviewReadyTask(
   harness: Awaited<ReturnType<typeof createHarness>>,
   options: { reviewRequired?: boolean } = {},

--- a/test/tools/tools.createTools.test.ts
+++ b/test/tools/tools.createTools.test.ts
@@ -208,6 +208,83 @@ describe("createTools", () => {
     );
   });
 
+  test("preserves one-off chat task promotion results on the dedicated createTask tool path", async () => {
+    const dir = await tmpDir();
+    const createTask = mock(async () => ({
+      workspaceDisposition: "promote_one_off" as const,
+      task: {
+        id: "task-created",
+        workspacePath: dir,
+        title: "Promote chat task",
+        objective: "Keep one-off chat promotion on the dedicated tool path.",
+        context: "The source chat established the implementation constraints.",
+        sourceSessionId: "chat-1",
+        creationOrigin: "chat_tool" as const,
+        status: "working" as const,
+        revision: 0,
+        reviewRequired: true,
+        createdAt: "2026-06-20T12:00:00.000Z",
+        updatedAt: "2026-06-20T12:00:00.000Z",
+        threadCount: 1,
+        completedWorkItemCount: 0,
+        totalWorkItemCount: 1,
+        activeBlockerCount: 0,
+        pendingQuestionCount: 0,
+        blockingQuestionCount: 0,
+        requirements: [],
+        threads: [
+          {
+            id: "task-thread-1",
+            taskId: "task-created",
+            sessionId: "task-session-1",
+            title: "Main",
+            createdBy: "coordinator" as const,
+            createdAt: "2026-06-20T12:00:00.000Z",
+            updatedAt: "2026-06-20T12:00:00.000Z",
+          },
+        ],
+        workItems: [],
+        decisions: [],
+        questions: [],
+        artifacts: [],
+        blockers: [],
+        activity: [],
+        latestCheckpoint: null,
+      },
+    }));
+    const tool = createTools(makeCtx(dir, { sessionId: "chat-1", createTask })).createTask as {
+      execute: (input: unknown) => Promise<string>;
+    };
+
+    const output = JSON.parse(
+      await tool.execute({
+        idempotencyKey: "promote-one-off-task",
+        title: "Promote chat task",
+        objective: "Keep one-off chat promotion on the dedicated tool path.",
+        context: "The source chat established the implementation constraints.",
+        requirements: [
+          { kind: "acceptance_criterion", text: "Task mode links back to the source chat." },
+        ],
+        workItems: [
+          {
+            key: "implement",
+            title: "Implement promotion",
+            dependsOn: null,
+            expectedOutputs: ["Working task promotion"],
+          },
+        ],
+      }),
+    );
+
+    expect(createTask).toHaveBeenCalledTimes(1);
+    expect(output).toMatchObject({
+      taskId: "task-created",
+      taskThreadId: "task-session-1",
+      workspaceDisposition: "promote_one_off",
+      modeChanged: true,
+    });
+  });
+
   test("rejects incomplete or cyclic task creation plans", async () => {
     const dir = await tmpDir();
     const createTask = mock(async () => {

--- a/test/webDesktopRoutes.test.ts
+++ b/test/webDesktopRoutes.test.ts
@@ -50,6 +50,21 @@ afterEach(async () => {
 });
 
 describe("web desktop routes", () => {
+  async function makeAliasedHome(prefix: string): Promise<{
+    cleanupRoot: string;
+    aliasHome: string;
+    processHome: string;
+  }> {
+    const cleanupRoot = await makeTempDir(prefix);
+    const realHome = path.join(cleanupRoot, "real-home");
+    const aliasHome = path.join(cleanupRoot, "home-alias");
+    const processHome = path.join(cleanupRoot, "process-home");
+    await fs.mkdir(realHome, { recursive: true });
+    await fs.mkdir(processHome, { recursive: true });
+    await fs.symlink(realHome, aliasHome, process.platform === "win32" ? "junction" : "dir");
+    return { cleanupRoot, aliasHome, processHome };
+  }
+
   test("desktop service route creates one-off chat workspaces", async () => {
     const workspace = await makeTempDir("cowork-web-desktop-one-off-route-");
     const service = {
@@ -73,6 +88,139 @@ describe("web desktop routes", () => {
       name: "Scratch pad",
       path: path.join(workspace, "created-chat"),
     });
+  });
+
+  test("desktop state roundtrip keeps fallback one-off workspaces classified as chats", async () => {
+    const { cleanupRoot, aliasHome } = await makeAliasedHome("cowork-web-desktop-fallback-oneoff-");
+    const userDataDir = path.join(cleanupRoot, "user-data");
+    const oneOffWorkspace = path.join(aliasHome, ".cowork", "chats", "fallback-chat");
+    const promotedProject = path.join(aliasHome, ".cowork", "chats", "promoted-project");
+    const projectWorkspace = path.join(cleanupRoot, "project");
+    await fs.mkdir(oneOffWorkspace, { recursive: true });
+    await fs.mkdir(promotedProject, { recursive: true });
+    await fs.mkdir(projectWorkspace, { recursive: true });
+    const oneOffPath = await fs.realpath(oneOffWorkspace);
+    const promotedProjectPath = await fs.realpath(promotedProject);
+    const projectPath = await fs.realpath(projectWorkspace);
+    const service = new WebDesktopService({ userDataDir, homedir: aliasHome });
+
+    const stateResponse = await handleWebDesktopRoute(
+      new Request("http://localhost/cowork/desktop/state"),
+      { cwd: oneOffPath, desktopService: service },
+    );
+    expect(stateResponse).not.toBeNull();
+    const roundtripState = (await readJson(stateResponse!)) as {
+      workspaces: Array<{ id: string; path: string; workspaceKind?: string }>;
+    };
+    expect(roundtripState.workspaces).toHaveLength(1);
+    expect(roundtripState.workspaces[0]).toEqual(
+      expect.objectContaining({
+        path: oneOffPath,
+        workspaceKind: "oneOffChat",
+      }),
+    );
+
+    const saveResponse = await handleWebDesktopRoute(
+      new Request("http://localhost/cowork/desktop/state", {
+        method: "POST",
+        body: JSON.stringify(roundtripState),
+      }),
+      { cwd: oneOffPath, desktopService: service },
+    );
+    expect(saveResponse).not.toBeNull();
+    const savedState = (await readJson(saveResponse!)) as {
+      workspaces: Array<{ path: string; workspaceKind?: string }>;
+    };
+    expect(savedState.workspaces[0]).toEqual(
+      expect.objectContaining({
+        path: oneOffPath,
+        workspaceKind: "oneOffChat",
+      }),
+    );
+    await expect(service.loadState({ fallbackCwd: oneOffPath })).resolves.toMatchObject({
+      workspaces: [expect.objectContaining({ path: oneOffPath, workspaceKind: "oneOffChat" })],
+    });
+
+    await expect(service.loadState({ fallbackCwd: projectPath })).resolves.toMatchObject({
+      workspaces: [expect.objectContaining({ path: oneOffPath, workspaceKind: "oneOffChat" })],
+    });
+    const projectService = new WebDesktopService({
+      userDataDir: path.join(cleanupRoot, "project-user-data"),
+      homedir: aliasHome,
+    });
+    await expect(projectService.loadState({ fallbackCwd: projectPath })).resolves.toMatchObject({
+      workspaces: [expect.objectContaining({ path: projectPath, workspaceKind: "project" })],
+    });
+
+    await service.saveState({
+      version: 2,
+      workspaces: [
+        {
+          id: "promoted-project",
+          name: "Promoted project",
+          path: promotedProjectPath,
+          workspaceKind: "project",
+          createdAt: "2026-06-20T00:00:00.000Z",
+          lastOpenedAt: "2026-06-20T00:00:00.000Z",
+        },
+      ],
+      threads: [],
+    });
+    await expect(service.loadState({ fallbackCwd: oneOffPath })).resolves.toMatchObject({
+      workspaces: [
+        expect.objectContaining({ path: promotedProjectPath, workspaceKind: "project" }),
+      ],
+    });
+  });
+
+  test("desktop service creates one-off chats under the configured home", async () => {
+    const { cleanupRoot, aliasHome, processHome } = await makeAliasedHome(
+      "cowork-web-desktop-oneoff-home-",
+    );
+    const userDataDir = path.join(cleanupRoot, "user-data");
+    const service = new WebDesktopService({ userDataDir, homedir: aliasHome });
+    const previousHome = process.env.HOME;
+    process.env.HOME = processHome;
+    try {
+      const response = await handleWebDesktopRoute(
+        new Request("http://localhost/cowork/desktop/one-off-chat/workspace", {
+          method: "POST",
+          body: JSON.stringify({ titleHint: "Configured home chat" }),
+        }),
+        { cwd: cleanupRoot, desktopService: service },
+      );
+      expect(response).not.toBeNull();
+      const created = (await readJson(response!)) as { name: string; path: string };
+      const configuredChatsRoot = await fs.realpath(getOneOffChatsRoot(aliasHome));
+      const processChatsRoot = path.join(processHome, ".cowork", "chats");
+      expect(created.name).toBe("New chat");
+      expect(created.path.startsWith(`${configuredChatsRoot}${path.sep}`)).toBe(true);
+      expect(created.path.startsWith(processChatsRoot)).toBe(false);
+
+      await service.saveState({
+        version: 2,
+        workspaces: [
+          {
+            id: "created-one-off",
+            name: "Created one-off",
+            path: created.path,
+            workspaceKind: "oneOffChat",
+            createdAt: "2026-06-20T00:00:00.000Z",
+            lastOpenedAt: "2026-06-20T00:00:00.000Z",
+          },
+        ],
+        threads: [],
+      });
+      await expect(service.loadState()).resolves.toMatchObject({
+        workspaces: [expect.objectContaining({ path: created.path, workspaceKind: "oneOffChat" })],
+      });
+    } finally {
+      if (previousHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = previousHome;
+      }
+    }
   });
 
   test("desktop service exposes persisted workspaces and allows fs access across them", async () => {

--- a/test/workspace.catalog.test.ts
+++ b/test/workspace.catalog.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { requireWorkspacePath } from "../src/server/jsonrpc/routes/shared";
 import { listWorkspaceSummaries } from "../src/server/jsonrpc/workspaceCatalog";
-import type { WebDesktopServiceLike } from "../src/server/webDesktopService";
+import { WebDesktopService, type WebDesktopServiceLike } from "../src/server/webDesktopService";
 import { getOneOffChatsRoot } from "../src/utils/oneOffChats";
 
 describe("workspace catalog and path rules", () => {
@@ -194,5 +194,84 @@ describe("workspace catalog and path rules", () => {
         workspaceKind: "project",
       }),
     ]);
+  });
+
+  test("listWorkspaceSummaries classifies legacy missing-kind chat records with configured home", async () => {
+    const cleanupRoot = await fs.mkdtemp(path.join(os.tmpdir(), "workspace-catalog-home-"));
+    const realHomeRoot = path.join(cleanupRoot, "home-real");
+    const aliasHome = path.join(cleanupRoot, "home-alias");
+    const userDataDir = path.join(cleanupRoot, "user-data");
+    const legacyChat = path.join(aliasHome, ".cowork", "chats", "legacy-chat");
+    const promotedProject = path.join(aliasHome, ".cowork", "chats", "promoted-project");
+    const ordinaryProject = path.join(cleanupRoot, "ordinary-project");
+    try {
+      await fs.mkdir(realHomeRoot, { recursive: true });
+      await fs.symlink(realHomeRoot, aliasHome, process.platform === "win32" ? "junction" : "dir");
+      await fs.mkdir(legacyChat, { recursive: true });
+      await fs.mkdir(promotedProject, { recursive: true });
+      await fs.mkdir(ordinaryProject, { recursive: true });
+      await fs.mkdir(userDataDir, { recursive: true });
+      const timestamp = "2026-06-20T00:00:00.000Z";
+      await fs.writeFile(
+        path.join(userDataDir, "state.json"),
+        JSON.stringify({
+          version: 2,
+          workspaces: [
+            {
+              id: "legacy-chat",
+              name: "Legacy chat",
+              path: legacyChat,
+              createdAt: timestamp,
+              lastOpenedAt: timestamp,
+            },
+            {
+              id: "promoted-project",
+              name: "Promoted project",
+              path: promotedProject,
+              workspaceKind: "project",
+              createdAt: timestamp,
+              lastOpenedAt: timestamp,
+            },
+            {
+              id: "ordinary-project",
+              name: "Ordinary project",
+              path: ordinaryProject,
+              createdAt: timestamp,
+              lastOpenedAt: timestamp,
+            },
+          ],
+          threads: [],
+        }),
+      );
+
+      const desktopService = new WebDesktopService({ userDataDir, homedir: aliasHome });
+      const result = await listWorkspaceSummaries({
+        workingDirectory: await fs.realpath(legacyChat),
+        desktopService,
+        homedir: aliasHome,
+      });
+
+      expect(result.workspaces).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: "legacy-chat",
+            path: await fs.realpath(legacyChat),
+            workspaceKind: "oneOffChat",
+          }),
+          expect.objectContaining({
+            id: "promoted-project",
+            path: await fs.realpath(promotedProject),
+            workspaceKind: "project",
+          }),
+          expect.objectContaining({
+            id: "ordinary-project",
+            path: await fs.realpath(ordinaryProject),
+            workspaceKind: "project",
+          }),
+        ]),
+      );
+    } finally {
+      await fs.rm(cleanupRoot, { recursive: true, force: true });
+    }
   });
 });

--- a/test/workspace.catalog.test.ts
+++ b/test/workspace.catalog.test.ts
@@ -64,6 +64,41 @@ describe("workspace catalog and path rules", () => {
     }
   });
 
+  test("listWorkspaceSummaries classifies no-desktop fallback one-off cwd with configured home", async () => {
+    const homedir = await fs.mkdtemp(path.join(os.tmpdir(), "cowork-home-"));
+    try {
+      const chatDir = path.join(getOneOffChatsRoot(homedir), "20260620-chat");
+      const projectDir = path.join(homedir, "project");
+      await fs.mkdir(chatDir, { recursive: true });
+      await fs.mkdir(projectDir, { recursive: true });
+
+      const chatResult = await listWorkspaceSummaries({
+        workingDirectory: await fs.realpath(chatDir),
+        homedir,
+      });
+      expect(chatResult.workspaces).toEqual([
+        expect.objectContaining({
+          path: await fs.realpath(chatDir),
+          workspaceKind: "oneOffChat",
+        }),
+      ]);
+      expect(chatResult.activeWorkspaceId).toBe(chatResult.workspaces[0]?.id);
+
+      const projectResult = await listWorkspaceSummaries({
+        workingDirectory: await fs.realpath(projectDir),
+        homedir,
+      });
+      expect(projectResult.workspaces).toEqual([
+        expect.objectContaining({
+          path: await fs.realpath(projectDir),
+          workspaceKind: "project",
+        }),
+      ]);
+    } finally {
+      await fs.rm(homedir, { recursive: true, force: true });
+    }
+  });
+
   test("listWorkspaceSummaries returns desktop workspaces with workspaceKind", async () => {
     const projectPath = "/tmp/project-a";
     const chatPath = "/tmp/chats/chat-1";

--- a/test/workspace.catalog.test.ts
+++ b/test/workspace.catalog.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { requireWorkspacePath } from "../src/server/jsonrpc/routes/shared";
 import { listWorkspaceSummaries } from "../src/server/jsonrpc/workspaceCatalog";
@@ -29,6 +30,38 @@ describe("workspace catalog and path rules", () => {
       requireWorkspacePath({ cwd: legacyChatDir }, "thread/list", projectDir, homedir),
     ).toThrow("thread/list cwd must match the server workspace or a one-off chat workspace");
     await fs.rm(homedir, { recursive: true, force: true });
+  });
+
+  test("requireWorkspacePath confines task RPCs to the canonical active workspace", async () => {
+    const homedir = await fs.mkdtemp(path.join(os.tmpdir(), "cowork-home-"));
+    try {
+      const projectRoot = path.join(homedir, "project");
+      const outsideRoot = path.join(homedir, "outside");
+      const aliasDir = path.join(homedir, "project-alias");
+      await fs.mkdir(projectRoot, { recursive: true });
+      await fs.mkdir(outsideRoot, { recursive: true });
+      const projectDir = await fs.realpath(projectRoot);
+      const outsideDir = await fs.realpath(outsideRoot);
+      await fs.symlink(projectDir, aliasDir, "dir");
+
+      expect(requireWorkspacePath({}, "task/list", projectDir, homedir)).toBe(
+        await fs.realpath(projectDir),
+      );
+      expect(requireWorkspacePath({ cwd: projectDir }, "task/list", projectDir, homedir)).toBe(
+        await fs.realpath(projectDir),
+      );
+      expect(() =>
+        requireWorkspacePath({ cwd: outsideDir }, "task/list", projectDir, homedir),
+      ).toThrow("task/list cwd must match an authorized workspace");
+      expect(() =>
+        requireWorkspacePath({ cwd: aliasDir }, "task/list", projectDir, homedir),
+      ).toThrow("task/list cwd must use the canonical workspace path");
+      expect(() =>
+        requireWorkspacePath({ cwd: "C:project" }, "task/list", projectDir, homedir),
+      ).toThrow("task/list cwd must use an absolute workspace path");
+    } finally {
+      await fs.rm(homedir, { recursive: true, force: true });
+    }
   });
 
   test("listWorkspaceSummaries returns desktop workspaces with workspaceKind", async () => {

--- a/test/workspaceControl.test.ts
+++ b/test/workspaceControl.test.ts
@@ -58,4 +58,62 @@ describe("WorkspaceControl", () => {
 
     expect(sent.map((entry) => entry.connectionId)).toEqual(["allowed-h3", "desktop"]);
   });
+
+  test("keeps workspace-control subscriptions on the latest registered workspace only", () => {
+    const sent: Array<{ connectionId: string | undefined; payload: unknown }> = [];
+    const control = new WorkspaceControl({
+      env: {},
+      fallbackWorkingDirectory: "/tmp",
+      registry: {} as never,
+      socketSendQueue: {
+        shouldSendNotification() {
+          return true;
+        },
+        send(ws: { data: { connectionId?: string } }, payload: unknown) {
+          sent.push({ connectionId: ws.data.connectionId, payload });
+        },
+      } as never,
+    });
+    const subscriber = testSocket({
+      connectionId: "workspace-control-client",
+      protocolMode: "jsonrpc",
+    });
+
+    control.registerSubscriber(subscriber, "/workspace-a");
+    control.registerSubscriber(subscriber, "/workspace-b");
+
+    (
+      control as unknown as {
+        notifySubscribers(cwd: string, event: Extract<SessionEvent, { type: "mcp_servers" }>): void;
+      }
+    ).notifySubscribers("/workspace-a", {
+      type: "mcp_servers",
+      sessionId: "workspace-a-control",
+      servers: [],
+    });
+    (
+      control as unknown as {
+        notifySubscribers(cwd: string, event: Extract<SessionEvent, { type: "mcp_servers" }>): void;
+      }
+    ).notifySubscribers("/workspace-b", {
+      type: "mcp_servers",
+      sessionId: "workspace-b-control",
+      servers: [],
+    });
+
+    expect(sent).toEqual([
+      {
+        connectionId: "workspace-control-client",
+        payload: {
+          method: "cowork/control/event",
+          params: {
+            cwd: "/workspace-b",
+            type: "mcp_servers",
+            sessionId: "workspace-b-control",
+            servers: [],
+          },
+        },
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
## What
- Enforces server-side task JSON-RPC permissions: task reads require `conversations`; task mutations, lifecycle operations, task thread creation, direct task creation, and artifact writes require both `conversations` and `turns`.
- Confines task `cwd` resolution to the canonical active workspace or an exact desktop-persisted workspace path, then relies on `TaskCoordinator` workspace ownership checks for task and artifact IDs.
- Filters task notification fan-out for sockets without task read permission.
- Documents the task RPC permission split, workspace confinement rules, and notification filtering in `docs/websocket-protocol.md`.

## Why / Threat Model
The task-mode review identified that paired/mobile JSON-RPC callers with insufficient permissions could reach `task/*` methods or task notifications and learn task IDs, summaries, activity, questions, approvals, artifact paths, thread IDs, and workspace metadata, or mutate task state without the analogous chat/workspace mutation permission. Caller-supplied `cwd` values also risked routing task operations outside the active workspace boundary.

The fixed boundary lives in the harness/server. Desktop and mobile UI state is not trusted for this decision. Task mode remains explicit and separate from ordinary chat; this PR does not expose task-owned sessions through `thread/list` or generic chat recents.

## Authorization Matrix
| Surface | Required capability | Workspace check | Task/object ownership | Allowed operation |
| --- | --- | --- | --- | --- |
| `task/list`, `task/read`, `task/artifact/read`, `task/artifact/version/compare`, `task/artifact/version/preview` | `conversations` | Canonical active workspace or exact desktop-persisted workspace path | Task/artifact workspace must match request context | Read task data only |
| `task/create`, task brief/graph/work-item/decision/question/blocker/lifecycle methods, `task/thread/create`, artifact register/capture/restore/accept/revision-start | `conversations` + `turns` | Same | Same | Mutate task state, task threads, or artifacts |
| Task notifications: `task/created`, `task/updated`, `task/activity`, `task/checkpointCreated` | Task read permission (`conversations`) | Workspace subscription plus canonical workspace key | Notification emitted only for authorized subscribers | Receive task metadata |
| Omitted `cwd` for task RPCs | Same as method | Active server workspace only | Same | Active-workspace task operation |
| Outside, symlink-alias, project-local chat alias, drive-relative, or non-canonical `cwd` | N/A | Rejected before task operation | N/A | Not allowed |

## Exploit / Regression Coverage
- Reproduced mobile H3 permission bypasses with deterministic tests: default devices cannot read tasks, conversation-only devices can read but cannot mutate, and conversations+turns devices can mutate.
- Reproduced shared route authorization gaps: sockets explicitly marked without task read or mutation permission are rejected before schema dispatch.
- Reproduced workspace confinement gaps: task RPC `cwd` outside the active workspace, symlink aliases, and Windows drive-relative inputs are rejected; exact canonical active workspace remains allowed.
- Reproduced notification eavesdropping: a subscriber without task read permission no longer receives task notifications.
- Added cross-workspace task ownership regression coverage at the coordinator layer for wrong-workspace task IDs.
- Added positive control for exact desktop-persisted workspace paths so multi-workspace desktop routing still works without allowing arbitrary directories.

## Verification
- `bun test test/h3.mobile-http-jsonrpc.test.ts test/workspace.catalog.test.ts test/jsonrpc.tasks-route.test.ts test/server/runtime/workspaceJsonRpcSubscribers.test.ts test/task-mode.persistence.test.ts` - 95 pass, 0 fail, 354 expects.
- `bunx biome check docs/websocket-protocol.md src/server/jsonrpc/taskPermissions.ts src/server/jsonrpc/routes/shared.ts src/server/jsonrpc/routes/tasks.ts src/server/runtime/WorkspaceJsonRpcSubscribers.ts src/server/startServer/types.ts src/server/transport/h3/server.ts test/h3.mobile-http-jsonrpc.test.ts test/jsonrpc.tasks-route.test.ts test/server/runtime/workspaceJsonRpcSubscribers.test.ts test/task-mode.persistence.test.ts test/workspace.catalog.test.ts` - passed, no fixes applied.
- `bun run check` - passed, with existing generated-doc size warnings for `docs/generated/websocket-jsonrpc.d.ts` and `.schema.json`.
- `bun run lint` - passed.
- `bun test --max-concurrency 1` - 5409 pass, 10 skip, 0 fail, 17880 expects across 540 files.
- `bun run typecheck` - passed.
- `bun run docs:check` - passed.

## Notes
- Did not launch Electron or touch the real Cowork profile; this is harness/server protocol behavior with deterministic server and route tests.
- Did not merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authorization, workspace path validation, and notification fan-out for task data on JSON-RPC/H3—security-sensitive surfaces that could leak task metadata or allow cross-workspace access if misimplemented.
> 
> **Overview**
> Hardens **task-mode JSON-RPC** so paired/mobile clients cannot read or mutate tasks—or receive task notifications—without the same capabilities as chat (`conversations` for reads, `conversations` + `turns` for mutations). **`task/artifact/read`** is treated as a mutation when it can lazily materialize a legacy baseline, so it requires both permissions.
> 
> **Workspace boundaries** for `task/*` are tightened: `cwd` must be canonical and resolve to an **authorized project** workspace (active server cwd, desktop catalog path, or explicit persisted project under `~/.cowork/chats`). One-off chat roots, symlink aliases, and arbitrary directories are rejected. **Workspace kind** classification now uses configured `homedir` and path canonicalization so legacy/fallback desktop state does not mis-label chats as projects.
> 
> **Task notification fan-out** is scoped: subscribers without task read permission are skipped; task workspace subscriptions are **additive** per authorized project (unlike single-workspace control events). Chat **createTask** promotion registers the source thread’s subscribers for the task workspace.
> 
> Protocol docs in `docs/websocket-protocol.md` describe the permission matrix, workspace rules, and notification filtering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bafc1bfc93fee51350e67bb08948b31f148abf9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->