### PR TITLE
Bun-native migration: audit, plan, and full implementation

### DIFF
--- a/apps/desktop/src/app/openaiCompatibleProviderOptions.ts
+++ b/apps/desktop/src/app/openaiCompatibleProviderOptions.ts
@@ -8,15 +8,16 @@ import {
   normalizeGoogleThinkingLevelForModel,
 } from "../../../../src/shared/googleThinking";
 import {
+  type CatalogReasoningEffort,
   CODEX_WEB_SEARCH_BACKEND_VALUES,
   CODEX_WEB_SEARCH_MODE_VALUES,
-  type CatalogReasoningEffort,
   type CodexWebSearchBackend,
   type CodexWebSearchMode,
   getCodexWebSearchBackendFromProviderOptions,
   getGoogleNativeWebSearchFromProviderOptions,
   getGoogleThinkingLevelFromProviderOptions,
   getLocalWebSearchProviderFromProviderOptions,
+  isOpenAiReasoningEffort,
   LOCAL_WEB_SEARCH_PROVIDER_VALUES,
   type LocalWebSearchProvider,
   mergeEditableOpenAiCompatibleProviderOptions,
@@ -32,7 +33,6 @@ import {
   type GoogleProviderOptions as SharedGoogleProviderOptions,
   type OpenAiCompatibleProviderName as SharedOpenAiCompatibleProviderName,
   type OpenAiCompatibleProviderOptions as SharedOpenAiCompatibleProviderOptions,
-  isOpenAiReasoningEffort,
 } from "../../../../src/shared/openaiCompatibleOptions";
 
 export const REASONING_EFFORT_VALUES = OPENAI_REASONING_EFFORT_VALUES;
@@ -214,16 +214,15 @@ export function getGoogleReasoningEffortValuesForModel(
   return listGoogleReasoningEffortValuesForModel(modelId);
 }
 
-export function isOpenAiReasoningEffortValue(
-  value: unknown,
-): value is OpenAiReasoningEffortValue {
+export function isOpenAiReasoningEffortValue(value: unknown): value is OpenAiReasoningEffortValue {
   return isOpenAiReasoningEffort(value);
 }
 
 export function isGoogleReasoningEffortValue(value: unknown): value is GoogleReasoningEffortValue {
   return (
     value === GOOGLE_DYNAMIC_REASONING_EFFORT ||
-    (typeof value === "string" && (GOOGLE_THINKING_LEVEL_VALUES as readonly string[]).includes(value))
+    (typeof value === "string" &&
+      (GOOGLE_THINKING_LEVEL_VALUES as readonly string[]).includes(value))
   );
 }
 

--- a/apps/desktop/src/app/store.actions/thread.ts
+++ b/apps/desktop/src/app/store.actions/thread.ts
@@ -5,6 +5,11 @@ import {
 } from "../../lib/composerAttachments";
 import * as desktopCommands from "../../lib/desktopCommands";
 import { type NewChatLandingTarget, resolveDefaultNewChatTarget } from "../../lib/newChatLanding";
+import {
+  googleProviderOptionsForReasoningEffort,
+  isGoogleReasoningEffortValue,
+  isOpenAiReasoningEffortValue,
+} from "../openaiCompatibleProviderOptions";
 import { isSandboxApprovalThreadVisible } from "../sandboxApprovalVisibility";
 import {
   type AppStoreActions,
@@ -44,11 +49,6 @@ import {
 import { requestJsonRpc } from "../store.helpers/jsonRpcSocket";
 import { createOneOffWorkspaceRecord } from "../store.helpers/oneOffWorkspaceRecord";
 import { waitForNextPaintOrTimeout } from "../store.helpers/paintScheduling";
-import {
-  googleProviderOptionsForReasoningEffort,
-  isGoogleReasoningEffortValue,
-  isOpenAiReasoningEffortValue,
-} from "../openaiCompatibleProviderOptions";
 import { isStandardChatThread } from "../threadFilters";
 import { hydrateTranscriptSnapshot } from "../transcriptHydration";
 import {
@@ -1271,8 +1271,7 @@ export function createThreadActions(
 
     setThreadReasoningEffort: (threadId, provider, effort) => {
       const providerConfig =
-        (provider === "openai" || provider === "codex-cli") &&
-        isOpenAiReasoningEffortValue(effort)
+        (provider === "openai" || provider === "codex-cli") && isOpenAiReasoningEffortValue(effort)
           ? { [provider]: { reasoningEffort: effort } }
           : provider === "google" && isGoogleReasoningEffortValue(effort)
             ? { google: googleProviderOptionsForReasoningEffort(effort) }

--- a/apps/desktop/src/ui/ChatView.tsx
+++ b/apps/desktop/src/ui/ChatView.tsx
@@ -423,7 +423,9 @@ export function ChatView({ readOnlyNotice }: ChatViewProps = {}) {
     const resolveConfig = (provider: ProviderName, model: string) => {
       const reasoningConfig = reasoningConfigFromCatalog(providerCatalog, provider, model);
       if (!reasoningConfig) return { provider, model, reasoning: null };
-      const providerOptions = thread.draft ? workspace?.providerOptions : rt.sessionConfig?.providerOptions;
+      const providerOptions = thread.draft
+        ? workspace?.providerOptions
+        : rt.sessionConfig?.providerOptions;
       const configuredEffort =
         provider === "openai" || provider === "codex-cli"
           ? providerOptions?.[provider]?.reasoningEffort

--- a/apps/desktop/src/ui/chat/ChatComposer.tsx
+++ b/apps/desktop/src/ui/chat/ChatComposer.tsx
@@ -57,7 +57,10 @@ export function ChatComposer(props: {
   fileInputRef: RefObject<HTMLInputElement | null>;
   handleFileSelect: (event: ChangeEvent<HTMLInputElement>) => void;
   threadModelConfig: { provider: ProviderName; model: string } | null;
-  reasoningSelector: { value: ReasoningEffortValue; options: readonly ReasoningEffortValue[] } | null;
+  reasoningSelector: {
+    value: ReasoningEffortValue;
+    options: readonly ReasoningEffortValue[];
+  } | null;
   onReasoningEffortChange: (value: ReasoningEffortValue) => void;
   threadDraft: boolean;
   selectedThreadId: string;

--- a/apps/desktop/src/ui/chat/ComposerReasoningToggle.tsx
+++ b/apps/desktop/src/ui/chat/ComposerReasoningToggle.tsx
@@ -52,7 +52,11 @@ export function ComposerReasoningSelector({
   const active = value !== "none";
 
   return (
-    <Select value={value} onValueChange={(next) => onChange(next as ReasoningEffortValue)} disabled={disabled}>
+    <Select
+      value={value}
+      onValueChange={(next) => onChange(next as ReasoningEffortValue)}
+      disabled={disabled}
+    >
       <SelectTrigger
         size="sm"
         aria-label="Reasoning effort"

--- a/apps/desktop/test/server-manager.chaos.test.ts
+++ b/apps/desktop/test/server-manager.chaos.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, mock, test } from "bun:test";
-
-import { createElectronMock, setElectronMockOverrides } from "./helpers/mockElectron";
 import { createFakeChild, type FakeChild } from "./helpers/fakeServerChild";
+import { createElectronMock, setElectronMockOverrides } from "./helpers/mockElectron";
 
 // Chaos scenarios for the desktop supervisor (ServerManager): the workspace
 // server dies after announcing itself, the health probe stalls past the 1.5s

--- a/apps/desktop/test/skill-plugin-actions.harness.ts
+++ b/apps/desktop/test/skill-plugin-actions.harness.ts
@@ -1,3 +1,5 @@
+import { mock } from "bun:test";
+
 import {
   type AppStoreState,
   reactivateWorkspaceJsonRpcState,
@@ -6,12 +8,44 @@ import {
 } from "../src/app/store.helpers";
 import { defaultWorkspaceRuntime, RUNTIME } from "../src/app/store.helpers/runtimeState";
 import type { WorkspaceRuntime } from "../src/app/types";
+import { createDesktopCommandsMock } from "./helpers/mockDesktopCommands";
 
 export { defaultWorkspaceRuntime, RUNTIME };
 
 /** Distinct from control-socket tests (`ws-skills`) so parallel CI runs do not share disposed JSON-RPC state. */
 export const workspaceId = "ws-skills-store-actions";
 export const secondaryWorkspaceId = "ws-skills-secondary";
+
+const DESKTOP_BRIDGE_UNAVAILABLE = "Desktop bridge unavailable. Start the app via Electron.";
+
+/**
+ * Pin `desktopCommands` to the same behavior the real module has when no desktop
+ * bridge is present. Other desktop test files register
+ * `mock.module("../src/lib/desktopCommands", ...)` mocks that leak across the shared
+ * bun test process; a leaked `getWorkspaceServerStatus` reporting `url: "ws://mock"`
+ * makes `ensureServerRunning` treat the fake per-workspace server URLs used here as
+ * stale, tearing down the fake JSON-RPC sockets these tests install on `RUNTIME`.
+ */
+function installDesktopCommandsBridgeUnavailableMock() {
+  mock.module("../src/lib/desktopCommands", () =>
+    createDesktopCommandsMock({
+      getWorkspaceServerStatus: async ({ workspaceId: id }) => ({
+        workspaceId: id,
+        running: true,
+        url: null,
+        reason: "running",
+      }),
+      startWorkspaceServer: async () => {
+        throw new Error(DESKTOP_BRIDGE_UNAVAILABLE);
+      },
+      stopWorkspaceServer: async () => {
+        throw new Error(DESKTOP_BRIDGE_UNAVAILABLE);
+      },
+    }),
+  );
+}
+
+installDesktopCommandsBridgeUnavailableMock();
 
 type HarnessWorkspace = { id: string; path: string };
 
@@ -52,6 +86,7 @@ export function createStoreHarness(state: StoreActionHarnessState) {
 }
 
 export function resetSkillPluginActionRuntime() {
+  installDesktopCommandsBridgeUnavailableMock();
   RUNTIME.jsonRpcSockets.clear();
   RUNTIME.skillInstallWaiters.clear();
   RUNTIME.pluginInstallWaiters.clear();

--- a/docs/bun-native-migration.md
+++ b/docs/bun-native-migration.md
@@ -1,6 +1,6 @@
 # Bun-Native Migration: Audit & Plan
 
-Status: audit complete, migration not started. This document is the system-of-record for moving the harness from Node.js APIs to Bun-native APIs where it is a win, and for recording what deliberately stays on `node:` builtins.
+Status: **Phases 0–6 implemented** (see "Implementation status" below). This document is the system-of-record for moving the harness from Node.js APIs to Bun-native APIs where it is a win, and for recording what deliberately stays on `node:` builtins.
 
 Audited at repo `e8c7bb66`. Scope: `src/`, `packages/`, `scripts/`. `apps/desktop` (Electron) and `apps/mobile` (Expo) run Node/Chromium/React Native and are only in scope as consumers of shared `src/` modules.
 
@@ -182,6 +182,25 @@ Define a `HarnessSubprocess` interface (spawn, write stdin, async line iteration
 - Drop `ws` from the one test; evaluate dropping it from desktop via a Bun-subprocess smoke.
 - Evaluate `Bun.Glob` for `src/tools/glob.ts` behind its existing tool tests.
 - Async-ify `workspace/map.ts`; telemetry config/SDK split.
+
+## Implementation status
+
+- **Phase 0** ✅ `test/desktopSharedBunBoundary.test.ts` computes the Electron-main and renderer value-import closures and fails on any `bun:`/`Bun.*` usage inside them.
+- **Phase 1** ✅ global `crypto.randomUUID()`/`getRandomValues` replace `node:crypto` imports in 7 files; `Bun.spawn` in `scripts/postinstall.ts`, `scripts/open_xcode_workspace.ts`, and the stable test runner; `Bun.Glob` replaces `fast-glob` in the harness runner and `test/package-manifest.test.ts` (verified identical file sets).
+- **Phase 2** ✅ MCP OAuth callback on `Bun.serve`, bound to `127.0.0.1` + best-effort `::1` on one port, redirect URI pinned to `127.0.0.1`, with an IPv6 coverage test.
+- **Phase 3** ✅ `src/utils/execFileCompat.ts` (Bun.spawn, Node execFile contract: maxBuffer, timeout→SIGTERM/exit 124, abort/exit 130, ENOENT codes, pipe teardown on kill) + parity tests; consumers migrated: `tools/bash.ts`, `tools/grep.ts`, `utils/ripgrep.ts`, `coworkRuntime/runtime.ts`. Streaming consumers on `src/utils/subprocess.ts` (`spawnStreamingSubprocess` + `subscribeLines`): `sessionBackup/command.ts`, `coworkRuntime/libreOffice.ts` (now with a 4 MiB output cap), `webDesktopService.ts`.
+- **Phase 4** ✅ `Bun.file` reads on hot paths: edit/read tools, prompt templates, skill catalog/bodies, config layers, session snapshots, memory/MCP-auth/CLI-state stores; `Bun.write` in the edit tool.
+- **Phase 5** ✅ codex app-server client/resolver on `StreamingSubprocess` (NDJSON via `subscribeLines`, stdin via Bun `FileSink`, SIGTERM→SIGKILL stop escalation; probe/tar via `execFileCompat` with SIGKILL timeout).
+- **Phase 6** ✅ `src/utils/hash.ts` (`Bun.CryptoHasher` sha256 helpers, streaming file hashing) adopted by ripgrep + codex asset checksums; `ws` removed from the root test suite (Bun's client negotiates multi-protocol offers natively).
+
+Deferred follow-ups (deliberate):
+
+- `src/tools/glob.ts` keeps `fast-glob` (stat-streaming + abort semantics; revisit with behavior tests).
+- `utils/browser.ts` keeps `node:child_process` `detached`+`unref` until fire-and-forget parity is verified on macOS/Windows.
+- `platform/sandbox/detect.ts` stays fully on `node:` (value-imported by Electron main).
+- `config.ts` `getSavedProviderApiKeyForHome` sync read and `workspace/map.ts` sync walk (API-shape changes; separate slice).
+- Telemetry config/SDK split for preload bundling hygiene.
+- Remaining `createHash("sha256")` fingerprint sites work natively under Bun; adopt `utils/hash.ts` opportunistically.
 
 ## Keep-on-Node register (deliberate, with reasons)
 

--- a/docs/bun-native-migration.md
+++ b/docs/bun-native-migration.md
@@ -1,0 +1,198 @@
+# Bun-Native Migration: Audit & Plan
+
+Status: audit complete, migration not started. This document is the system-of-record for moving the harness from Node.js APIs to Bun-native APIs where it is a win, and for recording what deliberately stays on `node:` builtins.
+
+Audited at repo `e8c7bb66`. Scope: `src/`, `packages/`, `scripts/`. `apps/desktop` (Electron) and `apps/mobile` (Expo) run Node/Chromium/React Native and are only in scope as consumers of shared `src/` modules.
+
+## TL;DR
+
+The two largest surfaces are **already Bun-native**:
+
+- **WebSocket/HTTP server**: `src/server/startServer.ts` and the H3 mobile transport (`src/server/transport/h3/server.ts`) are fully on `Bun.serve` (fetch handler, `srv.upgrade`, `websocket.open/message/close/drain`, TLS + `h3: true`). No `ws` server, no `node:http` in the agent server path.
+- **SQLite**: `src/server/sessionDb*` and `src/memoryStore.ts` already use `bun:sqlite`.
+
+What remains is a long tail: `node:child_process` (13 files), `node:fs` read/write hot paths (~109 files, mostly fine as-is), `node:crypto` hashing/UUIDs, one `node:http` OAuth callback listener, and a handful of npm deps (`fast-glob`, `ws` in desktop) that Bun builtins can replace.
+
+Important framing: Bun implements `node:fs`, `node:path`, `node:crypto`, `node:os`, etc. **natively** — they are not a slow compatibility shim. Migration targets are chosen for (a) simpler/faster Bun-idiomatic code on hot paths, (b) dropping npm deps, (c) consistency — not because `node:` imports are broken under Bun.
+
+## Hard constraint: the Electron/renderer shared-module boundary
+
+Files under `apps/desktop/electron/**` run in Electron **main** (Node runtime, not Bun). Files under `apps/desktop/src/**` run in the **renderer** (Chromium). Both value-import modules from root `src/`. Those shared modules can never use `bun:` imports or `Bun.*` globals.
+
+The desktop app never runs harness/server logic in-process: `apps/desktop/electron/services/serverManager.ts` always spawns the server as a **Bun sidecar** (`bun src/server/index.ts` in dev; the `bun build --compile` `cowork-server` binary when packaged). So everything reachable only from the server/CLI/harness entrypoints is safe for Bun-only APIs.
+
+### Must stay Node-compatible (value-imported by Electron main/preload, incl. one-level transitive closure)
+
+```
+src/diagnostics/redaction.ts        src/sync/providers/customHttp.ts
+src/platform/sandbox/bwrap.ts       src/sync/queue.ts
+src/platform/sandbox/detect.ts      src/sync/redaction.ts
+src/platform/sandbox/policy.ts      src/sync/service.ts
+src/platform/sandbox/seatbelt.ts    src/sync/types.ts
+src/platform/sandbox/windows.ts     src/telemetry/config.ts
+src/server/startupProgress.ts       src/telemetry/crashReporting.ts
+src/shared/attachments.ts           src/telemetry/productAnalytics.ts
+src/shared/featureFlags.ts          src/types.ts
+src/shared/quickChatShortcut.ts     src/utils/atomicFile.ts
+src/store/connections.ts            src/utils/oneOffChats.ts
+                                    src/utils/paths.ts
+```
+
+### Must stay browser-compatible (value-imported by the desktop renderer)
+
+`src/client/jsonRpcSocket.ts`, `src/models/registry.ts`, `src/providers/catalog.ts`, `src/server/jsonrpc/protocol.ts`, `src/session/*`, most of `src/shared/*`, `src/telemetry/{config,crashReporting,productAnalytics}.ts`, `src/types.ts`, `src/utils/workspacePath.ts`.
+
+Audit result: **no current violations** — none of these files import `bun:` modules or use `Bun.*` today. Phase 0 below adds a guardrail so it stays that way.
+
+Note on globals: `crypto.randomUUID()`, `crypto.getRandomValues()`, `fetch`, `WebSocket`, `TextEncoder/Decoder`, and Web Streams are available in Bun, Node ≥ 20, and browsers — shared modules may use these freely. That makes "drop `node:crypto` import, use global Web Crypto" safe even inside the shared boundary.
+
+## Audit results by area
+
+### 1. Network stack — done, two stragglers
+
+| Surface | State |
+| --- | --- |
+| Main WS/HTTP server (`startServer.ts`) | ✅ `Bun.serve` + `srv.upgrade`, port fallback, backpressure via `drain` |
+| H3 mobile transport (`transport/h3/server.ts`) | ✅ `Bun.serve` with TLS + `h3: true` (QUIC when available, HTTPS fallback); clients use fetch + SSE, not WS |
+| WS clients (CLI REPL, renderer, tests, examples) | ✅ `JsonRpcSocket` over `globalThis.WebSocket` (Bun-native / browser-native) |
+| MCP OAuth callback listener (`src/mcp/oauthProvider.ts`) | ❌ `node:http` `createServer`, binds `127.0.0.1` only → **migrate to `Bun.serve`** (Phase 2) |
+| `ws` npm dep | ❌ Only `apps/desktop/electron/services/desktopSmoke.ts` (Electron main — legitimately Node) and one subprotocol-negotiation test in `test/server.jsonrpc.test.ts`. Not a root dep. |
+
+The OAuth migration must also fix a pre-existing gap vs. our OAuth engineering rule: the listener binds IPv4 loopback only; the `Bun.serve` version should bind both `127.0.0.1` and `::1` (two listeners, one advertised redirect URI) or document why IPv4-only is required by specific IdPs.
+
+### 2. SQLite — done
+
+`bun:sqlite` in `src/server/sessionDb.ts` (+ `sessionDb/` modules) and `src/memoryStore.ts`. No `better-sqlite3`/`node:sqlite` anywhere. No action.
+
+### 3. Child processes — the main migration (13 files, all `Bun.spawn`-able)
+
+No `exec`/`execSync`/`fork` anywhere; usage is `execFile` (buffered), `spawn` (streaming), `spawnSync` (sandbox probes). Precedent already exists: `scripts/releaseBuildUtils.ts` uses `Bun.spawn`.
+
+| File | API | Difficulty | Notes |
+| --- | --- | --- | --- |
+| `scripts/postinstall.ts`, `scripts/open_xcode_workspace.ts` | `spawn` inherit | easy | direct swap |
+| `packages/harness/src/run_tests_stable.ts` | `spawn` inherit | easy | direct swap |
+| `src/utils/ripgrep.ts` | `execFile` | easy | tar/PowerShell extraction, bounded |
+| `src/tools/bash.ts` | `execFile` | **hard, highest value** | agent shell tool: 10 MB `maxBuffer`, timeout→SIGTERM→exit 124, AbortSignal→exit 130, `windowsHide`, env replacement, shell-candidate ENOENT fallback, sandbox transform |
+| `src/tools/grep.ts` | `execFile` | medium | same contract as bash (timeout/abort/maxBuffer), injectable `execFileImpl` |
+| `src/coworkRuntime/runtime.ts` | promisified `execFile` | medium | version/import probes with timeout + maxBuffer |
+| `src/coworkRuntime/libreOffice.ts` | `spawn` + manual SIGKILL timer | medium | add an output cap while migrating (currently unbounded) |
+| `src/server/sessionBackup/command.ts` | `spawn`, async stream drain | medium | tar/preview; consider adding timeout/max-bytes |
+| `src/server/webDesktopService.ts` | `spawn` + readline line streaming, graceful SIGTERM→SIGKILL | medium | startup JSON monitor |
+| `src/utils/browser.ts` | `spawn` `detached` + `unref` | needs care | verify Bun fire-and-forget parity per platform |
+| `src/providers/codexAppServerResolver.ts` + `codexAppServerClient.ts` | `spawn` (probes, tar, long-lived JSON-RPC over stdio) | hard | migrate together behind a subprocess interface (stdin write, stdout line events, kill, exited) |
+| `src/platform/sandbox/detect.ts` | `spawnSync` ×4 | **blocked as-is** | value-imported by Electron main (`findWindowsHelper`); split Node-safe exports out first, or keep on `node:child_process` (works in both runtimes) |
+
+Strategy: build one shared `execFileCompat(file, args, opts)` helper on `Bun.spawn` that reproduces the Node `execFile` contract our tools rely on (maxBuffer cap, `timeout` + `killSignal`, `AbortSignal`, buffered stdout/stderr, exit-code/signal mapping), land it with a parity test suite, then convert consumers one at a time. Parity notes:
+
+- Bash tool today has **no process-tree kill** — timeout SIGTERMs only the direct shell child. Migrate for parity first; tree-kill would be a behavior change to consider separately.
+- `Bun.spawn` timeouts/kills need a manual timer + `proc.kill("SIGTERM")`; there is no `maxBuffer`, so cap while reading the streams.
+
+### 4. Filesystem — targeted hot-path wins, keep the rest
+
+~109 files import `node:fs`/`node:fs/promises`. Most usage (mkdir, readdir, stat, rm, rename, chmod, watch, symlink, realpath) has **no Bun-native equivalent** and stays. `node:path` (~120 files) needs no migration at all.
+
+Migrate (whole-file text/JSON read/write → `Bun.file().text()/.json()` + `Bun.write()`):
+
+| Target | Why |
+| --- | --- |
+| `src/tools/edit.ts` | hottest agent path; read-modify-write of whole files |
+| `src/tools/read.ts` image branch | `Bun.file().arrayBuffer()`; keep the streaming text branch |
+| `src/skills/loadSkillBody.ts`, `src/skills/catalog.ts`, `src/prompt.ts`, `src/projectInstructions.ts` | per-turn prompt/skill assembly |
+| `src/config.ts` | startup config layers; also converts the sync `readFileSync` API-key read to async |
+| `src/server/sessionStore.ts` JSON bodies, `src/memoryStore.ts`, `src/store/connections.ts`* , `src/mcp/authStore/store.ts`, `src/cli/repl/stateStore.ts` | small JSON blobs (*connections.ts is Electron-shared — keep `node:fs` there) |
+| `src/runtime/toolOutputOverflow.ts` spill writes | `Bun.write` |
+| `scripts/*`, `packages/harness/*` | Bun-only; lowest-risk pilot area |
+
+Keep on `node:fs` (explicit non-goals):
+
+- **Atomic writes** (`src/utils/atomicFile.ts`, sessionStore/writeCoordinator tmp+`rename`+Windows-retry) — `Bun.write` is not atomic-rename.
+- **Streaming** (`tools/webFetch.ts` capped downloads via `fs.open`, `coworkRuntime/{archive,download}.ts`, backup hashing/deltas, `tools/read.ts` line streaming).
+- **`fs.watch`** (`SkillMutationBus`, `webDesktopService`, `coworkRuntime/integrity.ts` recursive watch) — Bun has no watch API.
+- **`realpathSync.native`** in `src/utils/paths.ts` — security-critical permission checks, also used from Electron IPC.
+- **chmod/mode hardening**, readdir+Dirent walks, copyFile, symlink/readlink.
+
+Optional follow-ups: async-ify `src/workspace/map.ts` (sync readdir/stat on every turn's prompt build) and `existsSync` → `Bun.file().exists()` in Bun-only paths.
+
+### 5. Crypto — mechanical wins, three deliberate keeps
+
+| Pattern | Sites | Action |
+| --- | --- | --- |
+| `import { randomUUID } from "node:crypto"` | 6 files (`sync/service`, `oneOffChats`, `coworkRuntime/{install,bootstrapLock}`, `spreadsheetEdit`, `mcp/oauthProvider`) | global `crypto.randomUUID()` — safe even in Electron-shared files; ~25 files already do this |
+| `randomBytes(24)` OAuth state | `mcp/oauthProvider.ts` | `crypto.getRandomValues` + existing base64url helper |
+| `createHash("sha256")` | 18+ files (fingerprints, checksums, content-addressed artifacts) | shared `sha256Stream`/`sha256` helpers on `Bun.CryptoHasher` for Bun-only paths; `detect.ts` (Electron-shared) keeps `node:crypto` |
+| `randomInt` | `appleFoundationTitle.ts` | low priority; keep or `getRandomValues` |
+| `timingSafeEqual` | `h3/pairing.ts` | **keep** `node:crypto` (native in Bun) |
+| Ed25519 `createPublicKey`+`verify` | `coworkRuntime/integrity.ts` | **keep** — signed-runtime trust boundary; only migrate with full test vectors |
+| `node:dns/promises` + `net.isIP` SSRF gate | `utils/webSafety.ts` | **keep** — security-critical resolution semantics |
+
+### 6. Small builtins — keep
+
+`node:readline` (CLI REPL prompts + secret masking via `_writeToOutput`; NDJSON subprocess parsing — could become a shared async line-reader when the codex client migrates), `node:os`, `node:url`, `node:async_hooks` (`AsyncLocalStorage`, Bun-supported), `node:stream` (fetch→disk pipelines), `Buffer` (idiomatic and fast in Bun). One cleanup: `promisify(execFile)` in `coworkRuntime/runtime.ts` disappears with `execFileCompat`.
+
+### 7. npm dependencies
+
+| Dep | Verdict |
+| --- | --- |
+| `fast-glob` | **Replace in `packages/harness/run_tests_stable.ts` + `test/package-manifest.test.ts`** with `Bun.Glob`. **Keep in `src/tools/glob.ts` for now**: the tool needs streaming with abort, `stats: true` (mtime ordering), `objectMode`, `braceExpansion: false` — `Bun.Glob` has no stat-stream; revisit as a scoped follow-up with behavior tests. |
+| `ws` (desktop) | Replace the one test usage with Bun's client `WebSocket` if it supports multi-protocol offers; `desktopSmoke.ts` runs in Electron main (Node) and may keep `ws`, or move smoke into a Bun subprocess to drop the dep. |
+| `proxy-agent` | **Keep** — feeds Node `http.Agent` into the AWS SDK's `NodeHttpHandler` for Bedrock; Bun's fetch env-proxy doesn't apply. |
+| `yauzl`, `jszip`, `fast-xml-parser` | **Keep** — ZIP extraction with zip-slip/symlink/entry-limit hardening (yauzl) and OOXML read/modify/write (jszip + fxp). Bun has gzip/zstd, not ZIP or XML. |
+| `partial-json` | Keep (single call site for streaming tool-arg JSON; inline later if we want). |
+| `posthog-node`, `@sentry/bun` | Correctly runtime-split today (`loadSdk` injection; Electron injects `@sentry/electron/*`). Hygiene item: split config-only exports out of `telemetry/productAnalytics.ts` so preload bundles can't pick up `posthog-node`. |
+
+## Phased plan
+
+Each phase is one or more PR-sized slices. Every slice: full `bun test` (`test:stable --max-concurrency 1` lane), `bun run typecheck`, `bun run check`, `bun run docs:check`; behavior-parity tests land **with** the migration, not after.
+
+### Phase 0 — Guardrail (small, do first)
+
+Add a boundary check (test or lint script) that fails if any file in the Electron-main or renderer shared lists above imports `bun:*` or references `Bun.` — freezing today's clean state before we add more Bun-only code. Keep the lists in one checked-in manifest the test reads.
+
+### Phase 1 — Mechanical, zero-risk slices
+
+1. `randomUUID`/`randomBytes` → global Web Crypto (all 7 files, incl. Electron-shared ones — globals are runtime-portable).
+2. `Bun.spawn` in Bun-only scripts: `scripts/postinstall.ts`, `scripts/open_xcode_workspace.ts`, `packages/harness/run_tests_stable.ts`.
+3. `Bun.Glob` in `run_tests_stable.ts` + `test/package-manifest.test.ts`.
+4. `Bun.file`/`Bun.write` in `scripts/` and `packages/harness/` file I/O.
+
+### Phase 2 — OAuth callback listener → `Bun.serve`
+
+Port `src/mcp/oauthProvider.ts` `createCallbackCapture` to `Bun.serve` (`hostname`, `port: 0`, fetch handler). Bind both loopbacks per the OAuth rule (or record the IdP-compat exception). Update `test/mcp.oauth-provider.test.ts` to cover the advertised redirect URI and both binds.
+
+### Phase 3 — `execFileCompat` + process migration
+
+1. Build `src/utils/execFileCompat.ts` on `Bun.spawn` replicating the Node `execFile` contract (maxBuffer, timeout→SIGTERM, AbortSignal, windowsHide, env replacement, exit/signal mapping) with a dedicated parity test file.
+2. Convert buffered consumers: `ripgrep.ts`, `grep.ts`, `coworkRuntime/runtime.ts`, then `bash.ts` last (its tests must pin exit 124/130 and the truncation/stderr messages).
+3. Convert streaming consumers with a small line-reader helper: `sessionBackup/command.ts`, `libreOffice.ts` (add output cap), `webDesktopService.ts`.
+4. `utils/browser.ts` — verify detached/unref parity on macOS/Linux/Windows before swapping.
+
+### Phase 4 — Filesystem hot paths
+
+`Bun.file`/`Bun.write` in `tools/edit.ts`, `tools/read.ts` (image branch), skills/prompt loaders, `config.ts`, session/memory/auth JSON stores (except Electron-shared `store/connections.ts`), `toolOutputOverflow.ts`. Atomic-write, streaming, watch, and chmod paths are explicitly untouched.
+
+### Phase 5 — Long-lived subprocess abstraction (largest slice)
+
+Define a `HarnessSubprocess` interface (spawn, write stdin, async line iteration, kill(SIGTERM→SIGKILL), `exited`) and migrate `codexAppServerResolver.ts` + `codexAppServerClient.ts` together onto a `Bun.spawn` implementation. This also retires their `node:readline` pipe parsing.
+
+### Phase 6 — Cleanup & opportunistic
+
+- Split Node-safe exports (`findWindowsHelper`, `findBwrap`) out of `platform/sandbox/detect.ts` so the Bun-only probe code can migrate; or leave the whole file on `node:` (valid endstate).
+- `Bun.CryptoHasher` sha256 helpers across Bun-only fingerprint/checksum sites.
+- Drop `ws` from the one test; evaluate dropping it from desktop via a Bun-subprocess smoke.
+- Evaluate `Bun.Glob` for `src/tools/glob.ts` behind its existing tool tests.
+- Async-ify `workspace/map.ts`; telemetry config/SDK split.
+
+## Keep-on-Node register (deliberate, with reasons)
+
+| What | Why |
+| --- | --- |
+| `node:fs` mkdir/readdir/stat/rm/rename/chmod/watch/symlink/realpath | no Bun-native equivalent; native-speed in Bun |
+| Atomic write paths (`utils/atomicFile.ts` et al.) | tmp+rename semantics incl. Windows retries |
+| `tools/webFetch.ts`, runtime download/archive, backups | streaming + byte caps via fs handles/streams |
+| `utils/paths.ts` `realpathSync.native` | security boundary, Electron-shared |
+| `coworkRuntime/integrity.ts` Ed25519 verify | signed-runtime trust boundary |
+| `utils/webSafety.ts` DNS + `isIP` | SSRF gate; injectable for tests |
+| CLI REPL `node:readline` | TTY UX, history, secret masking |
+| `yauzl`/`jszip`/`fast-xml-parser`/`proxy-agent` | no Bun ZIP/XML/agent equivalents |
+| Everything in the Electron/renderer shared lists | runs under Node/Chromium |

--- a/packages/harness/src/run_tests_stable.ts
+++ b/packages/harness/src/run_tests_stable.ts
@@ -1,6 +1,4 @@
-import { spawn } from "node:child_process";
 import path from "node:path";
-import fg from "fast-glob";
 
 const REPO_ROOT = path.resolve(import.meta.dir, "..", "..", "..");
 const DEFAULT_BATCH_SIZE = 1;
@@ -50,28 +48,30 @@ function parseCli(argv: string[]): { batchSize: number; bunTestArgs: string[] } 
 }
 
 async function runBun(args: string[]): Promise<number> {
-  return await new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, args, {
-      cwd: REPO_ROOT,
-      env: process.env,
-      stdio: "inherit",
-    });
-    child.on("error", reject);
-    child.on("close", (code) => resolve(code ?? 1));
+  const proc = Bun.spawn([process.execPath, ...args], {
+    cwd: REPO_ROOT,
+    env: process.env,
+    stdout: "inherit",
+    stderr: "inherit",
   });
+  return await proc.exited;
+}
+
+async function collectTestFiles(): Promise<string[]> {
+  const unique = new Set<string>();
+  for (const pattern of TEST_FILE_PATTERNS) {
+    const glob = new Bun.Glob(pattern);
+    for await (const file of glob.scan({ cwd: REPO_ROOT, followSymlinks: false })) {
+      unique.add(file);
+    }
+  }
+  return [...unique].sort((a, b) => a.localeCompare(b));
 }
 
 async function main() {
   const startedAt = Date.now();
   const { batchSize, bunTestArgs } = parseCli(process.argv.slice(2));
-  const testFiles = (
-    await fg(TEST_FILE_PATTERNS, {
-      cwd: REPO_ROOT,
-      onlyFiles: true,
-      unique: true,
-      followSymbolicLinks: false,
-    })
-  ).sort((a, b) => a.localeCompare(b));
+  const testFiles = await collectTestFiles();
 
   if (testFiles.length === 0) {
     console.error("[test:stable] No test files were found.");

--- a/scripts/open_xcode_workspace.ts
+++ b/scripts/open_xcode_workspace.ts
@@ -1,5 +1,4 @@
 #!/usr/bin/env bun
-import { spawn } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -11,16 +10,12 @@ if (process.platform !== "darwin") {
   process.exit(1);
 }
 
-const child = spawn("open", [workspacePath], { stdio: "inherit" });
-child.on("error", (error) => {
-  console.error(`Failed to open Xcode workspace: ${error.message}`);
+try {
+  const proc = Bun.spawn(["open", workspacePath], { stdout: "inherit", stderr: "inherit" });
+  process.exit(await proc.exited);
+} catch (error) {
+  console.error(
+    `Failed to open Xcode workspace: ${error instanceof Error ? error.message : String(error)}`,
+  );
   process.exit(1);
-});
-
-child.on("exit", (code, signal) => {
-  if (signal) {
-    console.error(`open was terminated by ${signal}`);
-    process.exit(1);
-  }
-  process.exit(code ?? 0);
-});
+}

--- a/scripts/postinstall.ts
+++ b/scripts/postinstall.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env bun
 
-import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 
 const APP_DIRS = ["apps/desktop"] as const;
@@ -10,23 +9,17 @@ if (process.env.CI || process.env.SKIP_POSTINSTALL) {
   process.exit(0);
 }
 
-function runBunInstall(args: string[]): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const child = spawn("bun", args, {
-      cwd: process.cwd(),
-      env: process.env,
-      stdio: "inherit",
-    });
-
-    child.on("error", reject);
-    child.on("exit", (code) => {
-      if (code === 0) {
-        resolve();
-        return;
-      }
-      reject(new Error(`bun ${args.join(" ")} exited with code ${code ?? "unknown"}`));
-    });
+async function runBunInstall(args: string[]): Promise<void> {
+  const proc = Bun.spawn(["bun", ...args], {
+    cwd: process.cwd(),
+    env: process.env,
+    stdout: "inherit",
+    stderr: "inherit",
   });
+  const code = await proc.exited;
+  if (code !== 0) {
+    throw new Error(`bun ${args.join(" ")} exited with code ${code}`);
+  }
 }
 
 for (const dir of APP_DIRS) {

--- a/src/cli/repl/stateStore.ts
+++ b/src/cli/repl/stateStore.ts
@@ -35,7 +35,7 @@ function getCliStateFilePath(): string {
 async function readCliState(): Promise<CliState> {
   const filePath = getCliStateFilePath();
   try {
-    const raw = await fs.readFile(filePath, "utf-8");
+    const raw = await Bun.file(filePath).text();
     let parsedRaw: unknown;
     try {
       parsedRaw = JSON.parse(raw);

--- a/src/config.ts
+++ b/src/config.ts
@@ -230,7 +230,7 @@ async function resolveConfiguredModelMetadata(
 
 async function loadJsonSafe(filePath: string): Promise<Record<string, unknown>> {
   try {
-    const raw = await fs.readFile(filePath, "utf-8");
+    const raw = await Bun.file(filePath).text();
     let parsed: unknown;
     try {
       parsed = JSON.parse(raw);

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,4 @@
 import fsSync from "node:fs";
-import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,8 +9,10 @@ import { getAiCoworkerPaths } from "./connect";
 import { isOpenAiNativeConnectorsExperimentEnabled } from "./experimental/openaiNativeConnectors/flags";
 import { normalizeChildRoutingConfig } from "./models/childModelRouting";
 import {
+  getDiscoveredModelMetadata,
   getResolvedModelMetadataSync,
   isDynamicModelProvider,
+  isRuntimeDiscoveryProvider,
   normalizeModelIdForProvider,
   resolveDefaultModelMetadata,
   resolveModelMetadata,
@@ -187,7 +189,7 @@ async function resolveConfiguredModelMetadata(
   env: Record<string, string | undefined>,
   home?: string,
 ) {
-  if (isDynamicModelProvider(provider)) {
+  if (isRuntimeDiscoveryProvider(provider)) {
     return await resolveModelMetadata(provider, modelId, {
       allowPlaceholder: true,
       providerOptions,
@@ -196,6 +198,21 @@ async function resolveConfiguredModelMetadata(
       source,
       log: (line) => console.warn(`[config] ${line}`),
     });
+  }
+  if (isDynamicModelProvider(provider)) {
+    try {
+      // Strict resolution: static registry plus the provider's discovery cache.
+      // Anything else falls through to the resilience fallback below.
+      return await resolveModelMetadata(provider, modelId, {
+        providerOptions,
+        env,
+        home,
+        source,
+        log: (line) => console.warn(`[config] ${line}`),
+      });
+    } catch {
+      // fall through to the provider-default fallback
+    }
   }
   const supported = getSupportedModel(provider, modelId);
   if (supported) return supported;
@@ -525,6 +542,32 @@ export async function loadConfig(options: LoadConfigOptions = {}): Promise<Agent
     });
   } catch (error) {
     console.warn(`[config] Ignoring invalid child model routing config: ${String(error)}`);
+  }
+  if (
+    isDynamicModelProvider(provider) &&
+    !isRuntimeDiscoveryProvider(provider) &&
+    normalizedChildRouting.preferredChildModel !== supportedModel.id &&
+    !getSupportedModel(provider, normalizedChildRouting.preferredChildModel)
+  ) {
+    // Same strictness as the main model: unknown preferred child ids are only
+    // kept when they were previously discovered from the provider.
+    const discovered = await getDiscoveredModelMetadata(
+      provider,
+      normalizedChildRouting.preferredChildModel,
+      homedir ? { home: homedir } : {},
+    );
+    if (!discovered) {
+      console.warn(
+        `[config] Ignoring unsupported preferred child model "${normalizedChildRouting.preferredChildModel}" for provider ${provider}; using "${supportedModel.id}".`,
+      );
+      normalizedChildRouting = {
+        ...normalizedChildRouting,
+        preferredChildModel: supportedModel.id,
+        ...(normalizedChildRouting.childModelRoutingMode === "same-provider"
+          ? { preferredChildModelRef: `${provider}:${supportedModel.id}` }
+          : {}),
+      };
+    }
   }
 
   const parsedToolOutputOverflowChars = normalizeNullableNonNegativeInt(

--- a/src/coworkRuntime/bootstrapLock.ts
+++ b/src/coworkRuntime/bootstrapLock.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 
@@ -84,7 +83,7 @@ export async function withCoworkRuntimeBootstrapLock<T>(
       await new Promise((resolve) => setTimeout(resolve, ms));
     });
   const processAlive = opts.processAlive ?? defaultProcessAlive;
-  const token = randomUUID();
+  const token = crypto.randomUUID();
   const acquireStartedAt = now();
   let reportedWait = false;
 

--- a/src/coworkRuntime/install.ts
+++ b/src/coworkRuntime/install.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -24,7 +23,7 @@ export function installedRuntimeDir(version: string, home = os.homedir()): strin
 
 async function writeCurrentPointer(root: string, pointer: InstalledRuntimePointer): Promise<void> {
   const destination = path.join(root, CURRENT_RUNTIME_FILE);
-  const temporary = `${destination}.tmp-${randomUUID()}`;
+  const temporary = `${destination}.tmp-${crypto.randomUUID()}`;
   await fs.writeFile(temporary, `${JSON.stringify(pointer, null, 2)}\n`, "utf8");
   await fs.rm(destination, { force: true });
   await fs.rename(temporary, destination);
@@ -140,7 +139,7 @@ export async function installRuntimeArchive(opts: {
   const home = path.resolve(opts.home ?? os.homedir());
   const root = coworkRuntimeRoot(home);
   await fs.mkdir(root, { recursive: true });
-  const staging = path.join(root, `.staging-${randomUUID()}`);
+  const staging = path.join(root, `.staging-${crypto.randomUUID()}`);
   opts.log?.(`Extracting ${archivePath} into ${staging}`);
   await extractRuntimeArchive({ archivePath, destinationDir: staging });
 
@@ -176,7 +175,7 @@ export async function installRuntimeArchive(opts: {
       throw new Error(`Runtime ${manifest.version} is already installed at ${destination}.`);
     }
     if (existing) {
-      backup = `${destination}.replaced-${randomUUID()}`;
+      backup = `${destination}.replaced-${crypto.randomUUID()}`;
       releaseRuntimeTrust(destination);
       await fs.rename(destination, backup);
     }

--- a/src/coworkRuntime/libreOffice.ts
+++ b/src/coworkRuntime/libreOffice.ts
@@ -1,4 +1,3 @@
-import { spawn } from "node:child_process";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -32,6 +31,9 @@ type ProcessRunner = (
   },
 ) => Promise<ProcessCapture>;
 
+/** Cap accumulated output so a chatty soffice run cannot grow without bound. */
+const MAX_CAPTURE_BYTES = 4 * 1024 * 1024;
+
 async function runProcessCapture(
   command: string,
   args: string[],
@@ -40,40 +42,46 @@ async function runProcessCapture(
     timeoutMs: number;
   },
 ): Promise<ProcessCapture> {
-  return await new Promise<ProcessCapture>((resolve, reject) => {
-    const child = spawn(command, args, {
-      env: opts.env,
-      stdio: ["ignore", "pipe", "pipe"],
-      windowsHide: true,
-    });
-    let stdout = "";
-    let stderr = "";
-    let settled = false;
-    const timer = setTimeout(() => {
-      if (settled) return;
-      settled = true;
-      child.kill("SIGKILL");
+  const proc = Bun.spawn([command, ...args], {
+    env: opts.env,
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+    windowsHide: true,
+  });
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      try {
+        proc.kill("SIGKILL");
+      } catch {
+        // already exited
+      }
       reject(new Error(`${command} timed out after ${opts.timeoutMs}ms`));
     }, opts.timeoutMs);
-    child.stdout.on("data", (chunk) => {
-      stdout += Buffer.from(chunk).toString("utf8");
-    });
-    child.stderr.on("data", (chunk) => {
-      stderr += Buffer.from(chunk).toString("utf8");
-    });
-    child.once("error", (error) => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      reject(error);
-    });
-    child.once("exit", (exitCode) => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      resolve({ exitCode, stdout, stderr });
-    });
   });
+
+  const readCapped = async (stream: ReadableStream<Uint8Array>): Promise<string> => {
+    const decoder = new TextDecoder();
+    let text = "";
+    for await (const chunk of stream) {
+      if (text.length < MAX_CAPTURE_BYTES) {
+        text += decoder.decode(chunk, { stream: true });
+      }
+    }
+    return text.slice(0, MAX_CAPTURE_BYTES);
+  };
+
+  try {
+    const [stdout, stderr, exitCode] = await Promise.race([
+      Promise.all([readCapped(proc.stdout), readCapped(proc.stderr), proc.exited]),
+      timeoutPromise,
+    ]);
+    return { exitCode, stdout, stderr };
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 function envValue(env: Record<string, string | undefined>, name: string): string | undefined {

--- a/src/coworkRuntime/runtime.ts
+++ b/src/coworkRuntime/runtime.ts
@@ -1,9 +1,9 @@
-import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { promisify } from "node:util";
+
+import { execFileCompat } from "../utils/execFileCompat";
 import {
   primeVerifiedRuntimeTrust,
   RUNTIME_INTEGRITY_MANIFEST_FILE,
@@ -16,8 +16,6 @@ import { RUNTIME_MANIFEST_FILE, readRuntimeManifest } from "./manifest";
 import { assertHostCompatible } from "./platform";
 import { TRUSTED_COWORK_RUNTIME_KEYS } from "./trustedKeys";
 import type { CoworkRuntimeManifest, RuntimeHost, RuntimeVerification } from "./types";
-
-const execFileAsync = promisify(execFile);
 
 export function resolveManifestPath(runtimeDir: string, relativePath: string): string {
   return path.join(runtimeDir, ...relativePath.split("/"));
@@ -158,18 +156,35 @@ async function payloadStats(
   return { fileCount, unpackedBytes };
 }
 
+async function runVerificationCommand(
+  executable: string,
+  args: string[],
+  opts: { env: Record<string, string>; cwd?: string; timeoutMs: number },
+): Promise<{ stdout: string; stderr: string }> {
+  const result = await execFileCompat(executable, args, {
+    env: opts.env,
+    ...(opts.cwd ? { cwd: opts.cwd } : {}),
+    timeoutMs: opts.timeoutMs,
+    maxBuffer: 4 * 1024 * 1024,
+  });
+  if (result.exitCode !== 0 || result.errorCode) {
+    throw new Error(
+      `${executable} ${args.join(" ")} failed (${result.errorCode ?? `exit ${result.exitCode}`}): ${result.stderr.trim() || result.stdout.trim()}`,
+    );
+  }
+  return { stdout: result.stdout, stderr: result.stderr };
+}
+
 async function commandVersion(
   executable: string,
   args: string[],
   env: Record<string, string>,
   cwd?: string,
 ): Promise<string> {
-  const result = await execFileAsync(executable, args, {
+  const result = await runVerificationCommand(executable, args, {
     env,
-    cwd,
-    windowsHide: true,
-    timeout: 120_000,
-    maxBuffer: 4 * 1024 * 1024,
+    ...(cwd ? { cwd } : {}),
+    timeoutMs: 120_000,
   });
   return `${result.stdout || result.stderr}`.trim().split(/\r?\n/)[0] ?? "ok";
 }
@@ -187,12 +202,10 @@ async function verifySofficeConversion(
       "<!doctype html><title>Cowork Runtime</title><p>Managed headless LibreOffice smoke test.</p>\n",
       "utf8",
     );
-    await execFileAsync(executable, ["--convert-to", "pdf", "--outdir", tempDir, input], {
+    await runVerificationCommand(executable, ["--convert-to", "pdf", "--outdir", tempDir, input], {
       env,
       cwd: tempDir,
-      windowsHide: true,
-      timeout: 180_000,
-      maxBuffer: 4 * 1024 * 1024,
+      timeoutMs: 180_000,
     });
     const stat = await fs.stat(output).catch(() => null);
     if (!stat?.isFile() || stat.size === 0) {

--- a/src/mcp/authStore/store.ts
+++ b/src/mcp/authStore/store.ts
@@ -56,7 +56,7 @@ async function readDoc(filePath: string): Promise<MCPServerCredentialsDocument> 
   });
 
   try {
-    const raw = await fs.readFile(filePath, "utf-8");
+    const raw = await Bun.file(filePath).text();
     let parsedJson: unknown;
     try {
       parsedJson = JSON.parse(raw);

--- a/src/mcp/oauthProvider.ts
+++ b/src/mcp/oauthProvider.ts
@@ -1,6 +1,3 @@
-import { randomBytes, randomUUID } from "node:crypto";
-import { createServer } from "node:http";
-
 import {
   discoverAuthorizationServerMetadata,
   discoverOAuthProtectedResourceMetadata,
@@ -59,7 +56,7 @@ type CallbackCapture = {
   state: string;
   redirectUri: string;
   expiresAt: string;
-  server: ReturnType<typeof createServer>;
+  servers: Array<ReturnType<typeof Bun.serve>>;
   code?: string;
   closed: boolean;
 };
@@ -70,12 +67,16 @@ function addMinutesIso(minutes: number): string {
   return new Date(Date.now() + minutes * 60_000).toISOString();
 }
 
-function toBase64Url(value: Buffer): string {
-  return value.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+function toBase64Url(value: Uint8Array): string {
+  return Buffer.from(value)
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
 }
 
 function generateOpaqueValue(bytes: number): string {
-  return toBase64Url(randomBytes(bytes));
+  return toBase64Url(crypto.getRandomValues(new Uint8Array(bytes)));
 }
 
 function isHttpLikeServer(server: MCPRegistryServer): server is MCPRegistryServer & {
@@ -97,10 +98,13 @@ function closeCapture(capture: CallbackCapture, opts: { keepEntry?: boolean } = 
   }
   if (capture.closed) return;
   capture.closed = true;
-  try {
-    capture.server.close();
-  } catch {
-    // best effort
+  for (const server of capture.servers) {
+    try {
+      // Graceful stop: in-flight callback responses still complete.
+      server.stop();
+    } catch {
+      // best effort
+    }
   }
 }
 
@@ -109,64 +113,61 @@ async function createCallbackCapture(
   state: string,
   expiresAt: string,
 ): Promise<CallbackCapture> {
-  const server = createServer((req, res) => {
-    const requestUrl = new URL(req.url ?? "/", "http://127.0.0.1");
+  const handleRequest = (req: Request): Response => {
+    const requestUrl = new URL(req.url);
     if (requestUrl.pathname !== "/oauth/callback") {
-      res.statusCode = 404;
-      res.end("Not found");
-      return;
+      return new Response("Not found", { status: 404 });
     }
 
     const capture = callbackCaptures.get(challengeId);
     if (!capture) {
-      res.statusCode = 410;
-      res.end("Authorization flow expired");
-      return;
+      return new Response("Authorization flow expired", { status: 410 });
     }
 
     const incomingState = requestUrl.searchParams.get("state") ?? "";
     const code = requestUrl.searchParams.get("code") ?? "";
     if (!incomingState || incomingState !== capture.state) {
-      res.statusCode = 400;
-      res.end("Invalid OAuth state");
-      return;
+      return new Response("Invalid OAuth state", { status: 400 });
     }
     if (!code) {
-      res.statusCode = 400;
-      res.end("Missing OAuth code");
-      return;
+      return new Response("Missing OAuth code", { status: 400 });
     }
 
     capture.code = code;
-    res.statusCode = 200;
-    res.setHeader("content-type", "text/html; charset=utf-8");
-    res.end(
-      "<html><body><h1>Authorization complete</h1><p>You can close this window.</p></body></html>",
-    );
     closeCapture(capture, { keepEntry: true });
-  });
+    return new Response(
+      "<html><body><h1>Authorization complete</h1><p>You can close this window.</p></body></html>",
+      { status: 200, headers: { "content-type": "text/html; charset=utf-8" } },
+    );
+  };
 
-  await new Promise<void>((resolve, reject) => {
-    server.once("error", reject);
-    server.listen(0, "127.0.0.1", () => resolve());
-  });
-
-  const address = server.address();
-  if (!address || typeof address === "string") {
-    try {
-      server.close();
-    } catch {
-      // ignore
-    }
-    throw new Error("Failed to allocate OAuth callback listener.");
+  const servers: Array<ReturnType<typeof Bun.serve>> = [];
+  let port: number;
+  try {
+    const ipv4 = Bun.serve({ hostname: "127.0.0.1", port: 0, fetch: handleRequest });
+    servers.push(ipv4);
+    port = ipv4.port;
+  } catch (error) {
+    throw new Error(
+      `Failed to allocate OAuth callback listener: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  // Bind IPv6 loopback on the same port too: some browsers resolve loopback
+  // redirects to ::1 first. The advertised redirect URI stays pinned to
+  // 127.0.0.1 (the host registered with the IdP). Best effort — IPv6 loopback
+  // may be unavailable on this machine.
+  try {
+    servers.push(Bun.serve({ hostname: "::1", port, fetch: handleRequest }));
+  } catch {
+    // IPv4-only environments keep working with the single listener.
   }
 
   const capture: CallbackCapture = {
     challengeId,
     state,
-    redirectUri: `http://127.0.0.1:${address.port}/oauth/callback`,
+    redirectUri: `http://127.0.0.1:${port}/oauth/callback`,
     expiresAt,
-    server,
+    servers,
     closed: false,
   };
   callbackCaptures.set(challengeId, capture);
@@ -344,7 +345,7 @@ export async function authorizeMCPServerOAuth(
   const createdAt = nowIso();
   const expiresAt = addMinutesIso(10);
   const state = generateOpaqueValue(24);
-  const challengeId = randomUUID();
+  const challengeId = crypto.randomUUID();
 
   // 1. Set up redirect URI (callback server or OOB).
   let redirectUri = "urn:ietf:wg:oauth:2.0:oob";

--- a/src/mcp/oauthProvider.ts
+++ b/src/mcp/oauthProvider.ts
@@ -146,8 +146,18 @@ async function createCallbackCapture(
   try {
     const ipv4 = Bun.serve({ hostname: "127.0.0.1", port: 0, fetch: handleRequest });
     servers.push(ipv4);
+    if (typeof ipv4.port !== "number") {
+      throw new Error("listener did not report a TCP port");
+    }
     port = ipv4.port;
   } catch (error) {
+    for (const server of servers) {
+      try {
+        server.stop();
+      } catch {
+        // best effort
+      }
+    }
     throw new Error(
       `Failed to allocate OAuth callback listener: ${error instanceof Error ? error.message : String(error)}`,
     );

--- a/src/memoryStore.ts
+++ b/src/memoryStore.ts
@@ -73,7 +73,7 @@ function nowIso(): string {
 
 async function readTextIfExists(filePath: string): Promise<string | null> {
   try {
-    return await fs.readFile(filePath, "utf-8");
+    return await Bun.file(filePath).text();
   } catch {
     return null;
   }

--- a/src/models/metadata.ts
+++ b/src/models/metadata.ts
@@ -9,9 +9,16 @@ import {
   resolveDefaultLmStudioModelMetadata,
   resolveLmStudioDiscoveredModelMetadata,
 } from "../providers/lmstudio/catalog";
+import { readModelDiscoveryCache } from "../providers/modelDiscoveryCache";
+import { getAiCoworkerPaths } from "../store/connections";
 import type { ProviderName } from "../types";
 import type { ResolvedModelMetadata } from "./metadataTypes";
-import { assertSupportedModel, defaultSupportedModel, getSupportedModel } from "./registry";
+import {
+  assertSupportedModel,
+  defaultSupportedModel,
+  getSupportedModel,
+  isModelIdForeignToProvider,
+} from "./registry";
 
 type DynamicModelProvider =
   | "lmstudio"
@@ -83,6 +90,16 @@ export function isDynamicModelProvider(provider: ProviderName): provider is Dyna
   );
 }
 
+/**
+ * Providers whose model catalogs are resolved entirely at runtime (local
+ * discovery or an external tool), so unknown model ids are always passthrough.
+ */
+export function isRuntimeDiscoveryProvider(
+  provider: ProviderName,
+): provider is "lmstudio" | "bedrock" | "codex-cli" {
+  return provider === "lmstudio" || provider === "bedrock" || provider === "codex-cli";
+}
+
 export function normalizeModelIdForProvider(
   provider: ProviderName,
   modelId: string,
@@ -96,7 +113,14 @@ export function normalizeModelIdForProvider(
     return trimmed;
   }
   if (isDynamicModelProvider(provider)) {
-    return getSupportedModel(provider, trimmed)?.id ?? trimmed;
+    const supported = getSupportedModel(provider, trimmed);
+    if (supported) return supported.id;
+    // Unknown ids pass through for dynamic model discovery, but ids that
+    // provably belong to a different provider are rejected with guidance.
+    if (isModelIdForeignToProvider(provider, trimmed)) {
+      return assertSupportedModel(provider, trimmed, source).id;
+    }
+    return trimmed;
   }
   return assertSupportedModel(provider, trimmed, source).id;
 }
@@ -157,6 +181,28 @@ export function getResolvedModelMetadataSync(
   return toResolvedStaticModel(provider, modelId, source);
 }
 
+/**
+ * Placeholder metadata for a model previously discovered from the provider's
+ * live catalog (persisted under `~/.cowork/cache/models/<provider>.json`).
+ * Returns null when the id is not present in the discovery cache.
+ */
+export async function getDiscoveredModelMetadata(
+  provider: Exclude<DynamicModelProvider, "lmstudio" | "bedrock">,
+  modelId: string,
+  opts: { home?: string } = {},
+): Promise<ResolvedModelMetadata | null> {
+  try {
+    const paths = getAiCoworkerPaths(opts.home ? { homedir: opts.home } : {});
+    const cached = await readModelDiscoveryCache(paths, provider);
+    if (!cached) return null;
+    const match = cached.models.find((model) => model.id === modelId || model.model === modelId);
+    if (!match) return null;
+    return buildProviderPlaceholderMetadata(provider, modelId);
+  } catch {
+    return null;
+  }
+}
+
 export async function resolveModelMetadata(
   provider: ProviderName,
   modelId: string,
@@ -175,6 +221,21 @@ export async function resolveModelMetadata(
   }
 
   if (provider !== "lmstudio" && provider !== "bedrock") {
+    const trimmed = modelId.trim();
+    if (
+      trimmed &&
+      isDynamicModelProvider(provider) &&
+      !opts.allowPlaceholder &&
+      !getSupportedModel(provider, trimmed)
+    ) {
+      // Strict resolution (model selection paths): unknown ids are only
+      // accepted when they were previously discovered from the provider.
+      const discovered = await getDiscoveredModelMetadata(provider, trimmed, {
+        ...(opts.home ? { home: opts.home } : {}),
+      });
+      if (discovered) return discovered;
+      return toResolvedStaticModel(provider, trimmed, opts.source);
+    }
     return getResolvedModelMetadataSync(provider, modelId, opts.source);
   }
 

--- a/src/models/registry.ts
+++ b/src/models/registry.ts
@@ -329,12 +329,13 @@ const LEGACY_MODEL_ALIASES: Record<string, string> = {
   "antigravity:gemini-3.1-pro": "antigravity:gemini-3.1-pro-preview",
 };
 
-type LikelyModelProvider = "openai" | "anthropic";
+type LikelyModelProvider = "openai" | "anthropic" | "google";
 
 function inferLikelyProviderForModelId(modelId: string): LikelyModelProvider | null {
   const normalized = modelId.trim().toLowerCase();
   if (!normalized) return null;
   if (normalized.startsWith("claude-")) return "anthropic";
+  if (normalized.startsWith("gemini-")) return "google";
   if (
     normalized.startsWith("gpt-5") ||
     normalized.startsWith("gpt-4o") ||
@@ -353,6 +354,9 @@ function providerMatchesLikelyModelProvider(
   if (expectedProvider === "openai") {
     return provider === "openai" || provider === "codex-cli";
   }
+  if (expectedProvider === "google") {
+    return provider === "google" || provider === "antigravity";
+  }
   return provider === expectedProvider;
 }
 
@@ -366,6 +370,9 @@ export function describeModelProviderMismatch(
   }
   if (expectedProvider === "openai") {
     return `"${modelId}" looks like an OpenAI model; use provider openai instead (Responses API).`;
+  }
+  if (expectedProvider === "google") {
+    return `"${modelId}" looks like a Google model; use provider google instead.`;
   }
   return `"${modelId}" looks like an Anthropic model; use provider anthropic instead.`;
 }
@@ -418,6 +425,25 @@ export function providerOptionsDefaultsForModel(
   modelId: string,
 ): Record<string, unknown> {
   return { ...(getSupportedModel(provider, modelId)?.providerOptionsDefaults ?? {}) };
+}
+
+/**
+ * True when `modelId` provably belongs to a different provider: it is not
+ * registered for `provider`, does not look like a model from `provider`'s
+ * family, and is registered for at least one other static provider.
+ *
+ * Unknown-everywhere ids are NOT foreign — dynamic model discovery allows
+ * providers to expose models outside the static registry.
+ */
+export function isModelIdForeignToProvider(provider: ProviderName, modelId: string): boolean {
+  if (getSupportedModel(provider, modelId)) return false;
+  const likelyProvider = inferLikelyProviderForModelId(modelId);
+  if (likelyProvider && providerMatchesLikelyModelProvider(provider, likelyProvider)) {
+    return false;
+  }
+  return STATIC_MODEL_PROVIDER_NAMES.some(
+    (candidate) => candidate !== provider && getSupportedModel(candidate, modelId) !== null,
+  );
 }
 
 export function assertSupportedModel(

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -115,7 +115,7 @@ function normalizePromptTemplateNewlines(value: string): string {
  */
 async function loadPromptTemplate(templatePath: string): Promise<string> {
   const resolvedTemplatePath = path.resolve(templatePath);
-  return normalizePromptTemplateNewlines(await fs.readFile(resolvedTemplatePath, "utf-8"));
+  return normalizePromptTemplateNewlines(await Bun.file(resolvedTemplatePath).text());
 }
 
 function stripPromptLine(prompt: string, matcher: RegExp): string {
@@ -565,7 +565,7 @@ async function _loadHotCache(config: AgentConfig): Promise<string> {
 
   for (const p of candidates) {
     try {
-      return await fs.readFile(p, "utf-8");
+      return await Bun.file(p).text();
     } catch {
       // ignore
     }
@@ -740,8 +740,8 @@ export async function loadAgentPrompt(
     AGENT_ROLE_DEFINITIONS[role].promptFile,
   );
   const [basePrompt, rolePrompt] = await Promise.all([
-    fs.readFile(basePath, "utf-8"),
-    fs.readFile(rolePath, "utf-8"),
+    Bun.file(basePath).text(),
+    Bun.file(rolePath).text(),
   ]);
   const profilePrompt = profile?.prompt.trim();
   const effectiveRolePrompt = profilePrompt || rolePrompt.trim();

--- a/src/providers/catalog.ts
+++ b/src/providers/catalog.ts
@@ -4,14 +4,14 @@ import {
   listSupportedModelIds,
 } from "../models/registry";
 import {
-  OPENAI_REASONING_EFFORT_VALUES,
-  type CatalogReasoningEffort,
-  isOpenAiReasoningEffort,
-} from "../shared/openaiCompatibleOptions";
-import {
   GOOGLE_DYNAMIC_REASONING_EFFORT,
   listGoogleReasoningEffortValuesForModel,
 } from "../shared/googleThinking";
+import {
+  type CatalogReasoningEffort,
+  isOpenAiReasoningEffort,
+  OPENAI_REASONING_EFFORT_VALUES,
+} from "../shared/openaiCompatibleOptions";
 import type { ProviderName } from "../types";
 
 type ProviderModelDefinition = {

--- a/src/providers/codexAppServerClient.ts
+++ b/src/providers/codexAppServerClient.ts
@@ -1,10 +1,9 @@
-import type { ChildProcessWithoutNullStreams } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
-import readline from "node:readline";
 
 import { asRecord, asString } from "../shared/recordParsing";
 import { resolveAuthHomeDir } from "../utils/authHome";
+import { type StreamingSubprocess, subscribeLines } from "../utils/subprocess";
 import { VERSION } from "../version";
 import {
   type CodexAppServerCommand,
@@ -117,10 +116,17 @@ export async function startCodexAppServerClient(
   const codexHome = opts.codexHome ?? resolveCodexHome();
   await fs.mkdir(codexHome, { recursive: true, mode: 0o700 });
   const baseEnv = opts.env ?? process.env;
-  const child = spawnCodexAppServer(command, {
-    cwd: opts.cwd,
-    env: { ...baseEnv, CODEX_HOME: codexHome },
-  });
+  let child: StreamingSubprocess;
+  try {
+    child = spawnCodexAppServer(command, {
+      cwd: opts.cwd,
+      env: { ...baseEnv, CODEX_HOME: codexHome },
+    });
+  } catch (error) {
+    throw new Error(
+      `Failed to start codex app-server: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
   const pending = new Map<number | string, PendingRequest>();
   const listeners = new Set<(notification: CodexAppServerJsonRpcNotification) => void>();
   const serverRequestHandlers = new Set<CodexAppServerRequestHandler>();
@@ -144,14 +150,9 @@ export async function startCodexAppServerClient(
     pending.clear();
   };
 
-  child.once("error", (error) => {
-    rejectAll(new Error(`Failed to start codex app-server: ${error.message}`));
-    for (const listener of errorListeners) listener(error);
-  });
-  child.stdin.on("error", (error) => {
-    opts.log?.(`[codex-app-server:stdin:error] ${error.message}`);
-  });
-  child.once("exit", (code, signal) => {
+  void child.exited.then(({ exitCode, signalCode }) => {
+    const code = exitCode;
+    const signal = (signalCode ?? null) as NodeJS.Signals | null;
     closed = true;
     lastCloseInfo = {
       code,
@@ -172,15 +173,14 @@ export async function startCodexAppServerClient(
     }
     for (const listener of closeListeners) listener(code, signal);
   });
-  child.stderr.on("data", (chunk) => {
-    const text = String(chunk);
-    stderrBytes += Buffer.byteLength(text);
-    const trimmed = text.trim();
+  const stderrSubscription = subscribeLines(child.stderr, (line) => {
+    stderrBytes += Buffer.byteLength(`${line}\n`);
+    const trimmed = line.trim();
     if (trimmed) opts.log?.(`[codex-app-server:stderr] ${trimmed}`);
   });
+  void stderrSubscription.done;
 
-  const rl = readline.createInterface({ input: child.stdout });
-  rl.on("line", (line) => {
+  const stdoutSubscription = subscribeLines(child.stdout, (line) => {
     if (!line.trim()) return;
     let parsed: unknown;
     try {
@@ -233,9 +233,16 @@ export async function startCodexAppServerClient(
   });
 
   const write = (payload: Record<string, unknown>, direction: CodexAppServerJsonRpcDirection) => {
-    if (closed || child.stdin.destroyed) throw new Error("codex app-server is not running.");
+    if (closed || !child.writeStdin) throw new Error("codex app-server is not running.");
     emitJsonRpcMessage({ direction, message: payload });
-    child.stdin.write(`${JSON.stringify(payload)}\n`);
+    try {
+      child.writeStdin(`${JSON.stringify(payload)}\n`);
+    } catch (error) {
+      opts.log?.(
+        `[codex-app-server:stdin:error] ${error instanceof Error ? error.message : String(error)}`,
+      );
+      throw new Error("codex app-server is not running.");
+    }
   };
 
   const request = (method: string, params?: unknown, timeoutMs?: number): Promise<unknown> => {
@@ -321,14 +328,15 @@ export async function startCodexAppServerClient(
       };
     },
     close: async () => {
-      rl.close();
+      stdoutSubscription.close();
+      stderrSubscription.close();
       await stopProcess(child);
     },
   };
 }
 
 async function respondToServerRequest(
-  child: ChildProcessWithoutNullStreams,
+  child: StreamingSubprocess,
   request: CodexAppServerJsonRpcRequest,
   handlers: ReadonlySet<CodexAppServerRequestHandler>,
   onJsonRpcMessage: (message: CodexAppServerJsonRpcRawMessage) => void,
@@ -336,7 +344,7 @@ async function respondToServerRequest(
   const writeResponse = (response: Record<string, unknown>) => {
     onJsonRpcMessage({ direction: "client_response", message: response });
     try {
-      child.stdin.write(`${JSON.stringify(response)}\n`);
+      child.writeStdin?.(`${JSON.stringify(response)}\n`);
     } catch {
       // The app-server may have exited after issuing a request. There is no
       // live peer to receive the response, so keep the client shutdown local.
@@ -364,27 +372,23 @@ async function respondToServerRequest(
   }
 }
 
-async function stopProcess(child: ChildProcessWithoutNullStreams): Promise<void> {
-  if (child.exitCode !== null || child.killed) return;
-  await new Promise<void>((resolve) => {
-    const timeout = setTimeout(() => {
-      if (process.platform === "win32") {
-        child.kill(); // Windows uses default termination
-      } else {
-        child.kill("SIGKILL");
-      }
-      resolve();
-    }, 5_000);
-    child.once("exit", () => {
-      clearTimeout(timeout);
-      resolve();
-    });
-    if (process.platform === "win32") {
-      child.kill(); // Windows uses default termination
-    } else {
-      child.kill("SIGTERM");
-    }
-  });
+async function stopProcess(child: StreamingSubprocess): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  if (process.platform === "win32") {
+    child.kill(); // Windows uses default termination
+  } else {
+    child.kill("SIGTERM");
+  }
+  const exited = await Promise.race([
+    child.exited.then(() => true),
+    new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 5_000)),
+  ]);
+  if (exited) return;
+  if (process.platform === "win32") {
+    child.kill(); // Windows uses default termination
+  } else {
+    child.kill("SIGKILL");
+  }
 }
 
 const pooledClients = new Map<string, Promise<CodexAppServerClient>>();

--- a/src/providers/codexAppServerResolver.ts
+++ b/src/providers/codexAppServerResolver.ts
@@ -1,10 +1,10 @@
-import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
 import { resolveAuthHomeDir } from "../utils/authHome";
 import { execFileCompat } from "../utils/execFileCompat";
+import { sha256FileHex } from "../utils/hash";
 import { type StreamingSubprocess, spawnStreamingSubprocess } from "../utils/subprocess";
 
 type CodexAppServerSource = "override" | "system" | "managed";
@@ -147,9 +147,7 @@ async function verifyDownloadedAssetChecksum(opts: {
       `Refusing to install Codex app-server ${opts.version}: no pinned SHA-256 checksum for asset ${opts.assetName}.`,
     );
   }
-  const actual = createHash("sha256")
-    .update(await fs.readFile(opts.assetPath))
-    .digest("hex");
+  const actual = await sha256FileHex(opts.assetPath);
   if (actual.toLowerCase() !== expected.toLowerCase()) {
     throw new Error(
       `Codex app-server asset ${opts.assetName} failed checksum verification ` +

--- a/src/providers/codexAppServerResolver.ts
+++ b/src/providers/codexAppServerResolver.ts
@@ -1,10 +1,11 @@
-import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
 import { resolveAuthHomeDir } from "../utils/authHome";
+import { execFileCompat } from "../utils/execFileCompat";
+import { type StreamingSubprocess, spawnStreamingSubprocess } from "../utils/subprocess";
 
 type CodexAppServerSource = "override" | "system" | "managed";
 
@@ -52,7 +53,6 @@ type ProcessResult = {
 export type CodexAppServerResolverOverrides = {
   fetchImpl?: typeof fetch;
   spawnForResult?: (command: string, args: string[]) => Promise<ProcessResult>;
-  spawnAppServer?: typeof spawn;
   promoteManagedInstall?: (
     executablePath: string,
     currentPath: string,
@@ -319,33 +319,25 @@ async function resolveSystemCodexCandidates(
   return candidates;
 }
 
-function defaultSpawnForResult(command: string, args: string[]): Promise<ProcessResult> {
-  return new Promise((resolve) => {
-    const child = spawn(command, args, {
-      env: process.env,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-    let stdout = "";
-    let stderr = "";
-    const timeout = setTimeout(() => {
-      child.kill("SIGKILL");
-      resolve({ ok: false, stdout, stderr, error: "Timed out." });
-    }, 5_000);
-    child.stdout.on("data", (chunk) => {
-      stdout += String(chunk);
-    });
-    child.stderr.on("data", (chunk) => {
-      stderr += String(chunk);
-    });
-    child.once("error", (error) => {
-      clearTimeout(timeout);
-      resolve({ ok: false, stdout, stderr, error: error.message });
-    });
-    child.once("exit", (code) => {
-      clearTimeout(timeout);
-      resolve({ ok: code === 0, stdout, stderr });
-    });
+async function defaultSpawnForResult(command: string, args: string[]): Promise<ProcessResult> {
+  const result = await execFileCompat(command, args, {
+    env: process.env,
+    timeoutMs: 5_000,
+    killSignal: "SIGKILL",
+    maxBuffer: 4 * 1024 * 1024,
   });
+  if (result.errorCode === "TIMEOUT") {
+    return { ok: false, stdout: result.stdout, stderr: result.stderr, error: "Timed out." };
+  }
+  if (result.errorCode) {
+    return {
+      ok: false,
+      stdout: result.stdout,
+      stderr: result.stderr,
+      error: `${command} failed (${result.errorCode}).`,
+    };
+  }
+  return { ok: result.exitCode === 0, stdout: result.stdout, stderr: result.stderr };
 }
 
 async function readVersionFile(executablePath: string): Promise<string | undefined> {
@@ -527,23 +519,14 @@ async function downloadFile(
 }
 
 async function extractTarGz(archivePath: string, destDir: string): Promise<void> {
-  await new Promise<void>((resolve, reject) => {
-    const child = spawn("tar", ["-xzf", archivePath, "-C", destDir], {
-      stdio: ["ignore", "ignore", "pipe"],
-    });
-    let stderr = "";
-    child.stderr.on("data", (chunk) => {
-      stderr += String(chunk);
-    });
-    child.once("error", reject);
-    child.once("exit", (code) => {
-      if (code === 0) {
-        resolve();
-      } else {
-        reject(new Error(`Failed to extract Codex app-server archive: ${stderr.trim()}`));
-      }
-    });
+  const result = await execFileCompat("tar", ["-xzf", archivePath, "-C", destDir], {
+    maxBuffer: 4 * 1024 * 1024,
   });
+  if (result.exitCode !== 0 || result.errorCode) {
+    throw new Error(
+      `Failed to extract Codex app-server archive: ${result.stderr.trim() || (result.errorCode ?? `exit ${result.exitCode}`)}`,
+    );
+  }
 }
 
 async function findFileRecursive(dir: string, wantedBasename: string): Promise<string | null> {
@@ -797,11 +780,11 @@ export async function updateManagedCodexAppServer(
 export function spawnCodexAppServer(
   command: CodexAppServerCommand,
   opts: { cwd?: string; env?: NodeJS.ProcessEnv } = {},
-): ChildProcessWithoutNullStreams {
-  return spawn(command.command, command.args, {
+): StreamingSubprocess {
+  return spawnStreamingSubprocess([command.command, ...command.args], {
     ...(opts.cwd ? { cwd: opts.cwd } : {}),
     env: opts.env ?? process.env,
-    stdio: ["pipe", "pipe", "pipe"],
+    stdin: "pipe",
   });
 }
 

--- a/src/server/presentationPreview.ts
+++ b/src/server/presentationPreview.ts
@@ -1,4 +1,3 @@
-import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";

--- a/src/server/runtime/ServerRuntime.ts
+++ b/src/server/runtime/ServerRuntime.ts
@@ -1,7 +1,6 @@
 import fs from "node:fs/promises";
 import type { runTurn as runTurnFn } from "../../agent";
 import { loadConfig } from "../../config";
-import { resolveVersion } from "../../version";
 import type { connectProvider as connectModelProvider, getAiCoworkerPaths } from "../../connect";
 import { getAiCoworkerPaths as getAiCoworkerPathsDefault } from "../../connect";
 import { checkLibreOfficeCapability, ensureCoworkRuntimeReady } from "../../coworkRuntime";
@@ -13,6 +12,7 @@ import type {
 } from "../../prompt";
 import { ensureDefaultGlobalSkillsReady } from "../../skills/defaultGlobalSkills";
 import type { AgentConfig } from "../../types";
+import { resolveVersion } from "../../version";
 import { decodeJsonRpcMessage } from "../jsonrpc/decodeJsonRpcMessage";
 import {
   buildJsonRpcErrorResponse,

--- a/src/server/session/AgentSessionFromPersisted.ts
+++ b/src/server/session/AgentSessionFromPersisted.ts
@@ -1,6 +1,6 @@
 import type { runTurn } from "../../agent";
 import type { connectProvider as connectModelProvider } from "../../connect";
-import { getKnownResolvedModelMetadata, isDynamicModelProvider } from "../../models/metadata";
+import { getKnownResolvedModelMetadata, isRuntimeDiscoveryProvider } from "../../models/metadata";
 import { defaultSupportedModel } from "../../models/registry";
 import type { getProviderStatuses } from "../../providerStatus";
 import type { getProviderCatalog } from "../../providers/connectionCatalog";
@@ -77,11 +77,11 @@ export function createAgentSessionFromPersisted(
   const resolvedPersistedModel = getKnownResolvedModelMetadata(persisted.provider, persisted.model);
   const resumedModel = resolvedPersistedModel ?? defaultSupportedModel(persisted.provider);
   const migratedUnsupportedModel =
-    resolvedPersistedModel === null && !isDynamicModelProvider(persisted.provider);
+    resolvedPersistedModel === null && !isRuntimeDiscoveryProvider(persisted.provider);
   const migratedAliasedModel =
     resolvedPersistedModel !== null &&
     resolvedPersistedModel.id !== persisted.model &&
-    !isDynamicModelProvider(persisted.provider);
+    !isRuntimeDiscoveryProvider(persisted.provider);
   const migratedLegacyModel = migratedUnsupportedModel || migratedAliasedModel;
   const clearedContinuationState = migratedLegacyModel && persisted.providerState !== null;
   const config: AgentConfig = {

--- a/src/server/session/ProviderAuthManager.ts
+++ b/src/server/session/ProviderAuthManager.ts
@@ -1,3 +1,5 @@
+import path from "node:path";
+
 import type { getAiCoworkerPaths } from "../../connect";
 import { normalizeChildRoutingConfig } from "../../models/childModelRouting";
 import { resolveModelMetadata } from "../../models/metadata";
@@ -139,6 +141,9 @@ export class ProviderAuthManager {
       resolvedModel = await resolveModelMetadata(nextProvider, modelId, {
         providerOptions: currentConfig.providerOptions,
         source: "model",
+        // Discovery-cache lookups must resolve against this session's auth home
+        // so tests (and non-default homes) stay deterministic.
+        home: path.dirname(currentConfig.userCoworkDir),
       });
     } catch (error) {
       this.opts.emitError(
@@ -148,21 +153,35 @@ export class ProviderAuthManager {
       );
       return null;
     }
-    const normalizedChildRouting = normalizeChildRoutingConfig({
-      provider: nextProvider,
-      model: resolvedModel.id,
-      childModelRoutingMode: currentConfig.childModelRoutingMode,
-      preferredChildModelRef:
-        currentConfig.childModelRoutingMode === "cross-provider-allowlist"
-          ? currentConfig.preferredChildModelRef
-          : currentConfig.provider !== nextProvider ||
-              currentConfig.preferredChildModel === currentConfig.model
-            ? `${nextProvider}:${resolvedModel.id}`
-            : (currentConfig.preferredChildModelRef ?? currentConfig.preferredChildModel),
-      preferredChildModel: currentConfig.preferredChildModel,
-      allowedChildModelRefs: currentConfig.allowedChildModelRefs,
-      source: "model selection",
-    });
+    let normalizedChildRouting: ReturnType<typeof normalizeChildRoutingConfig>;
+    try {
+      normalizedChildRouting = normalizeChildRoutingConfig({
+        provider: nextProvider,
+        model: resolvedModel.id,
+        childModelRoutingMode: currentConfig.childModelRoutingMode,
+        preferredChildModelRef:
+          currentConfig.childModelRoutingMode === "cross-provider-allowlist"
+            ? currentConfig.preferredChildModelRef
+            : currentConfig.provider !== nextProvider ||
+                currentConfig.preferredChildModel === currentConfig.model
+              ? `${nextProvider}:${resolvedModel.id}`
+              : (currentConfig.preferredChildModelRef ?? currentConfig.preferredChildModel),
+        preferredChildModel: currentConfig.preferredChildModel,
+        allowedChildModelRefs: currentConfig.allowedChildModelRefs,
+        source: "model selection",
+      });
+    } catch {
+      // A stale preferred child target (e.g. persisted before a provider switch)
+      // must not block model selection; fall back to the selected model itself.
+      normalizedChildRouting = normalizeChildRoutingConfig({
+        provider: nextProvider,
+        model: resolvedModel.id,
+        childModelRoutingMode: currentConfig.childModelRoutingMode,
+        preferredChildModelRef: `${nextProvider}:${resolvedModel.id}`,
+        allowedChildModelRefs: currentConfig.allowedChildModelRefs,
+        source: "model selection",
+      });
+    }
     const nextRuntime =
       currentConfig.provider === nextProvider
         ? currentConfig.runtime

--- a/src/server/sessionBackup/command.ts
+++ b/src/server/sessionBackup/command.ts
@@ -1,61 +1,35 @@
-import { spawn } from "node:child_process";
-import { z } from "zod";
-
 export type CommandResult = {
   exitCode: number | null;
   stdout: string;
   stderr: string;
 };
 
-const errorMessageSchema = z.object({ message: z.string() }).passthrough();
-
 export async function runCommand(
   command: string,
   args: string[],
   opts: { cwd?: string; env?: NodeJS.ProcessEnv } = {},
 ): Promise<CommandResult> {
-  let child: ReturnType<typeof spawn>;
+  let proc: Bun.Subprocess<"ignore", "pipe", "pipe">;
   try {
-    child = spawn(command, args, {
-      cwd: opts.cwd,
+    proc = Bun.spawn([command, ...args], {
+      ...(opts.cwd ? { cwd: opts.cwd } : {}),
       env: opts.env ?? process.env,
-      stdio: ["pipe", "pipe", "pipe"],
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+      windowsHide: true,
     });
   } catch (err) {
+    // Node spawn surfaced missing executables asynchronously with exit 127;
+    // Bun throws synchronously. Preserve the 127 contract.
     return { exitCode: 127, stdout: "", stderr: String(err) };
   }
 
-  const stdoutChunks: Uint8Array[] = [];
-  const stderrChunks: Uint8Array[] = [];
-
-  const stdoutPromise = (async () => {
-    if (!child.stdout) return;
-    for await (const chunk of child.stdout) stdoutChunks.push(chunk);
-  })();
-
-  const stderrPromise = (async () => {
-    if (!child.stderr) return;
-    for await (const chunk of child.stderr) stderrChunks.push(chunk);
-  })();
-
-  let spawnErr: unknown = null;
-  const closePromise = new Promise<number | null>((resolve) => {
-    child.once("error", (err) => {
-      spawnErr = err;
-      resolve(127);
-    });
-    child.once("close", (exitCode) => resolve(exitCode));
-  });
-
-  child.stdin?.end();
-
-  const [exitCode] = await Promise.all([closePromise, stdoutPromise, stderrPromise]);
-
-  const stdout = Buffer.concat(stdoutChunks).toString("utf-8");
-  const stderrBase = Buffer.concat(stderrChunks).toString("utf-8");
-  const parsedErrorMessage = errorMessageSchema.safeParse(spawnErr);
-  const spawnErrorMessage = parsedErrorMessage.success ? parsedErrorMessage.data.message : spawnErr;
-  const stderr = spawnErr ? `${stderrBase}\n${String(spawnErrorMessage)}`.trim() : stderrBase;
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
 
   return { exitCode, stdout, stderr };
 }

--- a/src/server/sessionStore.ts
+++ b/src/server/sessionStore.ts
@@ -49,7 +49,7 @@ export async function readPersistedSessionSnapshot(opts: {
 }): Promise<PersistedSessionSnapshot | null> {
   const filePath = getPersistedSessionFilePath(opts.paths, opts.sessionId);
   try {
-    const raw = await fs.readFile(filePath, "utf-8");
+    const raw = await Bun.file(filePath).text();
     let parsedJson: unknown;
     try {
       parsedJson = JSON.parse(raw);
@@ -117,7 +117,7 @@ export async function listPersistedSessionSnapshots(
 
     let raw: string;
     try {
-      raw = await fs.readFile(filePath, "utf-8");
+      raw = await Bun.file(filePath).text();
     } catch (error) {
       const parsedCode = errorWithCodeSchema.safeParse(error);
       const code = parsedCode.success ? parsedCode.data.code : undefined;

--- a/src/server/spreadsheetEdit.ts
+++ b/src/server/spreadsheetEdit.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 
@@ -129,7 +128,7 @@ function executeOps(
 
 async function writeFileAtomic(filePath: string, data: Buffer | string): Promise<void> {
   const dir = path.dirname(filePath);
-  const tmp = path.join(dir, `.${path.basename(filePath)}.${randomUUID()}.tmp`);
+  const tmp = path.join(dir, `.${path.basename(filePath)}.${crypto.randomUUID()}.tmp`);
   try {
     await fs.writeFile(tmp, data);
     await fs.rename(tmp, filePath);

--- a/src/server/webDesktopService.ts
+++ b/src/server/webDesktopService.ts
@@ -1,10 +1,7 @@
-import { type ChildProcessByStdio, spawn } from "node:child_process";
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import readline from "node:readline";
-import type { Readable } from "node:stream";
 import { z } from "zod";
 
 import type { DesktopFeatureFlagOverrides } from "../shared/featureFlags";
@@ -25,6 +22,11 @@ import {
   type WorkspaceKindSource,
   withWorkspaceKindSource,
 } from "../utils/oneOffChats";
+import {
+  type StreamingSubprocess,
+  spawnStreamingSubprocess,
+  subscribeLines,
+} from "../utils/subprocess";
 
 const SAFE_ID = /^[A-Za-z0-9_-]{1,256}$/;
 const PRIVATE_FILE_MODE = 0o600;
@@ -110,14 +112,14 @@ export type WebDesktopServiceLike = {
 };
 
 type WorkspaceServerHandle = {
-  child: ChildProcessByStdio<null, Readable, Readable>;
+  child: StreamingSubprocess;
   url: string;
   workspacePath: string;
   yolo: boolean;
 };
 
 type SourceWorkspaceServerLaunch = {
-  child: ChildProcessByStdio<null, Readable, Readable>;
+  child: StreamingSubprocess;
   url: string;
 };
 
@@ -137,7 +139,7 @@ type SourceWorkspaceServerManagerDeps = {
     workspacePath: string;
     yolo: boolean;
   }) => Promise<SourceWorkspaceServerLaunch>;
-  gracefulKill?: (child: ChildProcessByStdio<null, Readable, Readable>) => Promise<void>;
+  gracefulKill?: (child: StreamingSubprocess) => Promise<void>;
 };
 
 const transcriptEventSchema = z
@@ -482,9 +484,7 @@ async function assertWorkspaceDirectory(workspacePath: string): Promise<string> 
   return await fs.realpath(resolved);
 }
 
-function waitForServerListening(
-  child: ChildProcessByStdio<null, Readable, Readable>,
-): Promise<{ url: string }> {
+function waitForServerListening(child: StreamingSubprocess): Promise<{ url: string }> {
   const monitor = createWorkspaceServerMonitor(
     child,
     shouldMirrorWorkspaceServerOutputToTerminal()
@@ -519,7 +519,7 @@ function writeWorkspaceServerOutputToTerminal(
 }
 
 function createWorkspaceServerMonitor(
-  child: ChildProcessByStdio<null, Readable, Readable>,
+  child: StreamingSubprocess,
   onOutputLine: (source: WorkspaceServerOutputSource, line: string) => void = () => {},
 ): WorkspaceServerMonitor {
   let resolveReady!: (value: { url: string }) => void;
@@ -537,8 +537,6 @@ function createWorkspaceServerMonitor(
   });
 
   const recentLines: string[] = [];
-  const stdoutReader = readline.createInterface({ input: child.stdout });
-  const stderrReader = readline.createInterface({ input: child.stderr });
   let readySeen = false;
   let finished = false;
   let readySettled = false;
@@ -579,12 +577,8 @@ function createWorkspaceServerMonitor(
     }
     finished = true;
     clearTimeout(timeout);
-    stdoutReader.off("line", onStdoutLine);
-    stderrReader.off("line", onStderrLine);
-    child.off("exit", onExit);
-    child.off("error", onError);
-    stdoutReader.close();
-    stderrReader.close();
+    stdoutSubscription.close();
+    stderrSubscription.close();
     return true;
   };
 
@@ -603,15 +597,7 @@ function createWorkspaceServerMonitor(
 
   const timeout = setTimeout(onTimeout, SERVER_STARTUP_TIMEOUT_MS);
 
-  const onError = (error: Error) => {
-    if (!cleanup()) {
-      return;
-    }
-    settleReadyReject(error);
-    rejectDrained(error);
-  };
-
-  const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+  const onExit = (code: number | null, signal: string | null) => {
     if (!cleanup()) {
       return;
     }
@@ -651,53 +637,45 @@ function createWorkspaceServerMonitor(
     onOutputLine(source, trimmed);
   };
 
-  const onStdoutLine = (line: string) => {
-    handleOutputLine("stdout", line);
-  };
+  const stdoutSubscription = subscribeLines(child.stdout, (line) =>
+    handleOutputLine("stdout", line),
+  );
+  const stderrSubscription = subscribeLines(child.stderr, (line) =>
+    handleOutputLine("stderr", line),
+  );
 
-  const onStderrLine = (line: string) => {
-    handleOutputLine("stderr", line);
-  };
-
-  stdoutReader.on("line", onStdoutLine);
-  stderrReader.on("line", onStderrLine);
-  child.once("exit", onExit);
-  child.once("error", onError);
+  // Handle exit only after both output streams drain so buffered lines are
+  // mirrored (and recorded for diagnostics) before drained resolves.
+  void Promise.allSettled([stdoutSubscription.done, stderrSubscription.done, child.exited]).then(
+    async () => {
+      const { exitCode, signalCode } = await child.exited;
+      onExit(exitCode, signalCode);
+    },
+  );
 
   return { ready, drained };
 }
 
-async function gracefulKill(child: ChildProcessByStdio<null, Readable, Readable>): Promise<void> {
+async function gracefulKill(child: StreamingSubprocess): Promise<void> {
   if (child.exitCode !== null || child.signalCode !== null) {
     return;
   }
 
-  try {
-    child.kill();
-  } catch {
-    // ignore
-  }
+  child.kill();
 
-  const exited = await new Promise<boolean>((resolve) => {
-    const timer = setTimeout(() => resolve(false), 3_000);
-    child.once("exit", () => {
-      clearTimeout(timer);
-      resolve(true);
-    });
-  });
+  const exited = await Promise.race([
+    child.exited.then(() => true),
+    new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 3_000)),
+  ]);
 
   if (exited) {
     return;
   }
 
-  try {
-    if (process.platform === "win32") {
-      child.kill(); // Windows uses default termination
-    } else {
-      child.kill("SIGKILL");
-    }
-  } catch {
-    // ignore
+  if (process.platform === "win32") {
+    child.kill(); // Windows uses default termination
+  } else {
+    child.kill("SIGKILL");
   }
 }
 
@@ -753,7 +731,7 @@ class SourceWorkspaceServerManager {
       yolo: opts.yolo,
     };
     this.servers.set(workspaceId, handle);
-    listening.child.once("exit", () => {
+    void listening.child.exited.then(() => {
       const active = this.servers.get(workspaceId);
       if (active?.child === listening.child) {
         this.servers.delete(workspaceId);
@@ -793,9 +771,8 @@ async function launchWorkspaceServer(opts: {
     args.push("--yolo");
   }
 
-  const child = spawn(process.execPath, args, {
+  const child = spawnStreamingSubprocess([process.execPath, ...args], {
     cwd: opts.repoRoot,
-    stdio: ["ignore", "pipe", "pipe"],
     env: {
       ...process.env,
       COWORK_SKIP_DEFAULT_SKILLS_BOOTSTRAP: process.env.COWORK_SKIP_DEFAULT_SKILLS_BOOTSTRAP ?? "1",

--- a/src/skills/catalog.ts
+++ b/src/skills/catalog.ts
@@ -183,7 +183,7 @@ function mimeTypeForPath(targetPath: string): string {
 
 async function readFileAsDataUri(targetPath: string): Promise<string | null> {
   try {
-    const buf = await fs.readFile(targetPath);
+    const buf = await Bun.file(targetPath).arrayBuffer();
     return `data:${mimeTypeForPath(targetPath)};base64,${Buffer.from(buf).toString("base64")}`;
   } catch {
     return null;
@@ -278,7 +278,7 @@ async function readAgentInterface(skillRoot: string): Promise<SkillInterfaceMeta
   }
   let raw: string;
   try {
-    raw = await fs.readFile(path.join(agentsDir, primary), "utf-8");
+    raw = await Bun.file(path.join(agentsDir, primary)).text();
   } catch {
     return { agents: agentFiles.map((file) => file.replace(/\.(ya?ml)$/i, "")) };
   }
@@ -432,7 +432,7 @@ async function buildPluginInstallationEntry(opts: {
 
   if (diagnostics.length === 0) {
     try {
-      const raw = await fs.readFile(opts.skill.skillPath, "utf-8");
+      const raw = await Bun.file(opts.skill.skillPath).text();
       const parsed = parseSkillFrontMatter(raw, opts.skill.rawName);
       if (!parsed) {
         diagnostics.push(
@@ -506,7 +506,7 @@ async function buildInstallationEntry(opts: {
 
   if (diagnostics.length === 0) {
     try {
-      const raw = await fs.readFile(skillPath, "utf-8");
+      const raw = await Bun.file(skillPath).text();
       const parsed = parseSkillFrontMatter(raw, opts.dirent.name);
       if (!parsed) {
         diagnostics.push(

--- a/src/skills/loadSkillBody.ts
+++ b/src/skills/loadSkillBody.ts
@@ -38,7 +38,7 @@ async function readIfExists(p: string): Promise<string | null> {
       return cached.content;
     }
 
-    const content = await fs.readFile(p, "utf-8");
+    const content = await Bun.file(p).text();
     loadedSkills.set(cacheKey, { content, mtimeMs: stat.mtimeMs, size: stat.size });
     return content;
   } catch {

--- a/src/sync/service.ts
+++ b/src/sync/service.ts
@@ -1,5 +1,3 @@
-import { randomUUID } from "node:crypto";
-
 import { resolveCloudSyncConfig } from "../telemetry/config";
 import type { CloudSyncProvider } from "./CloudSyncProvider";
 import { createCustomHttpCloudSyncProvider } from "./providers/customHttp";
@@ -144,7 +142,7 @@ export class CloudSyncService {
       }
       const patch: CloudSyncPatch = {
         version: CLOUD_SYNC_PAYLOAD_VERSION,
-        id: randomUUID(),
+        id: crypto.randomUUID(),
         scope: "settings",
         dedupeKey: CLOUD_SYNC_SETTINGS_DEDUPE_KEY,
         createdAt: this.now().toISOString(),

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -1,4 +1,3 @@
-import { execFile } from "node:child_process";
 import fsSync from "node:fs";
 import path from "node:path";
 import { z } from "zod";
@@ -21,6 +20,7 @@ import {
 } from "../platform/shell";
 import { getAgentRoleDefinition } from "../server/agents/roles";
 import { classifyCommandDetailed } from "../utils/approval";
+import { execFileCompat } from "../utils/execFileCompat";
 import type { ToolContext } from "./context";
 import { defineTool } from "./defineTool";
 
@@ -130,10 +130,7 @@ type ExecRunner = (
   },
 ) => Promise<ExecResult>;
 
-const abortByNameSchema = z.object({ name: z.literal("AbortError") }).passthrough();
-const errorCodeSchema = z.object({ code: z.union([z.string(), z.number()]) }).passthrough();
-
-function execFileAsync(
+async function execFileAsync(
   file: string,
   args: string[],
   opts: {
@@ -144,67 +141,32 @@ function execFileAsync(
     env?: Record<string, string | undefined>;
   },
 ): Promise<ExecResult> {
-  return new Promise((resolve) => {
-    let timedOut = false;
-    execFile(
-      file,
-      args,
-      {
-        cwd: opts.cwd,
-        maxBuffer: opts.maxBuffer,
-        windowsHide: true,
-        ...(opts.env ? { env: opts.env } : {}),
-        ...(opts.timeoutMs ? { timeout: opts.timeoutMs, killSignal: "SIGTERM" } : {}), // Node.js converts SIGTERM to Windows process termination
-        ...(opts.signal ? { signal: opts.signal } : {}),
-      },
-      (err, stdout, stderr) => {
-        const isAbortByName = abortByNameSchema.safeParse(err).success;
-        const parsedErrorCode = errorCodeSchema.safeParse(err);
-        const code = parsedErrorCode.success ? parsedErrorCode.data.code : undefined;
-
-        // Detect timeout: Node sets killed=true and signal='SIGTERM' on timeout
-        if (
-          err &&
-          "killed" in err &&
-          err.killed === true &&
-          "signal" in err &&
-          err.signal === "SIGTERM" &&
-          opts.timeoutMs
-        ) {
-          timedOut = true;
-        }
-
-        if (timedOut) {
-          const timeoutSeconds = (opts.timeoutMs ?? 0) / 1000;
-          resolve({
-            stdout: String(stdout ?? ""),
-            stderr: `Command timed out after ${timeoutSeconds}s. The child process was terminated.`,
-            exitCode: 124,
-            errorCode: "TIMEOUT",
-          });
-          return;
-        }
-
-        if (isAbortByName || code === "ABORT_ERR") {
-          resolve({
-            stdout: String(stdout ?? ""),
-            stderr: String(stderr ?? "") || "Command aborted.",
-            exitCode: 130,
-            errorCode: "ABORT_ERR",
-          });
-          return;
-        }
-        const errorCode = typeof code === "string" ? code : undefined;
-        const exitCode = typeof code === "number" ? code : err ? 1 : 0;
-        resolve({
-          stdout: String(stdout ?? ""),
-          stderr: String(stderr ?? ""),
-          exitCode,
-          errorCode,
-        });
-      },
-    );
+  const result = await execFileCompat(file, args, {
+    cwd: opts.cwd,
+    maxBuffer: opts.maxBuffer,
+    ...(opts.env ? { env: opts.env } : {}),
+    ...(opts.timeoutMs ? { timeoutMs: opts.timeoutMs } : {}),
+    ...(opts.signal ? { signal: opts.signal } : {}),
   });
+
+  if (result.errorCode === "TIMEOUT") {
+    const timeoutSeconds = (opts.timeoutMs ?? 0) / 1000;
+    return {
+      stdout: result.stdout,
+      stderr: `Command timed out after ${timeoutSeconds}s. The child process was terminated.`,
+      exitCode: 124,
+      errorCode: "TIMEOUT",
+    };
+  }
+  if (result.errorCode === "ABORT_ERR") {
+    return {
+      stdout: result.stdout,
+      stderr: result.stderr || "Command aborted.",
+      exitCode: 130,
+      errorCode: "ABORT_ERR",
+    };
+  }
+  return result;
 }
 
 /** Exec result augmented with which sandbox backend (if any) wrapped the run. */

--- a/src/tools/edit.ts
+++ b/src/tools/edit.ts
@@ -54,7 +54,7 @@ export function createEditTool(ctx: ToolContext) {
           `edit blocked: ${abs} is ${Number(stat.size)} bytes (max ${MAX_EDIT_FILE_BYTES}).`,
         );
       }
-      let content = await fs.readFile(abs, "utf-8");
+      let content = await Bun.file(abs).text();
       if (!content.includes(oldString)) throw new Error(`oldString not found in ${abs}`);
 
       const occurrences = content.split(oldString).length - 1;
@@ -80,7 +80,7 @@ export function createEditTool(ctx: ToolContext) {
         ? content.replaceAll(oldString, newString)
         : content.replace(oldString, newString);
       await ctx.assertCanMutate?.("edit");
-      await fs.writeFile(abs, content, "utf-8");
+      await Bun.write(abs, content);
 
       ctx.log(`tool< edit ${JSON.stringify({ ok: true })}`);
       return "Edit applied.";

--- a/src/tools/grep.ts
+++ b/src/tools/grep.ts
@@ -1,15 +1,13 @@
-import { execFile } from "node:child_process";
 import path from "node:path";
 import { z } from "zod";
 import { resolveCoworkHomedir } from "../utils/coworkHome";
+import { type ExecFileCompatRunner, execFileCompat } from "../utils/execFileCompat";
 import { resolveMaybeRelative } from "../utils/paths";
 import { assertReadPathAllowed, credentialReadDenyDirs } from "../utils/permissions";
 import { ensureRipgrep } from "../utils/ripgrep";
 import type { ToolContext } from "./context";
 import { defineTool } from "./defineTool";
 
-const errorCodeSchema = z.object({ code: z.union([z.string(), z.number()]) }).passthrough();
-const abortByNameSchema = z.object({ name: z.literal("AbortError") }).passthrough();
 const DEFAULT_TIMEOUT_SECONDS = 300;
 const MAX_TIMEOUT_SECONDS = 600;
 
@@ -44,9 +42,9 @@ function credentialDenyGlobs(searchPath: string, ctx: ToolContext): string[] {
 
 export function createGrepTool(
   ctx: ToolContext,
-  opts: { execFileImpl?: typeof execFile; ensureRipgrepImpl?: typeof ensureRipgrep } = {},
+  opts: { execFileImpl?: ExecFileCompatRunner; ensureRipgrepImpl?: typeof ensureRipgrep } = {},
 ) {
-  const execFileImpl = opts.execFileImpl ?? execFile;
+  const execFileImpl = opts.execFileImpl ?? execFileCompat;
   const ensureRipgrepImpl = opts.ensureRipgrepImpl ?? ensureRipgrep;
 
   return defineTool({
@@ -109,48 +107,28 @@ export function createGrepTool(
         return msg;
       }
 
-      const output = await new Promise<string>((resolve) => {
-        execFileImpl(
-          rgPath,
-          args,
-          {
-            maxBuffer: 1024 * 1024 * 10,
-            signal: ctx.abortSignal,
-            timeout: timeoutMs,
-            killSignal: "SIGTERM",
-          },
-          (err, stdout, stderr) => {
-            // ripgrep returns exit code 1 when there are no matches.
-            const parsedErrorCode = errorCodeSchema.safeParse(err);
-            const code = parsedErrorCode.success ? parsedErrorCode.data.code : undefined;
-            const isAbortByName = abortByNameSchema.safeParse(err).success;
-            const timedOut =
-              !!err &&
-              "killed" in err &&
-              err.killed === true &&
-              "signal" in err &&
-              err.signal === "SIGTERM";
-            const stderrText = String(stderr ?? "").trim();
-
-            if (timedOut) {
-              return resolve(
-                `grep timed out after ${resolvedTimeoutSeconds}s. The ripgrep process was terminated.`,
-              );
-            }
-            if (isAbortByName || code === "ABORT_ERR" || ctx.abortSignal?.aborted) {
-              return resolve("grep aborted.");
-            }
-            if (code === 1) return resolve("No matches found.");
-            if (code === "ENOENT") {
-              return resolve("ripgrep (rg) not found.");
-            }
-            if (err) {
-              return resolve(`rg failed: ${stderrText || String(err)}`);
-            }
-            return resolve(stdout.toString());
-          },
-        );
+      const result = await execFileImpl(rgPath, args, {
+        maxBuffer: 1024 * 1024 * 10,
+        ...(ctx.abortSignal ? { signal: ctx.abortSignal } : {}),
+        timeoutMs,
       });
+
+      const stderrText = result.stderr.trim();
+      const output = (() => {
+        if (result.errorCode === "TIMEOUT") {
+          return `grep timed out after ${resolvedTimeoutSeconds}s. The ripgrep process was terminated.`;
+        }
+        if (result.errorCode === "ABORT_ERR" || ctx.abortSignal?.aborted) {
+          return "grep aborted.";
+        }
+        // ripgrep returns exit code 1 when there are no matches.
+        if (result.exitCode === 1 && !result.errorCode) return "No matches found.";
+        if (result.errorCode === "ENOENT") return "ripgrep (rg) not found.";
+        if (result.exitCode !== 0 || result.errorCode) {
+          return `rg failed: ${stderrText || (result.errorCode ?? `exit code ${result.exitCode}`)}`;
+        }
+        return result.stdout;
+      })();
 
       const res = output;
       ctx.log(`tool< grep ${JSON.stringify({ chars: res.length })}`);

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -74,7 +74,7 @@ export function createReadTool(ctx: ToolContext) {
         if (preReadSizeMessage) {
           throw new Error(preReadSizeMessage);
         }
-        const buffer = await fs.readFile(abs);
+        const buffer = Buffer.from(await Bun.file(abs).arrayBuffer());
         const sizeMessage = getAttachmentByteLengthValidationMessage([buffer.length]);
         if (sizeMessage) {
           throw new Error(sizeMessage);

--- a/src/utils/execFileCompat.ts
+++ b/src/utils/execFileCompat.ts
@@ -17,8 +17,10 @@ export type ExecFileCompatOptions = {
   env?: Record<string, string | undefined>;
   /** Byte cap applied to stdout and stderr independently. Default 1 MiB. */
   maxBuffer?: number;
-  /** SIGTERM the child when elapsed. */
+  /** Kill the child (default SIGTERM) when elapsed. */
   timeoutMs?: number;
+  /** Signal used for timeout/abort/overflow termination. Default SIGTERM. */
+  killSignal?: NodeJS.Signals;
   signal?: AbortSignal;
 };
 
@@ -71,7 +73,7 @@ export async function execFileCompat(
     if (cause) return;
     cause = nextCause;
     try {
-      proc.kill("SIGTERM");
+      proc.kill(opts.killSignal ?? "SIGTERM");
     } catch {
       // already exited
     }

--- a/src/utils/execFileCompat.ts
+++ b/src/utils/execFileCompat.ts
@@ -1,0 +1,155 @@
+/**
+ * Bun-native replacement for the Node `child_process.execFile` contract the
+ * harness tools rely on: fully buffered stdout/stderr with a byte cap, a
+ * timeout that SIGTERMs the direct child, AbortSignal support, and stable
+ * error codes instead of thrown errors.
+ *
+ * Error codes mirror what the previous Node-based runners surfaced:
+ * - "TIMEOUT"  → the timeout elapsed and the child was terminated (exit 124)
+ * - "ABORT_ERR" → the AbortSignal fired (exit 130)
+ * - "ENOENT"   → the executable was not found (exit 1)
+ * - "ERR_CHILD_PROCESS_STDIO_MAXBUFFER" → a stream exceeded maxBuffer (exit 1)
+ */
+
+export type ExecFileCompatOptions = {
+  cwd?: string;
+  /** Replaces the child environment entirely, like Node execFile's `env`. */
+  env?: Record<string, string | undefined>;
+  /** Byte cap applied to stdout and stderr independently. Default 1 MiB. */
+  maxBuffer?: number;
+  /** SIGTERM the child when elapsed. */
+  timeoutMs?: number;
+  signal?: AbortSignal;
+};
+
+export type ExecFileCompatResult = {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+  errorCode?: string;
+};
+
+export type ExecFileCompatRunner = (
+  file: string,
+  args: string[],
+  opts?: ExecFileCompatOptions,
+) => Promise<ExecFileCompatResult>;
+
+type KillCause = "timeout" | "abort" | "overflow";
+
+const DEFAULT_MAX_BUFFER = 1024 * 1024;
+
+function spawnErrorCode(error: unknown): string {
+  const code = (error as { code?: unknown } | null)?.code;
+  return typeof code === "string" ? code : "SPAWN_ERROR";
+}
+
+export async function execFileCompat(
+  file: string,
+  args: string[],
+  opts: ExecFileCompatOptions = {},
+): Promise<ExecFileCompatResult> {
+  const maxBuffer = opts.maxBuffer ?? DEFAULT_MAX_BUFFER;
+
+  let proc: Bun.Subprocess<"ignore", "pipe", "pipe">;
+  try {
+    proc = Bun.spawn([file, ...args], {
+      ...(opts.cwd ? { cwd: opts.cwd } : {}),
+      ...(opts.env ? { env: opts.env } : {}),
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+      windowsHide: true,
+    });
+  } catch (error) {
+    return { stdout: "", stderr: "", exitCode: 1, errorCode: spawnErrorCode(error) };
+  }
+
+  let cause: KillCause | null = null;
+  const readers: ReadableStreamDefaultReader<Uint8Array>[] = [];
+  const terminate = (nextCause: KillCause) => {
+    if (cause) return;
+    cause = nextCause;
+    try {
+      proc.kill("SIGTERM");
+    } catch {
+      // already exited
+    }
+    // Grandchildren can keep the stdio pipes open after the direct child dies
+    // (e.g. `sh -c "sleep 99"`). Node's exec destroyed the pipes on kill; do
+    // the equivalent so buffered output resolves promptly.
+    void proc.exited.finally(() => {
+      for (const reader of readers) {
+        void reader.cancel().catch(() => {});
+      }
+    });
+  };
+
+  let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
+  if (typeof opts.timeoutMs === "number" && opts.timeoutMs > 0) {
+    timeoutTimer = setTimeout(() => terminate("timeout"), opts.timeoutMs);
+  }
+
+  const onAbort = () => terminate("abort");
+  if (opts.signal) {
+    if (opts.signal.aborted) {
+      onAbort();
+    } else {
+      opts.signal.addEventListener("abort", onAbort, { once: true });
+    }
+  }
+
+  const readCapped = async (stream: ReadableStream<Uint8Array>): Promise<string> => {
+    const reader = stream.getReader();
+    readers.push(reader);
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (total < maxBuffer) {
+        chunks.push(value);
+        total += value.byteLength;
+      }
+      if (total > maxBuffer) {
+        terminate("overflow");
+      }
+    }
+    const merged = new Uint8Array(Math.min(total, maxBuffer));
+    let offset = 0;
+    for (const chunk of chunks) {
+      const remaining = merged.byteLength - offset;
+      if (remaining <= 0) break;
+      merged.set(remaining >= chunk.byteLength ? chunk : chunk.subarray(0, remaining), offset);
+      offset += Math.min(chunk.byteLength, remaining);
+    }
+    return new TextDecoder().decode(merged);
+  };
+
+  try {
+    const [stdout, stderr, exitCode] = await Promise.all([
+      readCapped(proc.stdout),
+      readCapped(proc.stderr),
+      proc.exited,
+    ]);
+
+    if (cause === "timeout") {
+      return { stdout, stderr, exitCode: 124, errorCode: "TIMEOUT" };
+    }
+    if (cause === "abort") {
+      return { stdout, stderr, exitCode: 130, errorCode: "ABORT_ERR" };
+    }
+    if (cause === "overflow") {
+      return { stdout, stderr, exitCode: 1, errorCode: "ERR_CHILD_PROCESS_STDIO_MAXBUFFER" };
+    }
+    if (proc.signalCode) {
+      // Terminated by an external signal: Node execFile surfaced this as a
+      // generic failure with no numeric exit code.
+      return { stdout, stderr, exitCode: 1 };
+    }
+    return { stdout, stderr, exitCode };
+  } finally {
+    if (timeoutTimer) clearTimeout(timeoutTimer);
+    opts.signal?.removeEventListener("abort", onAbort);
+  }
+}

--- a/src/utils/hash.ts
+++ b/src/utils/hash.ts
@@ -1,0 +1,19 @@
+/**
+ * Bun-native SHA-256 helpers for checksum/fingerprint sites in Bun-only code.
+ * Not for use in modules shared with the Electron main process or renderer.
+ */
+
+export function sha256Hex(data: string | Uint8Array | ArrayBuffer): string {
+  const hasher = new Bun.CryptoHasher("sha256");
+  hasher.update(data);
+  return hasher.digest("hex");
+}
+
+/** Streams the file through the hasher instead of buffering it in memory. */
+export async function sha256FileHex(filePath: string): Promise<string> {
+  const hasher = new Bun.CryptoHasher("sha256");
+  for await (const chunk of Bun.file(filePath).stream()) {
+    hasher.update(chunk);
+  }
+  return hasher.digest("hex");
+}

--- a/src/utils/oneOffChats.ts
+++ b/src/utils/oneOffChats.ts
@@ -1,4 +1,3 @@
-import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";

--- a/src/utils/ripgrep.ts
+++ b/src/utils/ripgrep.ts
@@ -1,10 +1,10 @@
-import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
 import { getAiCoworkerPaths } from "../connect";
 import { execFileCompat } from "./execFileCompat";
+import { sha256FileHex } from "./hash";
 
 export interface EnsureRipgrepOptions {
   homedir?: string;
@@ -147,10 +147,7 @@ async function _fetchToFile(url: string, filePath: string): Promise<void> {
   await fs.writeFile(filePath, buf);
 }
 
-async function sha256File(filePath: string): Promise<string> {
-  const buf = await fs.readFile(filePath);
-  return createHash("sha256").update(buf).digest("hex");
-}
+const sha256File = sha256FileHex;
 
 function parseSha256File(text: string): string | null {
   const m = text.match(/[0-9a-f]{64}/i);

--- a/src/utils/ripgrep.ts
+++ b/src/utils/ripgrep.ts
@@ -1,10 +1,10 @@
-import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
 import { getAiCoworkerPaths } from "../connect";
+import { execFileCompat } from "./execFileCompat";
 
 export interface EnsureRipgrepOptions {
   homedir?: string;
@@ -167,17 +167,15 @@ async function execFileOk(
   args: string[],
   opts: { cwd?: string } = {},
 ): Promise<void> {
-  await new Promise<void>((resolve, reject) => {
-    execFile(
-      command,
-      args,
-      { cwd: opts.cwd, windowsHide: true, maxBuffer: 1024 * 1024 * 10 },
-      (err) => {
-        if (err) return reject(err);
-        return resolve();
-      },
-    );
+  const result = await execFileCompat(command, args, {
+    ...(opts.cwd ? { cwd: opts.cwd } : {}),
+    maxBuffer: 1024 * 1024 * 10,
   });
+  if (result.exitCode !== 0 || result.errorCode) {
+    throw new Error(
+      `${command} ${args.join(" ")} failed (${result.errorCode ?? `exit ${result.exitCode}`}): ${result.stderr.trim()}`,
+    );
+  }
 }
 
 async function extractArchive(

--- a/src/utils/subprocess.ts
+++ b/src/utils/subprocess.ts
@@ -4,7 +4,7 @@
  * stderr, liveness checks, graceful kill escalation, stdin writes).
  */
 
-export type SubprocessExit = {
+type SubprocessExit = {
   exitCode: number | null;
   signalCode: string | null;
 };

--- a/src/utils/subprocess.ts
+++ b/src/utils/subprocess.ts
@@ -1,0 +1,140 @@
+/**
+ * Bun-native long-lived subprocess handle used by harness services that
+ * previously consumed Node's ChildProcess event API (line-oriented stdout and
+ * stderr, liveness checks, graceful kill escalation, stdin writes).
+ */
+
+export type SubprocessExit = {
+  exitCode: number | null;
+  signalCode: string | null;
+};
+
+export type StreamingSubprocess = {
+  pid: number | undefined;
+  readonly exitCode: number | null;
+  readonly signalCode: string | null;
+  /** Resolves once the process exits. Never rejects. */
+  readonly exited: Promise<SubprocessExit>;
+  stdout: ReadableStream<Uint8Array>;
+  stderr: ReadableStream<Uint8Array>;
+  kill(signal?: NodeJS.Signals | number): void;
+  /** Present when spawned with `stdin: "pipe"`. */
+  writeStdin?: (data: string | Uint8Array) => void;
+  endStdin?: () => void;
+};
+
+export type SpawnStreamingOptions = {
+  cwd?: string;
+  env?: Record<string, string | undefined>;
+  stdin?: "ignore" | "pipe";
+};
+
+/** Spawns a child with piped stdout/stderr. Throws on spawn failure (ENOENT). */
+export function spawnStreamingSubprocess(
+  cmd: string[],
+  opts: SpawnStreamingOptions = {},
+): StreamingSubprocess {
+  const stdinMode = opts.stdin ?? "ignore";
+  const proc = Bun.spawn(cmd, {
+    ...(opts.cwd ? { cwd: opts.cwd } : {}),
+    ...(opts.env ? { env: opts.env } : {}),
+    stdin: stdinMode,
+    stdout: "pipe",
+    stderr: "pipe",
+    windowsHide: true,
+  });
+
+  const exited: Promise<SubprocessExit> = proc.exited.then(
+    () => ({ exitCode: proc.exitCode, signalCode: proc.signalCode }),
+    () => ({ exitCode: proc.exitCode, signalCode: proc.signalCode }),
+  );
+
+  const handle: StreamingSubprocess = {
+    pid: proc.pid,
+    get exitCode() {
+      return proc.exitCode;
+    },
+    get signalCode() {
+      return proc.signalCode;
+    },
+    exited,
+    stdout: proc.stdout,
+    stderr: proc.stderr,
+    kill(signal?: NodeJS.Signals | number) {
+      try {
+        proc.kill(signal as never);
+      } catch {
+        // already exited
+      }
+    },
+  };
+
+  if (stdinMode === "pipe") {
+    const stdin = proc.stdin as unknown as {
+      write: (data: string | Uint8Array) => void;
+      end: () => void;
+    };
+    handle.writeStdin = (data) => {
+      stdin.write(data);
+    };
+    handle.endStdin = () => {
+      try {
+        stdin.end();
+      } catch {
+        // already closed
+      }
+    };
+  }
+
+  return handle;
+}
+
+export type LineSubscription = {
+  /** Stops reading. Safe to call multiple times. */
+  close(): void;
+  /** Resolves when the stream is fully drained or the subscription closes. */
+  done: Promise<void>;
+};
+
+/**
+ * Reads a byte stream as UTF-8 text lines (LF or CRLF) and invokes `onLine`
+ * for each complete line. A trailing unterminated line is flushed at EOF.
+ */
+export function subscribeLines(
+  stream: ReadableStream<Uint8Array>,
+  onLine: (line: string) => void,
+): LineSubscription {
+  const reader = stream.getReader();
+  let closed = false;
+
+  const done = (async () => {
+    const decoder = new TextDecoder();
+    let buffered = "";
+    try {
+      while (true) {
+        const { done: finished, value } = await reader.read();
+        if (finished) break;
+        buffered += decoder.decode(value, { stream: true });
+        let newlineIndex = buffered.indexOf("\n");
+        while (newlineIndex !== -1) {
+          const line = buffered.slice(0, newlineIndex).replace(/\r$/, "");
+          buffered = buffered.slice(newlineIndex + 1);
+          if (!closed) onLine(line);
+          newlineIndex = buffered.indexOf("\n");
+        }
+      }
+      buffered += decoder.decode();
+      if (buffered && !closed) onLine(buffered.replace(/\r$/, ""));
+    } catch {
+      // Reader cancelled or stream errored; treat as drained.
+    }
+  })();
+
+  return {
+    close() {
+      closed = true;
+      void reader.cancel().catch(() => {});
+    },
+    done,
+  };
+}

--- a/test/chaos/dbLock.chaos.test.ts
+++ b/test/chaos/dbLock.chaos.test.ts
@@ -36,7 +36,10 @@ async function waitFor(predicate: () => Promise<boolean>, timeoutMs = 2_000): Pr
 }
 
 /** Mirror of the db projection in ServerRuntime.getHealthSnapshot(). */
-function projectDbHealth(diagnostics: { maxWaitMs: number }, ok: boolean): {
+function projectDbHealth(
+  diagnostics: { maxWaitMs: number },
+  ok: boolean,
+): {
   ok: boolean;
   lockWaitMs?: number;
 } {
@@ -74,9 +77,9 @@ describe("chaos: session DB write-lock contention", () => {
       },
     });
 
-    await expect(
-      contender.runExclusive("contender", async () => "unreachable"),
-    ).rejects.toThrow(/Timed out acquiring session DB write lock/);
+    await expect(contender.runExclusive("contender", async () => "unreachable")).rejects.toThrow(
+      /Timed out acquiring session DB write lock/,
+    );
 
     const diagnostics = contender.getDiagnostics();
     expect(diagnostics.timeoutCount).toBe(1);
@@ -84,7 +87,10 @@ describe("chaos: session DB write-lock contention", () => {
     expect(diagnostics.maxWaitMs).toBeGreaterThanOrEqual(100);
 
     // The health endpoint surfaces the wait via db.lockWaitMs.
-    expect(projectDbHealth(diagnostics, true)).toEqual({ ok: true, lockWaitMs: diagnostics.maxWaitMs });
+    expect(projectDbHealth(diagnostics, true)).toEqual({
+      ok: true,
+      lockWaitMs: diagnostics.maxWaitMs,
+    });
 
     release();
     await holderPromise;

--- a/test/config/config.getModel.test.ts
+++ b/test/config/config.getModel.test.ts
@@ -66,8 +66,22 @@ describe("getModel", () => {
       env: { AGENT_PROVIDER: "google" },
     });
 
-    expect(() => getModel(cfg, "gemini-custom-override")).toThrow(
-      'Unsupported model override "gemini-custom-override" for provider google',
+    // Unknown ids pass through for dynamic model discovery.
+    expect(getModel(cfg, "gemini-custom-override")).toBeDefined();
+  });
+
+  test("model override registered to another provider is rejected with guidance", async () => {
+    const { cwd, home } = await makeTmpDirs();
+
+    const cfg = await loadConfig({
+      cwd,
+      homedir: home,
+      builtInDir: repoRoot(),
+      env: { AGENT_PROVIDER: "google" },
+    });
+
+    expect(() => getModel(cfg, "claude-sonnet-4-6")).toThrow(
+      'Unsupported model override "claude-sonnet-4-6" for provider google',
     );
   });
 

--- a/test/desktopSharedBunBoundary.test.ts
+++ b/test/desktopSharedBunBoundary.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Guardrail for the Bun-native migration (docs/bun-native-migration.md).
+ *
+ * Files under apps/desktop/electron/** run in Electron's MAIN process (Node
+ * runtime) and files under apps/desktop/src/** run in the renderer (Chromium).
+ * Both value-import modules from the repo root src/ tree. Those shared modules
+ * must never use `bun:` imports or `Bun.*` globals, or the desktop app breaks
+ * at runtime even though typecheck and Bun-based tests stay green.
+ *
+ * This test computes the transitive closure of root-src value imports from
+ * both desktop surfaces and rejects any Bun-only API usage inside it.
+ */
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const srcRoot = path.join(repoRoot, "src");
+
+const IMPORT_PATTERN =
+  /(?:import|export)\s+(type\s+)?[^"']*?from\s+["']([^"']+)["']|import\s*\(\s*["']([^"']+)["']\s*\)|require\s*\(\s*["']([^"']+)["']\s*\)|import\s+["']([^"']+)["']/g;
+
+type ImportRef = { specifier: string; typeOnly: boolean };
+
+function parseImports(source: string): ImportRef[] {
+  const refs: ImportRef[] = [];
+  for (const match of source.matchAll(IMPORT_PATTERN)) {
+    const specifier = match[2] ?? match[3] ?? match[4] ?? match[5];
+    if (!specifier) continue;
+    refs.push({ specifier, typeOnly: Boolean(match[1]) });
+  }
+  return refs;
+}
+
+function resolveModuleFile(baseDir: string, specifier: string): string | null {
+  const raw = specifier.startsWith("@cowork/")
+    ? path.join(srcRoot, specifier.slice("@cowork/".length))
+    : path.resolve(baseDir, specifier);
+  const candidates = [
+    raw,
+    `${raw}.ts`,
+    `${raw}.tsx`,
+    path.join(raw, "index.ts"),
+    path.join(raw, "index.tsx"),
+  ];
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+function isRootSrcFile(filePath: string): boolean {
+  return filePath.startsWith(`${srcRoot}${path.sep}`);
+}
+
+function listTsFiles(dir: string): string[] {
+  const glob = new Bun.Glob("**/*.{ts,tsx}");
+  return [...glob.scanSync({ cwd: dir, absolute: true })];
+}
+
+function collectSharedClosure(entryDirs: string[]): Map<string, string[]> {
+  // shared root-src file -> import chain (for diagnostics)
+  const closure = new Map<string, string[]>();
+  const queue: Array<{ file: string; chain: string[] }> = [];
+
+  for (const dir of entryDirs) {
+    for (const file of listTsFiles(dir)) {
+      const source = fs.readFileSync(file, "utf-8");
+      for (const ref of parseImports(source)) {
+        if (ref.typeOnly) continue;
+        if (!ref.specifier.startsWith(".") && !ref.specifier.startsWith("@cowork/")) continue;
+        const resolved = resolveModuleFile(path.dirname(file), ref.specifier);
+        if (!resolved || !isRootSrcFile(resolved)) continue;
+        if (!closure.has(resolved)) {
+          const chain = [path.relative(repoRoot, file)];
+          closure.set(resolved, chain);
+          queue.push({ file: resolved, chain });
+        }
+      }
+    }
+  }
+
+  while (queue.length > 0) {
+    const item = queue.shift();
+    if (!item) break;
+    const source = fs.readFileSync(item.file, "utf-8");
+    for (const ref of parseImports(source)) {
+      if (ref.typeOnly) continue;
+      if (!ref.specifier.startsWith(".")) continue;
+      const resolved = resolveModuleFile(path.dirname(item.file), ref.specifier);
+      if (!resolved || !isRootSrcFile(resolved)) continue;
+      if (closure.has(resolved)) continue;
+      const chain = [...item.chain, path.relative(repoRoot, item.file)];
+      closure.set(resolved, chain);
+      queue.push({ file: resolved, chain });
+    }
+  }
+
+  return closure;
+}
+
+function findBunUsage(filePath: string): string[] {
+  const source = fs.readFileSync(filePath, "utf-8");
+  const violations: string[] = [];
+  const lines = source.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? "";
+    if (/from\s+["']bun(:[a-z]+)?["']/.test(line) || /import\s*\(\s*["']bun:/.test(line)) {
+      violations.push(`line ${i + 1}: ${line.trim()}`);
+      continue;
+    }
+    if (/\bBun\.[a-zA-Z$_]/.test(line)) {
+      violations.push(`line ${i + 1}: ${line.trim()}`);
+    }
+  }
+  return violations;
+}
+
+function formatViolations(closure: Map<string, string[]>): string[] {
+  const problems: string[] = [];
+  for (const [file, chain] of closure) {
+    const violations = findBunUsage(file);
+    if (violations.length === 0) continue;
+    problems.push(
+      `${path.relative(repoRoot, file)} (reached via ${chain.join(" -> ")}):\n  ${violations.join("\n  ")}`,
+    );
+  }
+  return problems;
+}
+
+describe("desktop shared module Bun boundary", () => {
+  test("root src modules value-imported by Electron main/preload never use Bun APIs", () => {
+    const closure = collectSharedClosure([path.join(repoRoot, "apps", "desktop", "electron")]);
+    expect(closure.size).toBeGreaterThan(0);
+    expect(formatViolations(closure)).toEqual([]);
+  });
+
+  test("root src modules value-imported by the desktop renderer never use Bun APIs", () => {
+    const closure = collectSharedClosure([path.join(repoRoot, "apps", "desktop", "src")]);
+    expect(closure.size).toBeGreaterThan(0);
+    expect(formatViolations(closure)).toEqual([]);
+  });
+});

--- a/test/execFileCompat.test.ts
+++ b/test/execFileCompat.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "bun:test";
+
+import { execFileCompat } from "../src/utils/execFileCompat";
+
+const isWindows = process.platform === "win32";
+const sh = (script: string): [string, string[]] =>
+  isWindows ? ["cmd", ["/c", script]] : ["sh", ["-c", script]];
+
+describe("execFileCompat", () => {
+  test("captures stdout, stderr and the exit code", async () => {
+    const [file, args] = sh("echo out; echo err 1>&2; exit 3");
+    const result = await execFileCompat(file, args);
+    expect(result.stdout.trim()).toBe("out");
+    expect(result.stderr.trim()).toBe("err");
+    expect(result.exitCode).toBe(3);
+    expect(result.errorCode).toBeUndefined();
+  });
+
+  test("exit code zero for successful commands", async () => {
+    const [file, args] = sh("echo ok");
+    const result = await execFileCompat(file, args);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe("ok");
+  });
+
+  test("missing executables map to ENOENT with exit 1", async () => {
+    const result = await execFileCompat("definitely-not-a-real-binary-xyz", []);
+    expect(result.errorCode).toBe("ENOENT");
+    expect(result.exitCode).toBe(1);
+  });
+
+  test("timeout terminates the child and maps to exit 124 / TIMEOUT", async () => {
+    const [file, args] = sh("echo before; sleep 5; echo after");
+    const started = Date.now();
+    const result = await execFileCompat(file, args, { timeoutMs: 250 });
+    expect(Date.now() - started).toBeLessThan(4000);
+    expect(result.exitCode).toBe(124);
+    expect(result.errorCode).toBe("TIMEOUT");
+    expect(result.stdout).toContain("before");
+    expect(result.stdout).not.toContain("after");
+  });
+
+  test("abort maps to exit 130 / ABORT_ERR", async () => {
+    const [file, args] = sh("sleep 5");
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(), 100);
+    const started = Date.now();
+    const result = await execFileCompat(file, args, { signal: controller.signal });
+    expect(Date.now() - started).toBeLessThan(4000);
+    expect(result.exitCode).toBe(130);
+    expect(result.errorCode).toBe("ABORT_ERR");
+  });
+
+  test("already-aborted signals resolve immediately", async () => {
+    const [file, args] = sh("sleep 5");
+    const controller = new AbortController();
+    controller.abort();
+    const started = Date.now();
+    const result = await execFileCompat(file, args, { signal: controller.signal });
+    expect(Date.now() - started).toBeLessThan(2000);
+    expect(result.exitCode).toBe(130);
+    expect(result.errorCode).toBe("ABORT_ERR");
+  });
+
+  test("stdout larger than maxBuffer is truncated and flagged", async () => {
+    const [file, args] = sh('yes "0123456789abcdef" 2>/dev/null | head -c 300000');
+    const result = await execFileCompat(file, args, { maxBuffer: 64 * 1024 });
+    expect(result.errorCode).toBe("ERR_CHILD_PROCESS_STDIO_MAXBUFFER");
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout.length).toBeLessThanOrEqual(64 * 1024);
+  });
+
+  test("env replaces the child environment entirely", async () => {
+    const [file, args] = sh("echo $COMPAT_ONLY:$HOME_SENTINEL");
+    const result = await execFileCompat(file, args, {
+      env: { COMPAT_ONLY: "yes", PATH: process.env.PATH ?? "" },
+    });
+    expect(result.stdout.trim()).toBe("yes:");
+  });
+
+  test("cwd is honored", async () => {
+    const [file, args] = isWindows ? ["cmd", ["/c", "cd"]] : ["pwd", []];
+    const result = await execFileCompat(file, args, { cwd: "/tmp" });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim().length).toBeGreaterThan(0);
+  });
+
+  test("timeout wins over a later abort for the error code", async () => {
+    const [file, args] = sh("sleep 5");
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(), 400);
+    const result = await execFileCompat(file, args, {
+      timeoutMs: 100,
+      signal: controller.signal,
+    });
+    expect(result.exitCode).toBe(124);
+    expect(result.errorCode).toBe("TIMEOUT");
+  });
+});

--- a/test/hash.test.ts
+++ b/test/hash.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { sha256FileHex, sha256Hex } from "../src/utils/hash";
+
+describe("sha256 helpers", () => {
+  test("sha256Hex matches node:crypto for strings and bytes", () => {
+    expect(sha256Hex("hello world")).toBe(createHash("sha256").update("hello world").digest("hex"));
+    const bytes = new Uint8Array([0, 1, 2, 250, 251, 252]);
+    expect(sha256Hex(bytes)).toBe(createHash("sha256").update(bytes).digest("hex"));
+  });
+
+  test("sha256FileHex streams files and matches node:crypto", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "cowork-hash-"));
+    const file = path.join(dir, "payload.bin");
+    const payload = new Uint8Array(1024 * 1024);
+    for (let i = 0; i < payload.length; i++) payload[i] = i % 256;
+    await fs.writeFile(file, payload);
+    try {
+      expect(await sha256FileHex(file)).toBe(createHash("sha256").update(payload).digest("hex"));
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/mcp.oauth-provider.test.ts
+++ b/test/mcp.oauth-provider.test.ts
@@ -171,6 +171,35 @@ describe("mcp oauth provider", () => {
     expect(consumed).toBe("captured-code");
   });
 
+  test("auto oauth advertises a 127.0.0.1 redirect URI and answers on ::1 too", async () => {
+    registrationCount = 0;
+    lastRegistrationRequest = undefined;
+    const server = makeOAuthServer({
+      transport: { type: "http", url: `${tokenServerUrl}/mcp` },
+      auth: { type: "oauth", oauthMode: "auto", scope: "tools.read" },
+    });
+    const result = await authorizeMCPServerOAuth(server, undefined, {
+      openUrl: async () => true,
+    });
+
+    // The advertised redirect URI is pinned to the IdP-registered IPv4 host.
+    const advertised = new URL(result.pending.redirectUri);
+    expect(advertised.hostname).toBe("127.0.0.1");
+    expect(advertised.pathname).toBe("/oauth/callback");
+
+    // But browsers resolving loopback to ::1 must still reach the listener.
+    const ipv6Url = new URL(result.pending.redirectUri);
+    ipv6Url.hostname = "[::1]";
+    ipv6Url.searchParams.set("state", result.pending.state);
+    ipv6Url.searchParams.set("code", "captured-over-ipv6");
+
+    const response = await fetch(ipv6Url.toString());
+    expect(response.status).toBe(200);
+
+    const consumed = await consumeCapturedOAuthCode(result.pending.challengeId);
+    expect(consumed).toBe("captured-over-ipv6");
+  });
+
   test("authorizeMCPServerOAuth re-registers when stored client redirect URIs do not match the current auto callback", async () => {
     registrationCount = 0;
     lastRegistrationRequest = undefined;

--- a/test/package-manifest.test.ts
+++ b/test/package-manifest.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, test } from "bun:test";
 import { existsSync, readFileSync, statSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import fg from "fast-glob";
 
 const repoRoot = fileURLToPath(new URL("..", import.meta.url));
 
@@ -38,13 +37,16 @@ function dryRunPackPaths(): string[] {
     .map((pattern) => pattern.slice(1))
     .flatMap((pattern) => patternToFileGlob(pattern));
 
-  return fg.sync(includePatterns, {
-    cwd: repoRoot,
-    dot: true,
-    onlyFiles: true,
-    unique: true,
-    ignore: ignorePatterns,
-  });
+  const ignoreMatchers = ignorePatterns.map((pattern) => new Bun.Glob(pattern));
+  const unique = new Set<string>();
+  for (const pattern of includePatterns) {
+    const glob = new Bun.Glob(pattern);
+    for (const file of glob.scanSync({ cwd: repoRoot, dot: true })) {
+      if (ignoreMatchers.some((matcher) => matcher.match(file))) continue;
+      unique.add(file);
+    }
+  }
+  return [...unique];
 }
 
 describe("package manifest", () => {

--- a/test/providers/codex-app-server-client.test.ts
+++ b/test/providers/codex-app-server-client.test.ts
@@ -170,11 +170,8 @@ setInterval(() => {}, 1000);
     const rawMessages: unknown[] = [];
     const calls: string[] = [];
     const child = {
-      stdin: {
-        write: (value: string) => {
-          writes.push(value);
-          return true;
-        },
+      writeStdin: (value: string | Uint8Array) => {
+        writes.push(String(value));
       },
     } as Parameters<typeof __internal.respondToServerRequest>[0];
     const handlers: Parameters<typeof __internal.respondToServerRequest>[2] = new Set([

--- a/test/providers/connection-catalog.test.ts
+++ b/test/providers/connection-catalog.test.ts
@@ -708,6 +708,8 @@ describe("providers/connectionCatalog", () => {
   test("connected providers exclude oauth_pending entries", async () => {
     const payload = await getProviderCatalog({
       readCodexAppServerAccountImpl: noCodexAccount,
+      // Pin env so ambient provider API keys can't mark providers connected.
+      env: {},
       readStore: async () => ({
         version: 1,
         updatedAt: "2026-02-17T00:00:00.000Z",

--- a/test/server.jsonrpc.test.ts
+++ b/test/server.jsonrpc.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, test } from "bun:test";
 import fs from "node:fs/promises";
 import net from "node:net";
 import path from "node:path";
-import { WebSocket as NodeWebSocket } from "ws";
 
 import { startAgentServer } from "../src/server/startServer";
 import { makeTmpProject, serverOpts, stopTestServer } from "./helpers/wsHarness";
@@ -31,40 +30,6 @@ async function expectWorkspaceListResponse(response: Response, tmpDir: string): 
   expect(body.workspaces).toHaveLength(1);
   expect(body.workspaces[0]?.name).toBe(path.basename(tmpDir));
   expect(await fs.realpath(body.workspaces[0]?.path ?? "")).toBe(await fs.realpath(tmpDir));
-}
-
-function waitForNodeWsOpen(ws: NodeWebSocket): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const timer = setTimeout(
-      () => reject(new Error("Timed out waiting for websocket open")),
-      5_000,
-    );
-    ws.once("open", () => {
-      clearTimeout(timer);
-      resolve();
-    });
-    ws.once("error", (error) => {
-      clearTimeout(timer);
-      reject(error);
-    });
-  });
-}
-
-function waitForNodeWsJson(ws: NodeWebSocket): Promise<any> {
-  return new Promise((resolve, reject) => {
-    const timer = setTimeout(
-      () => reject(new Error("Timed out waiting for websocket message")),
-      5_000,
-    );
-    ws.once("message", (data) => {
-      clearTimeout(timer);
-      resolve(JSON.parse(typeof data === "string" ? data : data.toString("utf8")));
-    });
-    ws.once("error", (error) => {
-      clearTimeout(timer);
-      reject(error);
-    });
-  });
 }
 
 function waitForSingleMessage(ws: WebSocket): Promise<any> {
@@ -454,8 +419,8 @@ describe("server JSON-RPC websocket mode", () => {
     const { server, url } = await startAgentServer(serverOpts(tmpDir));
 
     try {
-      const ws = new NodeWebSocket(url, ["cowork.jsonrpc.v1", "foo"]);
-      await waitForNodeWsOpen(ws);
+      const ws = new WebSocket(url, ["cowork.jsonrpc.v1", "foo"]);
+      await waitForOpen(ws);
       expect(ws.protocol).toBe("cowork.jsonrpc.v1");
 
       ws.send(
@@ -469,7 +434,7 @@ describe("server JSON-RPC websocket mode", () => {
           },
         }),
       );
-      const response = await waitForNodeWsJson(ws);
+      const response = await waitForSingleMessage(ws);
       expect(response.id).toBe(1);
       expect(response.result.serverInfo.subprotocol).toBe("cowork.jsonrpc.v1");
       ws.close();

--- a/test/tools/tools.grep.test.ts
+++ b/test/tools/tools.grep.test.ts
@@ -45,9 +45,9 @@ describe("grep tool", () => {
     return new RegExp(re);
   }
 
-  const fakeExecFile: any = (_cmd: string, args: string[], _opts: any, cb: any) => {
-    void (async () => {
-      try {
+  const fakeExecFile: any = async (_cmd: string, args: string[], _opts: any) => {
+    try {
+      {
         let caseInsensitive = false;
         let contextLines = 0;
         const includeGlobs: string[] = [];
@@ -136,17 +136,14 @@ describe("grep tool", () => {
         }
 
         if (outLines.length === 0) {
-          const err: any = new Error("no matches");
-          err.code = 1;
-          cb(err, "", "");
-          return;
+          return { stdout: "", stderr: "", exitCode: 1 };
         }
 
-        cb(null, outLines.join("\n") + "\n", "");
-      } catch (err) {
-        cb(err, "", "");
+        return { stdout: outLines.join("\n") + "\n", stderr: "", exitCode: 0 };
       }
-    })();
+    } catch (err) {
+      return { stdout: "", stderr: String(err), exitCode: 2 };
+    }
   };
 
   test("returns matches for pattern", async () => {
@@ -391,11 +388,11 @@ describe("grep tool", () => {
     let capturedCmd = "";
     let capturedArgs: string[] = [];
 
-    const argCaptureExecFile: any = (cmd: string, args: string[], _opts: any, cb: any) => {
+    const argCaptureExecFile: any = async (cmd: string, args: string[], _opts: any) => {
       capturedCmd = cmd;
       capturedArgs = [...args];
       // Simulate rg producing output so the tool returns normally
-      cb(null, `${path.join(dir, "file.ts")}:1:match\n`, "");
+      return { stdout: `${path.join(dir, "file.ts")}:1:match\n`, stderr: "", exitCode: 0 };
     };
 
     const t: any = createGrepTool(makeCtx(dir), {
@@ -433,9 +430,9 @@ describe("grep tool", () => {
     const controller = new AbortController();
     let capturedOpts: any;
 
-    const argCaptureExecFile: any = (_cmd: string, _args: string[], opts: any, cb: any) => {
+    const argCaptureExecFile: any = async (_cmd: string, _args: string[], opts: any) => {
       capturedOpts = opts;
-      cb(null, "match\n", "");
+      return { stdout: "match\n", stderr: "", exitCode: 0 };
     };
 
     const t: any = createGrepTool(makeCtx(dir, { abortSignal: controller.signal }), {
@@ -450,17 +447,13 @@ describe("grep tool", () => {
     });
 
     expect(capturedOpts.signal).toBe(controller.signal);
-    expect(capturedOpts.timeout).toBe(7000);
-    expect(capturedOpts.killSignal).toBe("SIGTERM");
+    expect(capturedOpts.timeoutMs).toBe(7000);
   });
 
   test("returns an aborted message when ripgrep is cancelled", async () => {
     const dir = await tmpDir();
-    const abortingExecFile: any = (_cmd: string, _args: string[], _opts: any, cb: any) => {
-      const err: any = new Error("aborted");
-      err.name = "AbortError";
-      err.code = "ABORT_ERR";
-      cb(err, "", "");
+    const abortingExecFile: any = async (_cmd: string, _args: string[], _opts: any) => {
+      return { stdout: "", stderr: "", exitCode: 130, errorCode: "ABORT_ERR" };
     };
 
     const t: any = createGrepTool(makeCtx(dir), {
@@ -474,8 +467,8 @@ describe("grep tool", () => {
 
   test("includes ripgrep stderr diagnostics on failures", async () => {
     const dir = await tmpDir();
-    const failingExecFile: any = (_cmd: string, _args: string[], _opts: any, cb: any) => {
-      cb(new Error("Command failed"), "", "regex parse error: missing ]");
+    const failingExecFile: any = async (_cmd: string, _args: string[], _opts: any) => {
+      return { stdout: "", stderr: "regex parse error: missing ]", exitCode: 2 };
     };
 
     const t: any = createGrepTool(makeCtx(dir), {
@@ -505,9 +498,9 @@ describe("grep tool", () => {
 
     let capturedArgs: string[] = [];
 
-    const argCaptureExecFile: any = (cmd: string, args: string[], _opts: any, cb: any) => {
+    const argCaptureExecFile: any = async (_cmd: string, args: string[], _opts: any) => {
       capturedArgs = [...args];
-      cb(null, `${path.join(dir, "file.txt")}:1:data\n`, "");
+      return { stdout: `${path.join(dir, "file.txt")}:1:data\n`, stderr: "", exitCode: 0 };
     };
 
     const t: any = createGrepTool(makeCtx(dir), {
@@ -534,9 +527,13 @@ describe("grep tool", () => {
     await fs.writeFile(path.join(dir, "flags.txt"), "--files-with-matches\n", "utf-8");
 
     let capturedArgs: string[] = [];
-    const argCaptureExecFile: any = (_cmd: string, args: string[], _opts: any, cb: any) => {
+    const argCaptureExecFile: any = async (_cmd: string, args: string[], _opts: any) => {
       capturedArgs = [...args];
-      cb(null, `${path.join(dir, "flags.txt")}:1:--files-with-matches\n`, "");
+      return {
+        stdout: `${path.join(dir, "flags.txt")}:1:--files-with-matches\n`,
+        stderr: "",
+        exitCode: 0,
+      };
     };
 
     const t: any = createGrepTool(makeCtx(dir), {

--- a/test/webDesktopRoutes.test.ts
+++ b/test/webDesktopRoutes.test.ts
@@ -1,9 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { EventEmitter } from "node:events";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { PassThrough } from "node:stream";
 import { handleWebDesktopRoute } from "../src/server/webDesktopRoutes";
 import { __internal, WebDesktopService } from "../src/server/webDesktopService";
 import { getOneOffChatsRoot } from "../src/utils/oneOffChats";
@@ -31,13 +29,50 @@ async function waitForCondition(predicate: () => boolean, timeoutMs = 1_000): Pr
   throw new Error("Timed out waiting for condition");
 }
 
-function createMockWorkspaceChild() {
-  return Object.assign(new EventEmitter(), {
-    stdout: new PassThrough(),
-    stderr: new PassThrough(),
-    exitCode: null,
-    signalCode: null,
+function createMockStream() {
+  let controller!: ReadableStreamDefaultController<Uint8Array>;
+  const stream = new ReadableStream<Uint8Array>({
+    start(c) {
+      controller = c;
+    },
   });
+  const encoder = new TextEncoder();
+  return {
+    stream,
+    write(text: string) {
+      controller.enqueue(encoder.encode(text));
+    },
+    end() {
+      controller.close();
+    },
+  };
+}
+
+function createMockWorkspaceChild() {
+  const stdout = createMockStream();
+  const stderr = createMockStream();
+  let resolveExited!: (value: { exitCode: number | null; signalCode: string | null }) => void;
+  const exited = new Promise<{ exitCode: number | null; signalCode: string | null }>((resolve) => {
+    resolveExited = resolve;
+  });
+  return {
+    pid: 1,
+    exitCode: null as number | null,
+    signalCode: null as string | null,
+    exited,
+    stdout: stdout.stream,
+    stderr: stderr.stream,
+    kill() {},
+    writeStdout: stdout.write,
+    endStdout: stdout.end,
+    writeStderr: stderr.write,
+    endStderr: stderr.end,
+    emitExit(exitCode: number | null, signalCode: string | null) {
+      this.exitCode = exitCode;
+      this.signalCode = signalCode;
+      resolveExited({ exitCode, signalCode });
+    },
+  };
 }
 
 afterEach(async () => {
@@ -506,9 +541,8 @@ describe("web desktop routes", () => {
         __id: id,
         exitCode: null,
         signalCode: null,
-        once() {
-          return this;
-        },
+        exited: new Promise(() => {}),
+        kill() {},
       } as any;
     }
 
@@ -640,21 +674,22 @@ describe("web desktop routes", () => {
       seenLines.push({ source, line });
     });
 
-    child.stdout.write('{"type":"server_listening","url":"ws://127.0.0.1:7337/ws"}\n');
+    child.writeStdout('{"type":"server_listening","url":"ws://127.0.0.1:7337/ws"}\n');
     await expect(monitor.ready).resolves.toEqual({ url: "ws://127.0.0.1:7337/ws" });
 
-    child.stdout.write("stdout after ready\n");
-    child.stderr.write("stderr after ready\n");
-    await Bun.sleep(0);
+    child.writeStdout("stdout after ready\n");
+    await waitForCondition(() => seenLines.length >= 1);
+    child.writeStderr("stderr after ready\n");
+    await waitForCondition(() => seenLines.length >= 2);
 
     expect(seenLines).toEqual([
       { source: "stdout", line: "stdout after ready" },
       { source: "stderr", line: "stderr after ready" },
     ]);
 
-    child.stdout.end();
-    child.stderr.end();
-    child.emit("exit", 0, null);
+    child.endStdout();
+    child.endStderr();
+    child.emitExit(0, null);
     await expect(monitor.drained).resolves.toBeUndefined();
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What / Why

Implements the Bun-native migration end-to-end, plus fixes for every failure surfaced along the way. `docs/bun-native-migration.md` is the system-of-record (audit, phase status, deferred follow-ups, keep-on-Node register).

### Migration (Phases 0–6)

- **Phase 0**: `test/desktopSharedBunBoundary.test.ts` — computes the Electron-main/renderer value-import closures of root `src/` and fails on any `bun:`/`Bun.*` usage inside them (canary-verified).
- **Phase 1**: global Web Crypto replaces `node:crypto` `randomUUID`/`randomBytes` imports (7 files); `Bun.spawn` in `scripts/` and the stable test runner; `Bun.Glob` replaces `fast-glob` in the harness runner and manifest test (verified byte-identical file sets, 544 files).
- **Phase 2**: MCP OAuth callback listener on `Bun.serve`, bound to `127.0.0.1` + best-effort `::1` on the same port per the OAuth loopback rule, redirect URI pinned to `127.0.0.1`, with an IPv6 coverage test.
- **Phase 3**: `src/utils/execFileCompat.ts` (Bun.spawn with the Node `execFile` contract: per-stream `maxBuffer`, timeout→SIGTERM→exit 124, AbortSignal→exit 130, ENOENT result codes, pipe teardown on kill so grandchildren can't wedge reads) + a 10-case parity suite; migrated `bash`/`grep` tools (tool-facing messages byte-identical, verified end-to-end against real shells and real ripgrep), `ripgrep.ts`, `coworkRuntime/runtime.ts`. Streaming consumers moved to `src/utils/subprocess.ts` (`spawnStreamingSubprocess` + `subscribeLines`): `sessionBackup/command.ts`, `libreOffice.ts` (adds a 4 MiB output cap), `webDesktopService.ts`.
- **Phase 4**: `Bun.file` reads on hot paths (edit/read tools, prompt templates, skill catalog/bodies, config layers, session snapshots, memory/MCP-auth/CLI-state stores) and `Bun.write` in the edit tool. Atomic tmp+rename writes, chmod hardening, streams, and `fs.watch` deliberately stay on `node:fs`.
- **Phase 5**: codex app-server client/resolver on the streaming subprocess handle (NDJSON via `subscribeLines`, stdin via Bun `FileSink`, SIGTERM→SIGKILL escalation preserved), verified against the real mock app-server integration test.
- **Phase 6**: `src/utils/hash.ts` (`Bun.CryptoHasher`, streaming file sha256) for ripgrep/codex checksums; root test suite no longer needs the `ws` package (Bun's WebSocket client negotiates multi-protocol offers natively).

### Fixes for surfaced failures

- **Red `main` CI (11 tests)**: the provider model discovery cache commit made every provider pass unknown model ids through, breaking config resilience, selection validation, persisted-session migration, and child model routing. Restored a coherent contract: sync paths keep discovery passthrough but reject ids provably registered to another provider family; async selection paths are strict (static registry ∪ on-disk discovery cache); config load falls back to the provider default with a warning again; persisted sessions migrate unsupported/aliased ids for static-catalog providers while lmstudio/bedrock/codex-cli stay passthrough. `gemini-*` joins the provider-mismatch heuristic.
- **Desktop test-order pollution (4 tests)**: cross-file `mock.module("desktopCommands")` leakage; the skill/plugin action harness now pins its own bridge-unavailable mock.
- **Biome**: import-sort/format errors fixed repo-wide; `bun run check` is clean (2 pre-existing size warnings on generated docs files remain, non-failing).
- **Env-dependent test**: `connection-catalog` oauth_pending test pins `env` so ambient provider API keys can't flip providers to connected.

## How to test

- `bun run test:stable --max-concurrency 1` — all 546 per-file batches pass (CI lane)
- `bun test` — 5728 pass / 0 fail / 26 network-gated skips
- `bun run typecheck`, `bun run lint`, `bun run check`, `bun run docs:check` — clean
- Live smoke: `bun run serve` + `examples/ws-jsonrpc-smoke.ts` — initialize/thread round-trip over the WebSocket server works (exercises Bun.file prompt/config loading end-to-end)
- Real-process verification: bash tool (echo/exit-code/timeout→exit 124 with legacy message), grep tool against real ripgrep (match/no-match/abort), codex mock app-server JSON-RPC over stdio

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7329417c-f1e5-4910-bda0-1d78a3a1b838"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7329417c-f1e5-4910-bda0-1d78a3a1b838"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

