### PR TITLE
fix(composer): persist revision-safe per-chat drafts

### DIFF
--- a/apps/desktop/electron/services/persistence.ts
+++ b/apps/desktop/electron/services/persistence.ts
@@ -9,6 +9,7 @@ import {
   isPathInsideOneOffChatsRoot,
   normalizeWorkspaceKind,
 } from "../../../../src/utils/oneOffChats";
+import { sanitizePersistedComposerDrafts } from "../../src/app/composerDrafts";
 import { normalizeWorkspaceProviderOptions } from "../../src/app/openaiCompatibleProviderOptions";
 import { normalizePersistedProviderState } from "../../src/app/persistedProviderState";
 import {
@@ -426,6 +427,7 @@ async function sanitizePersistedState(value: unknown): Promise<PersistedState> {
     ...(providerState ? { providerState } : {}),
     providerUiState,
     ...(onboarding ? { onboarding } : {}),
+    composerDrafts: sanitizePersistedComposerDrafts(value.composerDrafts),
   };
 }
 

--- a/apps/desktop/src/app/composerDrafts.ts
+++ b/apps/desktop/src/app/composerDrafts.ts
@@ -1,0 +1,500 @@
+import { type NewChatLandingTarget, resolveNewChatLandingTarget } from "../lib/newChatLanding";
+import type { TurnReference } from "../lib/wsProtocol";
+import { PROVIDER_NAMES, type ProviderName } from "../lib/wsProtocol";
+import type { ReasoningEffortValue } from "./openaiCompatibleProviderOptions";
+import type { WorkspaceRecord } from "./types";
+
+const BASE64_BINARY_CHUNK_SIZE = 0x8000;
+const COMPOSER_DRAFT_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1_000;
+const REASONING_EFFORT_VALUES = new Set([
+  "none",
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "dynamic",
+]);
+
+export const MAX_COMPOSER_DRAFTS = 50;
+
+export type ComposerDraftAttachment = {
+  filename: string;
+  mimeType: string;
+  size: number;
+  lastModified: number;
+  file: File;
+  previewUrl?: string;
+  signature: string;
+  contentBase64: string;
+};
+
+export type ComposerDraft = {
+  revision: number;
+  generation: number;
+  updatedAt: string;
+  text: string;
+  attachments: ComposerDraftAttachment[];
+  references: TurnReference[];
+  provider: ProviderName | null;
+  model: string | null;
+  reasoningEffort: ReasoningEffortValue | null;
+};
+
+export type ComposerDraftsByKey = Record<string, ComposerDraft>;
+
+export type ComposerDraftRevision = {
+  key: string;
+  revision: number;
+};
+
+export type PersistedComposerDraftAttachment = Omit<ComposerDraftAttachment, "file" | "previewUrl">;
+
+export type PersistedComposerDraft = Omit<ComposerDraft, "attachments"> & {
+  attachments: PersistedComposerDraftAttachment[];
+};
+
+export type PersistedComposerDrafts = Record<string, PersistedComposerDraft>;
+
+export const EMPTY_COMPOSER_DRAFT: Readonly<ComposerDraft> = Object.freeze(
+  createEmptyComposerDraft(new Date(0).toISOString()),
+);
+
+type ObjectUrlOptions = {
+  createObjectURL?: (blob: Blob) => string;
+};
+
+type PruneComposerDraftOptions = {
+  nowMs?: number;
+  validThreadIds: ReadonlySet<string>;
+  validProjectWorkspaceIds: ReadonlySet<string>;
+  activeKey?: string | null;
+  maxDrafts?: number;
+  maxAgeMs?: number;
+};
+
+export function composerDraftKeyForThread(threadId: string): string {
+  return `thread:${threadId}`;
+}
+
+export function composerDraftKeyForNewChatTarget(target: NewChatLandingTarget): string {
+  return target.kind === "oneOff" ? "new:oneOff" : `new:project:${target.workspaceId}`;
+}
+
+export function resolveActiveComposerDraftKey(state: {
+  selectedThreadId: string | null;
+  newChatLandingTarget: NewChatLandingTarget | null;
+  workspaces: WorkspaceRecord[];
+  selectedWorkspaceId: string | null;
+}): string {
+  if (state.selectedThreadId) return composerDraftKeyForThread(state.selectedThreadId);
+  return composerDraftKeyForNewChatTarget(
+    resolveNewChatLandingTarget(
+      state.newChatLandingTarget,
+      state.workspaces,
+      state.selectedWorkspaceId,
+    ),
+  );
+}
+
+export function selectActiveComposerDraft(state: {
+  selectedThreadId: string | null;
+  newChatLandingTarget: NewChatLandingTarget | null;
+  workspaces: WorkspaceRecord[];
+  selectedWorkspaceId: string | null;
+  composerDraftsByKey: ComposerDraftsByKey;
+}): Readonly<ComposerDraft> {
+  return state.composerDraftsByKey[resolveActiveComposerDraftKey(state)] ?? EMPTY_COMPOSER_DRAFT;
+}
+
+export function createEmptyComposerDraft(updatedAt = new Date().toISOString()): ComposerDraft {
+  return {
+    revision: 0,
+    generation: 0,
+    updatedAt,
+    text: "",
+    attachments: [],
+    references: [],
+    provider: null,
+    model: null,
+    reasoningEffort: null,
+  };
+}
+
+export async function createComposerDraftAttachment(
+  file: File,
+  options: ObjectUrlOptions = {},
+): Promise<ComposerDraftAttachment> {
+  const contentBase64 = encodeArrayBufferToBase64(await file.arrayBuffer());
+  const createObjectURL = options.createObjectURL ?? defaultCreateObjectURL;
+  const previewUrl =
+    file.type.startsWith("image/") && file instanceof Blob ? createObjectURL(file) : undefined;
+  return {
+    filename: file.name,
+    mimeType: file.type || "application/octet-stream",
+    size: file.size,
+    lastModified: file.lastModified,
+    file,
+    previewUrl,
+    signature: `${file.name}\u0000${file.type}\u0000${file.size}\u0000${file.lastModified}`,
+    contentBase64,
+  };
+}
+
+export function serializeComposerDrafts(drafts: ComposerDraftsByKey): PersistedComposerDrafts {
+  return Object.fromEntries(
+    Object.entries(drafts)
+      .filter(([, draft]) => hasComposerDraftState(draft))
+      .map(([key, draft]) => [
+        key,
+        {
+          revision: draft.revision,
+          generation: draft.generation,
+          updatedAt: draft.updatedAt,
+          text: draft.text,
+          attachments: draft.attachments.map(
+            ({ filename, mimeType, size, lastModified, signature, contentBase64 }) => ({
+              filename,
+              mimeType,
+              size,
+              lastModified,
+              signature,
+              contentBase64,
+            }),
+          ),
+          references: draft.references.map((reference) => ({ ...reference })),
+          provider: draft.provider,
+          model: draft.model,
+          reasoningEffort: draft.reasoningEffort,
+        },
+      ]),
+  );
+}
+
+export function sanitizePersistedComposerDrafts(value: unknown): PersistedComposerDrafts {
+  if (!isRecord(value)) return {};
+  const drafts: PersistedComposerDrafts = {};
+  for (const [key, candidate] of Object.entries(value)) {
+    if (!isRecord(candidate)) continue;
+    const revision =
+      typeof candidate.revision === "number" &&
+      Number.isInteger(candidate.revision) &&
+      candidate.revision >= 0
+        ? candidate.revision
+        : 0;
+    const generation =
+      typeof candidate.generation === "number" &&
+      Number.isInteger(candidate.generation) &&
+      candidate.generation >= 0
+        ? candidate.generation
+        : 0;
+    const updatedAt =
+      typeof candidate.updatedAt === "string" && Number.isFinite(Date.parse(candidate.updatedAt))
+        ? candidate.updatedAt
+        : new Date(0).toISOString();
+    const attachments = Array.isArray(candidate.attachments)
+      ? candidate.attachments.flatMap((attachment) => {
+          const normalized = sanitizePersistedComposerDraftAttachment(attachment);
+          return normalized ? [normalized] : [];
+        })
+      : [];
+    drafts[key] = {
+      revision,
+      generation,
+      updatedAt,
+      text: typeof candidate.text === "string" ? candidate.text : "",
+      attachments,
+      references: hydrateReferences(candidate.references),
+      provider: isProviderName(candidate.provider) ? candidate.provider : null,
+      model:
+        typeof candidate.model === "string" && candidate.model.trim()
+          ? candidate.model.trim()
+          : null,
+      reasoningEffort: isReasoningEffortValue(candidate.reasoningEffort)
+        ? candidate.reasoningEffort
+        : null,
+    };
+  }
+  return drafts;
+}
+
+export function hydrateComposerDrafts(
+  value: unknown,
+  options: ObjectUrlOptions = {},
+): ComposerDraftsByKey {
+  const drafts: ComposerDraftsByKey = {};
+  for (const [key, candidate] of Object.entries(sanitizePersistedComposerDrafts(value))) {
+    const draft = hydrateComposerDraft(candidate, options);
+    if (draft) drafts[key] = draft;
+  }
+  return drafts;
+}
+
+export function clearComposerDraftRevision(
+  drafts: ComposerDraftsByKey,
+  owner: ComposerDraftRevision,
+): {
+  drafts: ComposerDraftsByKey;
+  cleared: boolean;
+  removedAttachments: ComposerDraftAttachment[];
+} {
+  const current = drafts[owner.key];
+  if (!current || current.revision !== owner.revision) {
+    return { drafts, cleared: false, removedAttachments: [] };
+  }
+  const next = { ...drafts };
+  next[owner.key] = {
+    ...createEmptyComposerDraft(current.updatedAt),
+    revision: current.revision + 1,
+    generation: current.generation + 1,
+  };
+  return {
+    drafts: next,
+    cleared: true,
+    removedAttachments: current.attachments,
+  };
+}
+
+export function pruneComposerDrafts(
+  drafts: ComposerDraftsByKey,
+  options: PruneComposerDraftOptions,
+): {
+  drafts: ComposerDraftsByKey;
+  removedKeys: string[];
+  removedAttachments: ComposerDraftAttachment[];
+} {
+  const nowMs = options.nowMs ?? Date.now();
+  const maxDrafts = options.maxDrafts ?? MAX_COMPOSER_DRAFTS;
+  const maxAgeMs = options.maxAgeMs ?? COMPOSER_DRAFT_MAX_AGE_MS;
+  const eligible = Object.entries(drafts)
+    .filter(([key, draft]) => {
+      if (!isValidComposerDraftKey(key, options)) return false;
+      if (key === options.activeKey) return true;
+      const updatedAtMs = Date.parse(draft.updatedAt);
+      return Number.isFinite(updatedAtMs) && nowMs - updatedAtMs <= maxAgeMs;
+    })
+    .sort(([leftKey, left], [rightKey, right]) => {
+      if (leftKey === options.activeKey) return -1;
+      if (rightKey === options.activeKey) return 1;
+      return (
+        Date.parse(right.updatedAt) - Date.parse(left.updatedAt) || leftKey.localeCompare(rightKey)
+      );
+    })
+    .slice(0, Math.max(0, maxDrafts));
+  const next = Object.fromEntries(eligible);
+  const retainedKeys = new Set(Object.keys(next));
+  const removedKeys = Object.keys(drafts).filter((key) => !retainedKeys.has(key));
+  return {
+    drafts: next,
+    removedKeys,
+    removedAttachments: removedKeys.flatMap((key) => drafts[key]?.attachments ?? []),
+  };
+}
+
+export function revokeComposerDraftAttachmentPreviews(
+  attachments: readonly ComposerDraftAttachment[],
+  revokeObjectURL: (url: string) => void = defaultRevokeObjectURL,
+): void {
+  for (const attachment of attachments) {
+    if (attachment.previewUrl) revokeObjectURL(attachment.previewUrl);
+  }
+}
+
+export function hasComposerDraftContent(draft: ComposerDraft | undefined): boolean {
+  return Boolean(draft && (draft.text.length > 0 || draft.attachments.length > 0));
+}
+
+function hasComposerDraftState(draft: ComposerDraft): boolean {
+  return Boolean(
+    hasComposerDraftContent(draft) ||
+      draft.references.length > 0 ||
+      draft.provider ||
+      draft.model ||
+      draft.reasoningEffort,
+  );
+}
+
+function hydrateComposerDraft(value: unknown, options: ObjectUrlOptions): ComposerDraft | null {
+  if (!isRecord(value)) return null;
+  const revision =
+    typeof value.revision === "number" && Number.isInteger(value.revision) && value.revision >= 0
+      ? value.revision
+      : 0;
+  const generation =
+    typeof value.generation === "number" &&
+    Number.isInteger(value.generation) &&
+    value.generation >= 0
+      ? value.generation
+      : 0;
+  const updatedAt =
+    typeof value.updatedAt === "string" && Number.isFinite(Date.parse(value.updatedAt))
+      ? value.updatedAt
+      : new Date(0).toISOString();
+  const text = typeof value.text === "string" ? value.text : "";
+  const references = hydrateReferences(value.references);
+  const provider = isProviderName(value.provider) ? value.provider : null;
+  const model = typeof value.model === "string" && value.model.trim() ? value.model.trim() : null;
+  const reasoningEffort = isReasoningEffortValue(value.reasoningEffort)
+    ? value.reasoningEffort
+    : null;
+  const attachments = Array.isArray(value.attachments)
+    ? value.attachments.flatMap((attachment) => {
+        const hydrated = hydrateComposerDraftAttachment(attachment, options);
+        return hydrated ? [hydrated] : [];
+      })
+    : [];
+  return {
+    revision,
+    generation,
+    updatedAt,
+    text,
+    attachments,
+    references,
+    provider,
+    model,
+    reasoningEffort,
+  };
+}
+
+function hydrateComposerDraftAttachment(
+  value: unknown,
+  options: ObjectUrlOptions,
+): ComposerDraftAttachment | null {
+  if (!isRecord(value)) return null;
+  if (
+    typeof value.filename !== "string" ||
+    !value.filename ||
+    typeof value.mimeType !== "string" ||
+    typeof value.size !== "number" ||
+    !Number.isFinite(value.size) ||
+    value.size < 0 ||
+    typeof value.lastModified !== "number" ||
+    !Number.isFinite(value.lastModified) ||
+    typeof value.signature !== "string" ||
+    typeof value.contentBase64 !== "string"
+  ) {
+    return null;
+  }
+  try {
+    const bytes = decodeBase64(value.contentBase64);
+    if (bytes.byteLength !== value.size) return null;
+    const file = new File([bytes], value.filename, {
+      type: value.mimeType,
+      lastModified: value.lastModified,
+    });
+    const createObjectURL = options.createObjectURL ?? defaultCreateObjectURL;
+    const previewUrl = value.mimeType.startsWith("image/") ? createObjectURL(file) : undefined;
+    return {
+      filename: value.filename,
+      mimeType: value.mimeType,
+      size: value.size,
+      lastModified: value.lastModified,
+      file,
+      previewUrl,
+      signature: value.signature,
+      contentBase64: value.contentBase64,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function sanitizePersistedComposerDraftAttachment(
+  value: unknown,
+): PersistedComposerDraftAttachment | null {
+  if (!isRecord(value)) return null;
+  if (
+    typeof value.filename !== "string" ||
+    !value.filename ||
+    typeof value.mimeType !== "string" ||
+    typeof value.size !== "number" ||
+    !Number.isFinite(value.size) ||
+    value.size < 0 ||
+    typeof value.lastModified !== "number" ||
+    !Number.isFinite(value.lastModified) ||
+    typeof value.signature !== "string" ||
+    typeof value.contentBase64 !== "string"
+  ) {
+    return null;
+  }
+  try {
+    if (decodeBase64(value.contentBase64).byteLength !== value.size) return null;
+  } catch {
+    return null;
+  }
+  return {
+    filename: value.filename,
+    mimeType: value.mimeType,
+    size: value.size,
+    lastModified: value.lastModified,
+    signature: value.signature,
+    contentBase64: value.contentBase64,
+  };
+}
+
+function hydrateReferences(value: unknown): TurnReference[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((candidate) => {
+    if (
+      !isRecord(candidate) ||
+      (candidate.kind !== "skill" && candidate.kind !== "plugin") ||
+      typeof candidate.name !== "string" ||
+      !candidate.name.trim()
+    ) {
+      return [];
+    }
+    return [{ kind: candidate.kind, name: candidate.name.trim() }];
+  });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isValidComposerDraftKey(
+  key: string,
+  options: Pick<PruneComposerDraftOptions, "validThreadIds" | "validProjectWorkspaceIds">,
+): boolean {
+  if (key === "new:oneOff") return true;
+  if (key.startsWith("thread:")) {
+    return options.validThreadIds.has(key.slice("thread:".length));
+  }
+  if (key.startsWith("new:project:")) {
+    return options.validProjectWorkspaceIds.has(key.slice("new:project:".length));
+  }
+  return false;
+}
+
+function isProviderName(value: unknown): value is ProviderName {
+  return typeof value === "string" && (PROVIDER_NAMES as readonly string[]).includes(value);
+}
+
+function isReasoningEffortValue(value: unknown): value is ReasoningEffortValue {
+  return typeof value === "string" && REASONING_EFFORT_VALUES.has(value);
+}
+
+function encodeArrayBufferToBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  const chunks: string[] = [];
+  for (let index = 0; index < bytes.length; index += BASE64_BINARY_CHUNK_SIZE) {
+    chunks.push(String.fromCharCode(...bytes.subarray(index, index + BASE64_BINARY_CHUNK_SIZE)));
+  }
+  return btoa(chunks.join(""));
+}
+
+function decodeBase64(value: string): Uint8Array<ArrayBuffer> {
+  const binary = atob(value);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return bytes;
+}
+
+function defaultCreateObjectURL(blob: Blob): string {
+  return typeof URL.createObjectURL === "function" ? URL.createObjectURL(blob) : "";
+}
+
+function defaultRevokeObjectURL(url: string): void {
+  if (url && typeof URL.revokeObjectURL === "function") URL.revokeObjectURL(url);
+}

--- a/apps/desktop/src/app/composerDrafts.ts
+++ b/apps/desktop/src/app/composerDrafts.ts
@@ -1,3 +1,9 @@
+import {
+  MAX_ATTACHMENT_BASE64_SIZE,
+  MAX_ATTACHMENT_INLINE_BYTE_SIZE,
+  MAX_TURN_ATTACHMENT_COUNT,
+  MAX_TURN_ATTACHMENT_TOTAL_INLINE_BYTE_SIZE,
+} from "../../../../src/shared/attachments";
 import { type NewChatLandingTarget, resolveNewChatLandingTarget } from "../lib/newChatLanding";
 import type { TurnReference } from "../lib/wsProtocol";
 import { PROVIDER_NAMES, type ProviderName } from "../lib/wsProtocol";
@@ -17,6 +23,11 @@ const REASONING_EFFORT_VALUES = new Set([
 ]);
 
 export const MAX_COMPOSER_DRAFTS = 50;
+export const MAX_COMPOSER_DRAFT_ATTACHMENT_COUNT = MAX_TURN_ATTACHMENT_COUNT;
+export const MAX_COMPOSER_DRAFT_ATTACHMENT_BYTE_SIZE = MAX_ATTACHMENT_INLINE_BYTE_SIZE;
+export const MAX_COMPOSER_DRAFT_TOTAL_ATTACHMENT_BYTES = MAX_TURN_ATTACHMENT_TOTAL_INLINE_BYTE_SIZE;
+export const MAX_PERSISTED_COMPOSER_DRAFT_ATTACHMENT_BYTES =
+  MAX_TURN_ATTACHMENT_TOTAL_INLINE_BYTE_SIZE;
 
 export type ComposerDraftAttachment = {
   filename: string;
@@ -48,6 +59,11 @@ export type ComposerDraftRevision = {
   revision: number;
 };
 
+export type ComposerDraftRevisionFloor = {
+  revision: number;
+  generation: number;
+};
+
 export type PersistedComposerDraftAttachment = Omit<ComposerDraftAttachment, "file" | "previewUrl">;
 
 export type PersistedComposerDraft = Omit<ComposerDraft, "attachments"> & {
@@ -69,6 +85,7 @@ type PruneComposerDraftOptions = {
   validThreadIds: ReadonlySet<string>;
   validProjectWorkspaceIds: ReadonlySet<string>;
   activeKey?: string | null;
+  protectedKeys?: ReadonlySet<string>;
   maxDrafts?: number;
   maxAgeMs?: number;
 };
@@ -141,6 +158,46 @@ export async function createComposerDraftAttachment(
   };
 }
 
+export function getComposerDraftAttachmentValidationMessage(
+  drafts: ComposerDraftsByKey,
+  ownerKey: string,
+  selectedFiles: readonly Pick<File, "size">[],
+): string | null {
+  const currentAttachments = drafts[ownerKey]?.attachments ?? [];
+  const totalCount = currentAttachments.length + selectedFiles.length;
+  if (totalCount > MAX_COMPOSER_DRAFT_ATTACHMENT_COUNT) {
+    return `Too many file attachments (max ${MAX_COMPOSER_DRAFT_ATTACHMENT_COUNT})`;
+  }
+
+  const selectedBytes = sumAttachmentBytes(selectedFiles);
+  if (!Number.isFinite(selectedBytes)) {
+    return "File attachment size is invalid";
+  }
+  if (selectedFiles.some((file) => file.size > MAX_COMPOSER_DRAFT_ATTACHMENT_BYTE_SIZE)) {
+    return "File too large to save in a draft (max 25MB)";
+  }
+
+  const currentDraftBytes = sumAttachmentBytes(currentAttachments);
+  if (
+    !Number.isFinite(currentDraftBytes) ||
+    currentDraftBytes + selectedBytes > MAX_COMPOSER_DRAFT_TOTAL_ATTACHMENT_BYTES
+  ) {
+    return "Draft attachments too large in total (max 25MB combined)";
+  }
+
+  const persistedBytes = Object.values(drafts).reduce(
+    (total, draft) => total + sumAttachmentBytes(draft.attachments),
+    0,
+  );
+  if (
+    !Number.isFinite(persistedBytes) ||
+    persistedBytes + selectedBytes > MAX_PERSISTED_COMPOSER_DRAFT_ATTACHMENT_BYTES
+  ) {
+    return "Saved draft attachments too large in total (max 25MB across chats)";
+  }
+  return null;
+}
+
 export function serializeComposerDrafts(drafts: ComposerDraftsByKey): PersistedComposerDrafts {
   return Object.fromEntries(
     Object.entries(drafts)
@@ -174,8 +231,14 @@ export function serializeComposerDrafts(drafts: ComposerDraftsByKey): PersistedC
 export function sanitizePersistedComposerDrafts(value: unknown): PersistedComposerDrafts {
   if (!isRecord(value)) return {};
   const drafts: PersistedComposerDrafts = {};
-  for (const [key, candidate] of Object.entries(value)) {
-    if (!isRecord(candidate)) continue;
+  let persistedAttachmentBytes = 0;
+  const candidates = Object.entries(value)
+    .filter((entry): entry is [string, Record<string, unknown>] => isRecord(entry[1]))
+    .sort(([leftKey, left], [rightKey, right]) => {
+      const updatedAtDelta = persistedDraftUpdatedAtMs(right) - persistedDraftUpdatedAtMs(left);
+      return updatedAtDelta || leftKey.localeCompare(rightKey);
+    });
+  for (const [key, candidate] of candidates) {
     const revision =
       typeof candidate.revision === "number" &&
       Number.isInteger(candidate.revision) &&
@@ -192,12 +255,26 @@ export function sanitizePersistedComposerDrafts(value: unknown): PersistedCompos
       typeof candidate.updatedAt === "string" && Number.isFinite(Date.parse(candidate.updatedAt))
         ? candidate.updatedAt
         : new Date(0).toISOString();
-    const attachments = Array.isArray(candidate.attachments)
-      ? candidate.attachments.flatMap((attachment) => {
-          const normalized = sanitizePersistedComposerDraftAttachment(attachment);
-          return normalized ? [normalized] : [];
-        })
-      : [];
+    const attachments: PersistedComposerDraftAttachment[] = [];
+    let draftAttachmentBytes = 0;
+    if (Array.isArray(candidate.attachments)) {
+      for (const attachment of candidate.attachments) {
+        if (attachments.length >= MAX_COMPOSER_DRAFT_ATTACHMENT_COUNT) break;
+        const declaredSize = persistedAttachmentDeclaredSize(attachment);
+        if (declaredSize === null) continue;
+        if (
+          draftAttachmentBytes + declaredSize > MAX_COMPOSER_DRAFT_TOTAL_ATTACHMENT_BYTES ||
+          persistedAttachmentBytes + declaredSize > MAX_PERSISTED_COMPOSER_DRAFT_ATTACHMENT_BYTES
+        ) {
+          continue;
+        }
+        const normalized = sanitizePersistedComposerDraftAttachment(attachment);
+        if (!normalized) continue;
+        attachments.push(normalized);
+        draftAttachmentBytes += declaredSize;
+        persistedAttachmentBytes += declaredSize;
+      }
+    }
     drafts[key] = {
       revision,
       generation,
@@ -266,9 +343,14 @@ export function pruneComposerDrafts(
   const nowMs = options.nowMs ?? Date.now();
   const maxDrafts = options.maxDrafts ?? MAX_COMPOSER_DRAFTS;
   const maxAgeMs = options.maxAgeMs ?? COMPOSER_DRAFT_MAX_AGE_MS;
+  const protectedEntries = Object.entries(drafts).filter(
+    ([key]) => options.protectedKeys?.has(key) === true && isValidComposerDraftKey(key, options),
+  );
   const eligible = Object.entries(drafts)
     .filter(([key, draft]) => {
       if (!isValidComposerDraftKey(key, options)) return false;
+      if (options.protectedKeys?.has(key) === true) return false;
+      if (!hasComposerDraftState(draft)) return false;
       if (key === options.activeKey) return true;
       const updatedAtMs = Date.parse(draft.updatedAt);
       return Number.isFinite(updatedAtMs) && nowMs - updatedAtMs <= maxAgeMs;
@@ -279,9 +361,26 @@ export function pruneComposerDrafts(
       return (
         Date.parse(right.updatedAt) - Date.parse(left.updatedAt) || leftKey.localeCompare(rightKey)
       );
-    })
-    .slice(0, Math.max(0, maxDrafts));
-  const next = Object.fromEntries(eligible);
+    });
+  const retainedDrafts: Array<[string, ComposerDraft]> = [];
+  let persistedAttachmentBytes = protectedEntries.reduce(
+    (total, [, draft]) => total + validatedDraftAttachmentBytes(draft),
+    0,
+  );
+  for (const entry of eligible) {
+    if (retainedDrafts.length >= Math.max(0, maxDrafts)) break;
+    const draftAttachmentBytes = validatedDraftAttachmentBytes(entry[1]);
+    if (
+      !Number.isFinite(draftAttachmentBytes) ||
+      persistedAttachmentBytes + draftAttachmentBytes >
+        MAX_PERSISTED_COMPOSER_DRAFT_ATTACHMENT_BYTES
+    ) {
+      continue;
+    }
+    retainedDrafts.push(entry);
+    persistedAttachmentBytes += draftAttachmentBytes;
+  }
+  const next = Object.fromEntries([...protectedEntries, ...retainedDrafts]);
   const retainedKeys = new Set(Object.keys(next));
   const removedKeys = Object.keys(drafts).filter((key) => !retainedKeys.has(key));
   return {
@@ -368,10 +467,12 @@ function hydrateComposerDraftAttachment(
     typeof value.size !== "number" ||
     !Number.isFinite(value.size) ||
     value.size < 0 ||
+    value.size > MAX_COMPOSER_DRAFT_ATTACHMENT_BYTE_SIZE ||
     typeof value.lastModified !== "number" ||
     !Number.isFinite(value.lastModified) ||
     typeof value.signature !== "string" ||
-    typeof value.contentBase64 !== "string"
+    typeof value.contentBase64 !== "string" ||
+    value.contentBase64.length > MAX_ATTACHMENT_BASE64_SIZE
   ) {
     return null;
   }
@@ -410,10 +511,12 @@ function sanitizePersistedComposerDraftAttachment(
     typeof value.size !== "number" ||
     !Number.isFinite(value.size) ||
     value.size < 0 ||
+    value.size > MAX_COMPOSER_DRAFT_ATTACHMENT_BYTE_SIZE ||
     typeof value.lastModified !== "number" ||
     !Number.isFinite(value.lastModified) ||
     typeof value.signature !== "string" ||
-    typeof value.contentBase64 !== "string"
+    typeof value.contentBase64 !== "string" ||
+    value.contentBase64.length > MAX_ATTACHMENT_BASE64_SIZE
   ) {
     return null;
   }
@@ -430,6 +533,52 @@ function sanitizePersistedComposerDraftAttachment(
     signature: value.signature,
     contentBase64: value.contentBase64,
   };
+}
+
+function persistedAttachmentDeclaredSize(value: unknown): number | null {
+  if (
+    !isRecord(value) ||
+    typeof value.size !== "number" ||
+    !Number.isFinite(value.size) ||
+    value.size < 0 ||
+    value.size > MAX_COMPOSER_DRAFT_ATTACHMENT_BYTE_SIZE ||
+    typeof value.contentBase64 !== "string" ||
+    value.contentBase64.length > MAX_ATTACHMENT_BASE64_SIZE
+  ) {
+    return null;
+  }
+  return value.size;
+}
+
+function persistedDraftUpdatedAtMs(value: Record<string, unknown>): number {
+  if (typeof value.updatedAt !== "string") return 0;
+  const updatedAtMs = Date.parse(value.updatedAt);
+  return Number.isFinite(updatedAtMs) ? updatedAtMs : 0;
+}
+
+function sumAttachmentBytes(attachments: readonly Pick<{ size: number }, "size">[]): number {
+  let total = 0;
+  for (const attachment of attachments) {
+    if (!Number.isFinite(attachment.size) || attachment.size < 0) return Number.POSITIVE_INFINITY;
+    total += attachment.size;
+    if (!Number.isSafeInteger(total)) return Number.POSITIVE_INFINITY;
+  }
+  return total;
+}
+
+function validatedDraftAttachmentBytes(draft: ComposerDraft): number {
+  if (draft.attachments.length > MAX_COMPOSER_DRAFT_ATTACHMENT_COUNT) {
+    return Number.POSITIVE_INFINITY;
+  }
+  if (
+    draft.attachments.some(
+      (attachment) => attachment.size > MAX_COMPOSER_DRAFT_ATTACHMENT_BYTE_SIZE,
+    )
+  ) {
+    return Number.POSITIVE_INFINITY;
+  }
+  const total = sumAttachmentBytes(draft.attachments);
+  return total <= MAX_COMPOSER_DRAFT_TOTAL_ATTACHMENT_BYTES ? total : Number.POSITIVE_INFINITY;
 }
 
 function hydrateReferences(value: unknown): TurnReference[] {

--- a/apps/desktop/src/app/store.actions/bootstrap.ts
+++ b/apps/desktop/src/app/store.actions/bootstrap.ts
@@ -766,6 +766,8 @@ export function buildCachedDesktopStateSeed(value: unknown): Partial<AppStoreDat
       selectedWorkspaceId: ui.selectedWorkspaceId,
       selectedThreadId: ui.selectedThreadId,
       selectedTaskId: ui.selectedTaskId,
+      composerDraftRevisionFloorByKey: {},
+      composerAttachmentIngestionCountByKey: {},
       composerDraftsByKey: buildRestoredComposerDrafts(
         state.composerDrafts,
         state.workspaces,
@@ -1068,6 +1070,8 @@ export function createBootstrapActions(
             selectedWorkspaceId: ui.selectedWorkspaceId,
             selectedThreadId: ui.selectedThreadId,
             selectedTaskId: ui.selectedTaskId,
+            composerDraftRevisionFloorByKey: {},
+            composerAttachmentIngestionCountByKey: {},
             composerDraftsByKey: restoredComposerDrafts,
             newChatLandingTarget: ui.newChatLandingTarget,
             providerStatusByName: state.providerState?.statusByName ?? {},

--- a/apps/desktop/src/app/store.actions/bootstrap.ts
+++ b/apps/desktop/src/app/store.actions/bootstrap.ts
@@ -20,6 +20,13 @@ import { isCanvasSupportedFile } from "../../lib/filePreviewKind";
 import { normalizeQuickChatShortcutAccelerator } from "../../lib/quickChatShortcut";
 import type { ChildModelRoutingMode } from "../../lib/wsProtocol";
 import { type ProviderName, safeParseSessionEvent } from "../../lib/wsProtocol";
+import {
+  hydrateComposerDrafts,
+  pruneComposerDrafts,
+  resolveActiveComposerDraftKey,
+  revokeComposerDraftAttachmentPreviews,
+  sanitizePersistedComposerDrafts,
+} from "../composerDrafts";
 import { normalizeWorkspaceProviderOptions } from "../openaiCompatibleProviderOptions";
 import {
   deriveConnectedProviders,
@@ -381,6 +388,13 @@ const persistedUiSchema = z.preprocess(
       contextSidebarWidth: normalizedUiWidthSchema(200, 600, 300).optional(),
       canvasSidebarWidth: normalizedUiWidthSchema(200, 900, 500).optional(),
       messageBarHeight: normalizedUiWidthSchema(80, 500, 96).optional(),
+      newChatLandingTarget: z
+        .union([
+          z.object({ kind: z.literal("oneOff") }),
+          z.object({ kind: z.literal("project"), workspaceId: z.string().min(1) }),
+        ])
+        .nullable()
+        .optional(),
     })
     .passthrough()
     .transform(
@@ -397,6 +411,7 @@ const persistedUiSchema = z.preprocess(
         contextSidebarWidth: ui.contextSidebarWidth ?? 300,
         canvasSidebarWidth: ui.canvasSidebarWidth ?? 500,
         messageBarHeight: ui.messageBarHeight ?? 96,
+        newChatLandingTarget: ui.newChatLandingTarget ?? null,
       }),
     ),
 );
@@ -498,6 +513,7 @@ const persistedStateSchema = z
         .passthrough()
         .optional(),
     ),
+    composerDrafts: z.unknown().optional(),
   })
   .passthrough()
   .transform((state) => {
@@ -527,6 +543,7 @@ const persistedStateSchema = z
       providerState,
       providerUiState,
       onboarding,
+      composerDrafts: sanitizePersistedComposerDrafts(state.composerDrafts),
     };
   });
 
@@ -589,9 +606,10 @@ function buildResolvedDesktopUiState(
         ?.id ??
       null)
     : null;
-  const selectedThreadId = migratedSelectedThreadId
-    ? migratedSelectedThreadId
-    : fallbackSelectedThreadId;
+  const selectedThreadId =
+    normalizedUi.selectedThreadId === null && normalizedUi.newChatLandingTarget
+      ? null
+      : (migratedSelectedThreadId ?? fallbackSelectedThreadId);
   const fallbackLastNonSettingsView =
     normalizedUi.view === "settings" ? "chat" : (normalizedUi.view ?? "chat");
   const rawLastNonSettingsView =
@@ -616,7 +634,38 @@ function buildResolvedDesktopUiState(
     contextSidebarWidth: normalizedUi.contextSidebarWidth ?? 300,
     canvasSidebarWidth: normalizedUi.canvasSidebarWidth ?? 500,
     messageBarHeight: normalizedUi.messageBarHeight ?? 96,
+    newChatLandingTarget: normalizedUi.newChatLandingTarget ?? null,
   };
+}
+
+function buildRestoredComposerDrafts(
+  persistedDrafts: HydratedPersistedDesktopState["composerDrafts"],
+  workspaces: WorkspaceRecord[],
+  threads: ThreadRecord[],
+  selection: {
+    selectedThreadId: string | null;
+    selectedWorkspaceId: string | null;
+    newChatLandingTarget: CachedDesktopUiState["newChatLandingTarget"];
+  },
+): AppStoreDataState["composerDraftsByKey"] {
+  const drafts = hydrateComposerDrafts(persistedDrafts);
+  const activeKey = resolveActiveComposerDraftKey({
+    selectedThreadId: selection.selectedThreadId,
+    selectedWorkspaceId: selection.selectedWorkspaceId,
+    newChatLandingTarget: selection.newChatLandingTarget ?? null,
+    workspaces,
+  });
+  const pruned = pruneComposerDrafts(drafts, {
+    validThreadIds: new Set(threads.map((thread) => thread.id)),
+    validProjectWorkspaceIds: new Set(
+      workspaces
+        .filter((workspace) => workspace.workspaceKind !== "oneOffChat")
+        .map((workspace) => workspace.id),
+    ),
+    activeKey,
+  });
+  revokeComposerDraftAttachmentPreviews(pruned.removedAttachments);
+  return pruned.drafts;
 }
 
 function extractCachedDesktopState(value: unknown): {
@@ -717,6 +766,17 @@ export function buildCachedDesktopStateSeed(value: unknown): Partial<AppStoreDat
       selectedWorkspaceId: ui.selectedWorkspaceId,
       selectedThreadId: ui.selectedThreadId,
       selectedTaskId: ui.selectedTaskId,
+      composerDraftsByKey: buildRestoredComposerDrafts(
+        state.composerDrafts,
+        state.workspaces,
+        state.threads,
+        {
+          selectedThreadId: ui.selectedThreadId,
+          selectedWorkspaceId: ui.selectedWorkspaceId,
+          newChatLandingTarget: ui.newChatLandingTarget,
+        },
+      ),
+      newChatLandingTarget: ui.newChatLandingTarget,
       providerStatusByName: state.providerState?.statusByName ?? {},
       providerStatusLastUpdatedAt: state.providerState?.statusLastUpdatedAt ?? null,
       providerConnected: connectedProviders,
@@ -797,13 +857,14 @@ export function createBootstrapActions(
     const startupSelectionContext = getThreadSelectionContext(ui.view, ui.lastNonSettingsView);
 
     if (ui.selectedThreadId && ui.view === "chat") {
+      const selectedThreadId = ui.selectedThreadId;
       if (!isCurrent()) return;
       set((state) => ({
         threadRuntimeById: {
           ...state.threadRuntimeById,
-          [ui.selectedThreadId]: {
+          [selectedThreadId]: {
             ...defaultThreadRuntime(),
-            ...state.threadRuntimeById[ui.selectedThreadId],
+            ...state.threadRuntimeById[selectedThreadId],
             hydrating: true,
           },
         },
@@ -813,10 +874,10 @@ export function createBootstrapActions(
         return;
       }
       const current = get();
-      if (current.selectedThreadId !== ui.selectedThreadId || current.view !== "chat") {
+      if (current.selectedThreadId !== selectedThreadId || current.view !== "chat") {
         return;
       }
-      await current.selectThread(ui.selectedThreadId, { signal });
+      await current.selectThread(selectedThreadId, { signal });
       return;
     }
 
@@ -924,6 +985,7 @@ export function createBootstrapActions(
               contextSidebarWidth: get().contextSidebarWidth,
               canvasSidebarWidth: get().canvasSidebarWidth,
               messageBarHeight: get().messageBarHeight,
+              newChatLandingTarget: get().newChatLandingTarget,
             },
           );
           const connectedProviders = deriveConnectedProviders(
@@ -986,12 +1048,28 @@ export function createBootstrapActions(
           if (!isCurrent()) {
             return;
           }
+          const restoredComposerDrafts = buildRestoredComposerDrafts(
+            state.composerDrafts,
+            state.workspaces,
+            finalThreads,
+            {
+              selectedThreadId: ui.selectedThreadId,
+              selectedWorkspaceId: ui.selectedWorkspaceId,
+              newChatLandingTarget: ui.newChatLandingTarget,
+            },
+          );
+          const previousDrafts = get().composerDraftsByKey;
+          revokeComposerDraftAttachmentPreviews(
+            Object.values(previousDrafts).flatMap((draft) => draft.attachments),
+          );
           set({
             workspaces: state.workspaces,
             threads: finalThreads,
             selectedWorkspaceId: ui.selectedWorkspaceId,
             selectedThreadId: ui.selectedThreadId,
             selectedTaskId: ui.selectedTaskId,
+            composerDraftsByKey: restoredComposerDrafts,
+            newChatLandingTarget: ui.newChatLandingTarget,
             providerStatusByName: state.providerState?.statusByName ?? {},
             providerStatusLastUpdatedAt: state.providerState?.statusLastUpdatedAt ?? null,
             providerConnected: connectedProviders,

--- a/apps/desktop/src/app/store.actions/lmstudioLocal.ts
+++ b/apps/desktop/src/app/store.actions/lmstudioLocal.ts
@@ -82,6 +82,7 @@ export function createLmStudioLocalActions(
               retry.attachments,
               retry.references,
               retry.clientMessageId,
+              retry.draftSubmission,
             );
           }
           void get().refreshProviderStatus({ workspaceId: modal.workspaceId });

--- a/apps/desktop/src/app/store.actions/thread.ts
+++ b/apps/desktop/src/app/store.actions/thread.ts
@@ -7,12 +7,14 @@ import * as desktopCommands from "../../lib/desktopCommands";
 import { type NewChatLandingTarget, resolveDefaultNewChatTarget } from "../../lib/newChatLanding";
 import { buildAttachmentSignature, buildUserInputDisplayText } from "../attachmentInputs";
 import {
+  type ComposerDraft,
   type ComposerDraftAttachment,
   type ComposerDraftRevision,
   clearComposerDraftRevision,
   composerDraftKeyForThread,
   createComposerDraftAttachment,
   createEmptyComposerDraft,
+  getComposerDraftAttachmentValidationMessage,
   pruneComposerDrafts as pruneComposerDraftEntries,
   resolveActiveComposerDraftKey,
   revokeComposerDraftAttachmentPreviews,
@@ -83,6 +85,18 @@ type HydrateThreadSelectionOptions = {
   reconnectAfterHydration?: boolean;
   skipWorkspaceSelectOnReconnect?: boolean;
 } & AbortableActionOptions;
+
+function createEmptyComposerDraftForState(state: AppStoreState, key: string): ComposerDraft {
+  const draft = createEmptyComposerDraft(nowIso());
+  const revisionFloor = state.composerDraftRevisionFloorByKey[key];
+  return revisionFloor
+    ? {
+        ...draft,
+        revision: revisionFloor.revision,
+        generation: revisionFloor.generation,
+      }
+    : draft;
+}
 
 /**
  * Queue the first message of a brand-new chat AND render its user bubble
@@ -1497,7 +1511,8 @@ export function createThreadActions(
     setComposerText: (text, references = []) => {
       set((state) => {
         const key = resolveActiveComposerDraftKey(state);
-        const current = state.composerDraftsByKey[key] ?? createEmptyComposerDraft(nowIso());
+        const current =
+          state.composerDraftsByKey[key] ?? createEmptyComposerDraftForState(state, key);
         return {
           composerDraftsByKey: {
             ...state.composerDraftsByKey,
@@ -1511,6 +1526,7 @@ export function createThreadActions(
           },
         };
       });
+      get().pruneComposerDrafts(undefined, Number.POSITIVE_INFINITY);
       persist(get);
     },
 
@@ -1520,9 +1536,9 @@ export function createThreadActions(
       let ownerGeneration = 1;
       set((state) => {
         const existing = state.composerDraftsByKey[ownerKey];
-        const current = existing ?? createEmptyComposerDraft(nowIso());
+        const current = existing ?? createEmptyComposerDraftForState(state, ownerKey);
         ownerGeneration = Math.max(1, current.generation);
-        if (existing && existing.generation === ownerGeneration) return {};
+        const pendingCount = (state.composerAttachmentIngestionCountByKey[ownerKey] ?? 0) + 1;
         return {
           composerDraftsByKey: {
             ...state.composerDraftsByKey,
@@ -1531,39 +1547,78 @@ export function createThreadActions(
               generation: ownerGeneration,
             },
           },
-        };
-      });
-      const attachments: ComposerDraftAttachment[] = [];
-      try {
-        for (const file of files) {
-          attachments.push(await createComposerDraftAttachment(file));
-        }
-      } catch (error) {
-        revokeComposerDraftAttachmentPreviews(attachments);
-        throw error;
-      }
-      let accepted = false;
-      set((state) => {
-        const current = state.composerDraftsByKey[ownerKey] ?? createEmptyComposerDraft(nowIso());
-        if (current.generation !== ownerGeneration) return {};
-        accepted = true;
-        return {
-          composerDraftsByKey: {
-            ...state.composerDraftsByKey,
-            [ownerKey]: {
-              ...current,
-              revision: current.revision + 1,
-              updatedAt: nowIso(),
-              attachments: [...current.attachments, ...attachments],
-            },
+          composerAttachmentIngestionCountByKey: {
+            ...state.composerAttachmentIngestionCountByKey,
+            [ownerKey]: pendingCount,
           },
         };
       });
-      if (!accepted) {
-        revokeComposerDraftAttachmentPreviews(attachments);
-        return;
-      }
-      persist(get);
+      const previousIngestion = RUNTIME.composerAttachmentIngestionTail ?? Promise.resolve();
+      const ingestion = previousIngestion
+        .catch(() => undefined)
+        .then(async () => {
+          const current = get().composerDraftsByKey[ownerKey];
+          if (current?.generation !== ownerGeneration) return;
+          const validationMessage = getComposerDraftAttachmentValidationMessage(
+            get().composerDraftsByKey,
+            ownerKey,
+            files,
+          );
+          if (validationMessage) {
+            throw new Error(validationMessage);
+          }
+
+          const attachments: ComposerDraftAttachment[] = [];
+          try {
+            for (const file of files) {
+              attachments.push(await createComposerDraftAttachment(file));
+            }
+          } catch (error) {
+            revokeComposerDraftAttachmentPreviews(attachments);
+            throw error;
+          }
+
+          let accepted = false;
+          set((state) => {
+            const draft = state.composerDraftsByKey[ownerKey];
+            if (draft?.generation !== ownerGeneration) return {};
+            accepted = true;
+            return {
+              composerDraftsByKey: {
+                ...state.composerDraftsByKey,
+                [ownerKey]: {
+                  ...draft,
+                  revision: draft.revision + 1,
+                  updatedAt: nowIso(),
+                  attachments: [...draft.attachments, ...attachments],
+                },
+              },
+            };
+          });
+          if (!accepted) {
+            revokeComposerDraftAttachmentPreviews(attachments);
+            return;
+          }
+          persist(get);
+        });
+      let trackedIngestion: Promise<void>;
+      trackedIngestion = ingestion.finally(() => {
+        set((state) => {
+          const pendingCount = (state.composerAttachmentIngestionCountByKey[ownerKey] ?? 1) - 1;
+          const nextPendingCounts = {
+            ...state.composerAttachmentIngestionCountByKey,
+          };
+          if (pendingCount > 0) nextPendingCounts[ownerKey] = pendingCount;
+          else delete nextPendingCounts[ownerKey];
+          return { composerAttachmentIngestionCountByKey: nextPendingCounts };
+        });
+        if (RUNTIME.composerAttachmentIngestionTail === trackedIngestion) {
+          RUNTIME.composerAttachmentIngestionTail = null;
+        }
+        get().pruneComposerDrafts(undefined, Number.POSITIVE_INFINITY);
+      });
+      RUNTIME.composerAttachmentIngestionTail = trackedIngestion;
+      await trackedIngestion;
     },
 
     removeComposerAttachment: (index) => {
@@ -1588,6 +1643,7 @@ export function createThreadActions(
         };
       });
       revokeComposerDraftAttachmentPreviews(removed);
+      get().pruneComposerDrafts(undefined, Number.POSITIVE_INFINITY);
       persist(get);
     },
 
@@ -1596,7 +1652,8 @@ export function createThreadActions(
       if (!normalizedModel) return;
       set((state) => {
         const key = resolveActiveComposerDraftKey(state);
-        const current = state.composerDraftsByKey[key] ?? createEmptyComposerDraft(nowIso());
+        const current =
+          state.composerDraftsByKey[key] ?? createEmptyComposerDraftForState(state, key);
         if (current.provider === provider && current.model === normalizedModel) return {};
         return {
           composerDraftsByKey: {
@@ -1612,13 +1669,15 @@ export function createThreadActions(
           },
         };
       });
+      get().pruneComposerDrafts(undefined, Number.POSITIVE_INFINITY);
       persist(get);
     },
 
     setComposerDraftReasoningEffort: (effort) => {
       set((state) => {
         const key = resolveActiveComposerDraftKey(state);
-        const current = state.composerDraftsByKey[key] ?? createEmptyComposerDraft(nowIso());
+        const current =
+          state.composerDraftsByKey[key] ?? createEmptyComposerDraftForState(state, key);
         if (current.reasoningEffort === effort) return {};
         return {
           composerDraftsByKey: {
@@ -1632,6 +1691,7 @@ export function createThreadActions(
           },
         };
       });
+      get().pruneComposerDrafts(undefined, Number.POSITIVE_INFINITY);
       persist(get);
     },
 
@@ -1647,6 +1707,7 @@ export function createThreadActions(
       });
       if (cleared) {
         revokeComposerDraftAttachmentPreviews(removedAttachments);
+        get().pruneComposerDrafts(undefined, Number.POSITIVE_INFINITY);
         persist(get);
       }
       return cleared;
@@ -1660,7 +1721,7 @@ export function createThreadActions(
       return get().clearComposerDraft(owner);
     },
 
-    pruneComposerDrafts: (nowMs) => {
+    pruneComposerDrafts: (nowMs, maxAgeMs) => {
       let removedAttachments: ReturnType<typeof pruneComposerDraftEntries>["removedAttachments"] =
         [];
       let changed = false;
@@ -1674,10 +1735,32 @@ export function createThreadActions(
               .map((workspace) => workspace.id),
           ),
           activeKey: resolveActiveComposerDraftKey(state),
+          maxAgeMs,
+          protectedKeys: new Set(
+            Object.entries(state.composerAttachmentIngestionCountByKey)
+              .filter(([, count]) => count > 0)
+              .map(([key]) => key),
+          ),
         });
         removedAttachments = result.removedAttachments;
         changed = result.removedKeys.length > 0;
-        return result.removedKeys.length > 0 ? { composerDraftsByKey: result.drafts } : {};
+        if (result.removedKeys.length === 0) return {};
+        const composerDraftRevisionFloorByKey = {
+          ...state.composerDraftRevisionFloorByKey,
+        };
+        for (const key of result.removedKeys) {
+          const removedDraft = state.composerDraftsByKey[key];
+          if (!removedDraft) continue;
+          const currentFloor = composerDraftRevisionFloorByKey[key];
+          composerDraftRevisionFloorByKey[key] = {
+            revision: Math.max(currentFloor?.revision ?? 0, removedDraft.revision),
+            generation: Math.max(currentFloor?.generation ?? 0, removedDraft.generation),
+          };
+        }
+        return {
+          composerDraftsByKey: result.drafts,
+          composerDraftRevisionFloorByKey,
+        };
       });
       revokeComposerDraftAttachmentPreviews(removedAttachments);
       if (changed) persist(get);

--- a/apps/desktop/src/app/store.actions/thread.ts
+++ b/apps/desktop/src/app/store.actions/thread.ts
@@ -7,6 +7,17 @@ import * as desktopCommands from "../../lib/desktopCommands";
 import { type NewChatLandingTarget, resolveDefaultNewChatTarget } from "../../lib/newChatLanding";
 import { buildAttachmentSignature, buildUserInputDisplayText } from "../attachmentInputs";
 import {
+  type ComposerDraftAttachment,
+  type ComposerDraftRevision,
+  clearComposerDraftRevision,
+  composerDraftKeyForThread,
+  createComposerDraftAttachment,
+  createEmptyComposerDraft,
+  pruneComposerDrafts as pruneComposerDraftEntries,
+  resolveActiveComposerDraftKey,
+  revokeComposerDraftAttachmentPreviews,
+} from "../composerDrafts";
+import {
   googleProviderOptionsForReasoningEffort,
   isGoogleReasoningEffortValue,
   isOpenAiReasoningEffortValue,
@@ -52,6 +63,7 @@ import type { FileAttachmentInput } from "../store.helpers/jsonRpcSocket";
 import { requestJsonRpc } from "../store.helpers/jsonRpcSocket";
 import { createOneOffWorkspaceRecord } from "../store.helpers/oneOffWorkspaceRecord";
 import { waitForNextPaintOrTimeout } from "../store.helpers/paintScheduling";
+import { persist } from "../store.helpers/persistence";
 import { MAX_FEED_ITEMS } from "../store.helpers/threadEventReducerContext";
 import { isStandardChatThread } from "../threadFilters";
 import { hydrateTranscriptSnapshot } from "../transcriptHydration";
@@ -85,13 +97,21 @@ function queueOptimisticFirstThreadMessage(
   text: string,
   attachments?: FileAttachmentInput[],
   references?: import("../../lib/wsProtocol").TurnReference[],
+  draftSubmission?: ComposerDraftRevision,
 ): void {
   const trimmed = text.trim();
   const hasAttachments = (attachments?.length ?? 0) > 0;
   if (!trimmed && !hasAttachments) return;
 
   const clientMessageId = makeId();
-  queuePendingThreadMessage(threadId, trimmed, attachments, references, clientMessageId);
+  queuePendingThreadMessage(
+    threadId,
+    trimmed,
+    attachments,
+    references,
+    clientMessageId,
+    draftSubmission,
+  );
 
   const optimisticSeen = RUNTIME.optimisticUserMessageIds.get(threadId) ?? new Set<string>();
   optimisticSeen.add(clientMessageId);
@@ -157,50 +177,6 @@ function findLatestSandboxApprovalPrompt(
   }
 
   return latest;
-}
-
-/** Draft map key for New Chat landing (`selectedThreadId === null`). */
-const LANDING_COMPOSER_DRAFT_KEY = "__landing__";
-
-function composerDraftKey(threadId: string | null | undefined): string {
-  return threadId ?? LANDING_COMPOSER_DRAFT_KEY;
-}
-
-/** Save active composer draft for fromThreadId and restore toThreadId's draft. */
-function swapComposerDraft(
-  state: { composerText: string; composerTextByThreadId?: Record<string, string> },
-  fromThreadId: string | null | undefined,
-  toThreadId: string | null | undefined,
-): { composerText: string; composerTextByThreadId: Record<string, string> } {
-  const nextById = { ...(state.composerTextByThreadId ?? {}) };
-  const fromKey = composerDraftKey(fromThreadId);
-  const toKey = composerDraftKey(toThreadId);
-  if (fromKey !== toKey) {
-    const trimmed = state.composerText ?? "";
-    if (trimmed.length > 0) nextById[fromKey] = trimmed;
-    else delete nextById[fromKey];
-  }
-  const restored = typeof nextById[toKey] === "string" ? nextById[toKey] : "";
-  return { composerText: restored, composerTextByThreadId: nextById };
-}
-
-function clearComposerDraftForThread(
-  state: {
-    composerText: string;
-    composerTextByThreadId?: Record<string, string>;
-    selectedThreadId?: string | null;
-  },
-  threadId: string | null | undefined,
-): { composerText: string; composerTextByThreadId: Record<string, string> } {
-  const base = state.composerTextByThreadId ?? {};
-  if (!threadId) return { composerText: "", composerTextByThreadId: base };
-  const nextById = { ...base };
-  delete nextById[threadId];
-  // Only blank the live composer when it still belongs to the sent thread.
-  // If the user switched chats while send awaited network work, keep the new
-  // thread's draft in `composerText` and only drop the sender's stored draft.
-  const composerText = state.selectedThreadId === threadId ? "" : (state.composerText ?? "");
-  return { composerText, composerTextByThreadId: nextById };
 }
 
 export async function hydrateThreadSelection(
@@ -400,14 +376,11 @@ export async function hydrateThreadSelection(
     if (!isOperationCurrent()) return;
     const selectedTaskId = selectedTaskIdForThread(thread);
     set((state) => {
-      const draft = swapComposerDraft(state, state.selectedThreadId, threadId);
       return {
         selectedThreadId: threadId,
         selectedWorkspaceId: thread.workspaceId,
         selectedTaskId,
         view: options.preserveView ? state.view : "chat",
-        composerText: draft.composerText,
-        composerTextByThreadId: draft.composerTextByThreadId,
         threadRuntimeById: {
           ...state.threadRuntimeById,
           [threadId]: {
@@ -491,14 +464,11 @@ export async function hydrateThreadSelection(
   if (!isOperationCurrent()) return;
   set((state) => {
     if (!isOperationCurrent()) return {};
-    const draft = swapComposerDraft(state, state.selectedThreadId, threadId);
     return {
       selectedThreadId: threadId,
       selectedWorkspaceId: thread.workspaceId,
       selectedTaskId,
       view: options.preserveView ? state.view : "chat",
-      composerText: draft.composerText,
-      composerTextByThreadId: draft.composerTextByThreadId,
       threadRuntimeById: {
         ...state.threadRuntimeById,
         [threadId]: {
@@ -673,6 +643,13 @@ export function createThreadActions(
   | "setThreadModel"
   | "setThreadReasoningEffort"
   | "setComposerText"
+  | "addComposerAttachments"
+  | "removeComposerAttachment"
+  | "setComposerDraftModel"
+  | "setComposerDraftReasoningEffort"
+  | "clearComposerDraft"
+  | "discardComposerDraft"
+  | "pruneComposerDrafts"
   | "setInjectContext"
   | "answerAsk"
   | "answerApproval"
@@ -784,6 +761,7 @@ export function createThreadActions(
 
     removeThread: async (threadId: string) => {
       const thread = get().threads.find((t) => t.id === threadId);
+      get().discardComposerDraft(composerDraftKeyForThread(threadId));
       const runtimeSessionId = get().threadRuntimeById[threadId]?.sessionId ?? null;
       const sessionSnapshotIds = thread
         ? sessionSnapshotIdsForThread(thread, runtimeSessionId)
@@ -1049,18 +1027,29 @@ export function createThreadActions(
         draft: !createSessionImmediately,
       };
 
+      let queuedDraftSubmission = opts?.draftSubmission;
       set((s) => {
-        const draft = swapComposerDraft(s, s.selectedThreadId, threadId);
+        let composerDraftsByKey = s.composerDraftsByKey;
+        if (queuedDraftSubmission) {
+          const submittedDraft = composerDraftsByKey[queuedDraftSubmission.key];
+          if (submittedDraft?.revision === queuedDraftSubmission.revision) {
+            const nextKey = composerDraftKeyForThread(threadId);
+            const nextDrafts = { ...composerDraftsByKey };
+            delete nextDrafts[queuedDraftSubmission.key];
+            nextDrafts[nextKey] = submittedDraft;
+            composerDraftsByKey = nextDrafts;
+            queuedDraftSubmission = {
+              key: nextKey,
+              revision: queuedDraftSubmission.revision,
+            };
+          }
+        }
         return {
           threads: [thread, ...s.threads],
           selectedThreadId: threadId,
           selectedTaskId: null,
           view: "chat",
-          composerText: "",
-          composerTextByThreadId: {
-            ...draft.composerTextByThreadId,
-            // New thread starts empty even if draft map had a stale id collision.
-          },
+          composerDraftsByKey,
           newChatLandingTarget: null,
         };
       });
@@ -1110,6 +1099,7 @@ export function createThreadActions(
           firstMessage,
           resolvedAttachments,
           opts?.references,
+          queuedDraftSubmission,
         );
       }
       ensureThreadSocket(
@@ -1134,16 +1124,11 @@ export function createThreadActions(
         (opts?.defaultTargetKind === "oneOff"
           ? { kind: "oneOff" }
           : resolveDefaultNewChatTarget(state.workspaces, state.selectedWorkspaceId));
-      set((s) => {
-        const draft = swapComposerDraft(s, s.selectedThreadId, null);
-        return {
-          selectedThreadId: null,
-          selectedTaskId: null,
-          view: "chat",
-          composerText: draft.composerText,
-          composerTextByThreadId: draft.composerTextByThreadId,
-          newChatLandingTarget: landingTarget,
-        };
+      set({
+        selectedThreadId: null,
+        selectedTaskId: null,
+        view: "chat",
+        newChatLandingTarget: landingTarget,
       });
       syncDesktopStateCache(get);
       await persistNow(get);
@@ -1175,6 +1160,7 @@ export function createThreadActions(
         references?: import("../../lib/wsProtocol").TurnReference[];
         refreshSnapshot?: boolean;
         signal?: AbortSignal;
+        draftSubmission?: ComposerDraftRevision;
       },
     ) => {
       const isReconnectCurrent = () =>
@@ -1226,6 +1212,8 @@ export function createThreadActions(
           firstMessage ?? "",
           opts?.attachments,
           opts?.references,
+          undefined,
+          opts?.draftSubmission,
         );
       }
       if (!isReconnectCurrent()) return false;
@@ -1247,12 +1235,23 @@ export function createThreadActions(
       busyPolicy: ThreadBusyPolicy = "reject",
       attachments?: import("../store.helpers/jsonRpcSocket").FileAttachmentInput[],
       references?: import("../../lib/wsProtocol").TurnReference[],
+      options?: {
+        targetThreadId?: string;
+        draftSubmission?: ComposerDraftRevision;
+      },
     ): Promise<boolean> => {
-      const activeThreadId = get().selectedThreadId;
+      const activeThreadId = options?.targetThreadId ?? get().selectedThreadId;
       if (!activeThreadId) return false;
 
       const thread = get().threads.find((t) => t.id === activeThreadId);
       if (!thread) return false;
+      const threadDraftKey = composerDraftKeyForThread(activeThreadId);
+      const currentDraft = get().composerDraftsByKey[threadDraftKey];
+      const draftSubmission =
+        options?.draftSubmission ??
+        (currentDraft && currentDraft.text.trim() === text.trim()
+          ? { key: threadDraftKey, revision: currentDraft.revision }
+          : undefined);
 
       if (!(thread.workspaceId in get().taskSummariesByWorkspaceId)) {
         // Warm task summaries without blocking the send; the server enforces
@@ -1276,7 +1275,7 @@ export function createThreadActions(
             arguments: taskCommand[1]?.trim() ?? "",
             clientMessageId: makeId(),
           });
-          set((state) => clearComposerDraftForThread(state, activeThreadId));
+          if (draftSubmission) get().clearComposerDraft(draftSubmission);
           return true;
         } catch (error) {
           const detail = error instanceof Error ? error.message : String(error);
@@ -1304,9 +1303,9 @@ export function createThreadActions(
           firstMessage,
           attachments,
           references,
+          draftSubmission,
         });
         if (!started) return false;
-        set((state) => clearComposerDraftForThread(state, activeThreadId));
         return true;
       }
 
@@ -1316,9 +1315,9 @@ export function createThreadActions(
         const reconnected = await get().reconnectThread(activeThreadId, firstMessage, {
           attachments,
           references,
+          draftSubmission,
         });
         if (!reconnected) return false;
-        set((state) => clearComposerDraftForThread(state, activeThreadId));
         return true;
       }
 
@@ -1330,11 +1329,10 @@ export function createThreadActions(
         busyPolicy,
         attachments,
         references,
+        undefined,
+        draftSubmission,
       );
       if (!accepted) return false;
-      if (busyPolicy === "steer" && rt?.busy) return true;
-
-      set((state) => clearComposerDraftForThread(state, activeThreadId));
       return true;
     },
 
@@ -1496,14 +1494,194 @@ export function createThreadActions(
       }
     },
 
-    setComposerText: (text) =>
+    setComposerText: (text, references = []) => {
       set((state) => {
-        const draftKey = composerDraftKey(state.selectedThreadId);
-        const nextById = { ...(state.composerTextByThreadId ?? {}) };
-        if (text.length > 0) nextById[draftKey] = text;
-        else delete nextById[draftKey];
-        return { composerText: text, composerTextByThreadId: nextById };
-      }),
+        const key = resolveActiveComposerDraftKey(state);
+        const current = state.composerDraftsByKey[key] ?? createEmptyComposerDraft(nowIso());
+        return {
+          composerDraftsByKey: {
+            ...state.composerDraftsByKey,
+            [key]: {
+              ...current,
+              revision: current.revision + 1,
+              updatedAt: nowIso(),
+              text,
+              references: references.map((reference) => ({ ...reference })),
+            },
+          },
+        };
+      });
+      persist(get);
+    },
+
+    addComposerAttachments: async (files) => {
+      if (files.length === 0) return;
+      const ownerKey = resolveActiveComposerDraftKey(get());
+      let ownerGeneration = 1;
+      set((state) => {
+        const existing = state.composerDraftsByKey[ownerKey];
+        const current = existing ?? createEmptyComposerDraft(nowIso());
+        ownerGeneration = Math.max(1, current.generation);
+        if (existing && existing.generation === ownerGeneration) return {};
+        return {
+          composerDraftsByKey: {
+            ...state.composerDraftsByKey,
+            [ownerKey]: {
+              ...current,
+              generation: ownerGeneration,
+            },
+          },
+        };
+      });
+      const attachments: ComposerDraftAttachment[] = [];
+      try {
+        for (const file of files) {
+          attachments.push(await createComposerDraftAttachment(file));
+        }
+      } catch (error) {
+        revokeComposerDraftAttachmentPreviews(attachments);
+        throw error;
+      }
+      let accepted = false;
+      set((state) => {
+        const current = state.composerDraftsByKey[ownerKey] ?? createEmptyComposerDraft(nowIso());
+        if (current.generation !== ownerGeneration) return {};
+        accepted = true;
+        return {
+          composerDraftsByKey: {
+            ...state.composerDraftsByKey,
+            [ownerKey]: {
+              ...current,
+              revision: current.revision + 1,
+              updatedAt: nowIso(),
+              attachments: [...current.attachments, ...attachments],
+            },
+          },
+        };
+      });
+      if (!accepted) {
+        revokeComposerDraftAttachmentPreviews(attachments);
+        return;
+      }
+      persist(get);
+    },
+
+    removeComposerAttachment: (index) => {
+      let removed: ComposerDraftAttachment[] = [];
+      set((state) => {
+        const key = resolveActiveComposerDraftKey(state);
+        const current = state.composerDraftsByKey[key];
+        if (!current?.attachments[index]) return {};
+        removed = [current.attachments[index]];
+        return {
+          composerDraftsByKey: {
+            ...state.composerDraftsByKey,
+            [key]: {
+              ...current,
+              revision: current.revision + 1,
+              updatedAt: nowIso(),
+              attachments: current.attachments.filter(
+                (_attachment, currentIndex) => currentIndex !== index,
+              ),
+            },
+          },
+        };
+      });
+      revokeComposerDraftAttachmentPreviews(removed);
+      persist(get);
+    },
+
+    setComposerDraftModel: (provider, model) => {
+      const normalizedModel = model.trim();
+      if (!normalizedModel) return;
+      set((state) => {
+        const key = resolveActiveComposerDraftKey(state);
+        const current = state.composerDraftsByKey[key] ?? createEmptyComposerDraft(nowIso());
+        if (current.provider === provider && current.model === normalizedModel) return {};
+        return {
+          composerDraftsByKey: {
+            ...state.composerDraftsByKey,
+            [key]: {
+              ...current,
+              revision: current.revision + 1,
+              updatedAt: nowIso(),
+              provider,
+              model: normalizedModel,
+              reasoningEffort: null,
+            },
+          },
+        };
+      });
+      persist(get);
+    },
+
+    setComposerDraftReasoningEffort: (effort) => {
+      set((state) => {
+        const key = resolveActiveComposerDraftKey(state);
+        const current = state.composerDraftsByKey[key] ?? createEmptyComposerDraft(nowIso());
+        if (current.reasoningEffort === effort) return {};
+        return {
+          composerDraftsByKey: {
+            ...state.composerDraftsByKey,
+            [key]: {
+              ...current,
+              revision: current.revision + 1,
+              updatedAt: nowIso(),
+              reasoningEffort: effort,
+            },
+          },
+        };
+      });
+      persist(get);
+    },
+
+    clearComposerDraft: (owner) => {
+      let cleared = false;
+      let removedAttachments: ReturnType<typeof clearComposerDraftRevision>["removedAttachments"] =
+        [];
+      set((state) => {
+        const result = clearComposerDraftRevision(state.composerDraftsByKey, owner);
+        cleared = result.cleared;
+        removedAttachments = result.removedAttachments;
+        return result.cleared ? { composerDraftsByKey: result.drafts } : {};
+      });
+      if (cleared) {
+        revokeComposerDraftAttachmentPreviews(removedAttachments);
+        persist(get);
+      }
+      return cleared;
+    },
+
+    discardComposerDraft: (key) => {
+      const ownerKey = key ?? resolveActiveComposerDraftKey(get());
+      const current = get().composerDraftsByKey[ownerKey];
+      if (!current) return false;
+      const owner = { key: ownerKey, revision: current.revision };
+      return get().clearComposerDraft(owner);
+    },
+
+    pruneComposerDrafts: (nowMs) => {
+      let removedAttachments: ReturnType<typeof pruneComposerDraftEntries>["removedAttachments"] =
+        [];
+      let changed = false;
+      set((state) => {
+        const result = pruneComposerDraftEntries(state.composerDraftsByKey, {
+          nowMs,
+          validThreadIds: new Set(state.threads.map((thread) => thread.id)),
+          validProjectWorkspaceIds: new Set(
+            state.workspaces
+              .filter((workspace) => !isOneOffChatWorkspace(workspace))
+              .map((workspace) => workspace.id),
+          ),
+          activeKey: resolveActiveComposerDraftKey(state),
+        });
+        removedAttachments = result.removedAttachments;
+        changed = result.removedKeys.length > 0;
+        return result.removedKeys.length > 0 ? { composerDraftsByKey: result.drafts } : {};
+      });
+      revokeComposerDraftAttachmentPreviews(removedAttachments);
+      if (changed) persist(get);
+    },
 
     setInjectContext: (v) => set({ injectContext: v }),
 

--- a/apps/desktop/src/app/store.actions/workspace.ts
+++ b/apps/desktop/src/app/store.actions/workspace.ts
@@ -268,6 +268,7 @@ export function createWorkspaceActions(
           newTaskWorkspaceId: s.newTaskWorkspaceId === workspaceId ? null : s.newTaskWorkspaceId,
         };
       });
+      get().pruneComposerDrafts();
       clearWorkspaceStartState(workspaceId);
       await persistNow(get);
       captureProductEvent("workspace_removed", {

--- a/apps/desktop/src/app/store.actions/workspaceDefaults.ts
+++ b/apps/desktop/src/app/store.actions/workspaceDefaults.ts
@@ -656,6 +656,7 @@ export function createWorkspaceDefaultsActions(
       queuedAttachments,
       queuedReferences,
       next.clientMessageId,
+      next.draftSubmission,
     );
     if (!accepted) {
       prependPendingThreadMessageWithAttachments(
@@ -664,6 +665,7 @@ export function createWorkspaceDefaultsActions(
         queuedAttachments,
         queuedReferences,
         next.clientMessageId,
+        next.draftSubmission,
       );
     }
     return accepted;

--- a/apps/desktop/src/app/store.helpers.ts
+++ b/apps/desktop/src/app/store.helpers.ts
@@ -46,8 +46,10 @@ import type {
   ProviderName,
   SessionEvent,
   TodoItem,
+  TurnReference,
 } from "../lib/wsProtocol";
 import { PROVIDER_NAMES } from "../lib/wsProtocol";
+import type { ComposerDraftRevision, ComposerDraftsByKey } from "./composerDrafts";
 import type { ReasoningEffortValue } from "./openaiCompatibleProviderOptions";
 import { buildContextPreamble, extractUsageStateFromTranscript } from "./store.feedMapping";
 import { createControlSocketHelpers } from "./store.helpers/controlSocket";
@@ -263,9 +265,7 @@ export type AppStoreState = {
   providerLastAuthResult: ProviderAuthResultEvent | null;
   providerUiState: PersistedProviderUiState;
 
-  composerText: string;
-  /** Drafts keyed by thread id; active draft is mirrored in composerText. */
-  composerTextByThreadId: Record<string, string>;
+  composerDraftsByKey: ComposerDraftsByKey;
   newChatLandingTarget: NewChatLandingTarget | null;
   injectContext: boolean;
   developerMode: boolean;
@@ -324,6 +324,7 @@ export type AppStoreState = {
     provider?: ProviderName;
     model?: string;
     reasoningEffort?: ReasoningEffortValue;
+    draftSubmission?: ComposerDraftRevision;
   }) => Promise<boolean>;
   openNewChatLanding: (opts?: {
     defaultTargetKind?: "project" | "oneOff";
@@ -345,6 +346,7 @@ export type AppStoreState = {
       references?: import("../lib/wsProtocol").TurnReference[];
       refreshSnapshot?: boolean;
       signal?: AbortSignal;
+      draftSubmission?: ComposerDraftRevision;
     },
   ) => Promise<boolean>;
   renameThread: (threadId: string, newTitle: string) => void;
@@ -354,6 +356,10 @@ export type AppStoreState = {
     busyPolicy?: ThreadBusyPolicy,
     attachments?: import("./store.helpers/jsonRpcSocket").FileAttachmentInput[],
     references?: import("../lib/wsProtocol").TurnReference[],
+    options?: {
+      targetThreadId?: string;
+      draftSubmission?: ComposerDraftRevision;
+    },
   ) => Promise<boolean>;
   cancelThread: (threadId: string, opts?: { includeSubagents?: boolean }) => void;
   clearThreadUsageHardCap: (threadId: string) => void;
@@ -363,7 +369,14 @@ export type AppStoreState = {
     provider: ProviderName,
     effort: ReasoningEffortValue,
   ) => void;
-  setComposerText: (text: string) => void;
+  setComposerText: (text: string, references?: TurnReference[]) => void;
+  addComposerAttachments: (files: File[]) => Promise<void>;
+  removeComposerAttachment: (index: number) => void;
+  setComposerDraftModel: (provider: ProviderName, model: string) => void;
+  setComposerDraftReasoningEffort: (effort: ReasoningEffortValue | null) => void;
+  clearComposerDraft: (owner: ComposerDraftRevision) => boolean;
+  discardComposerDraft: (key?: string) => boolean;
+  pruneComposerDrafts: (nowMs?: number) => void;
   setInjectContext: (v: boolean) => void;
   setDeveloperMode: (v: boolean) => void;
   setShowHiddenFiles: (v: boolean) => void;

--- a/apps/desktop/src/app/store.helpers.ts
+++ b/apps/desktop/src/app/store.helpers.ts
@@ -49,7 +49,11 @@ import type {
   TurnReference,
 } from "../lib/wsProtocol";
 import { PROVIDER_NAMES } from "../lib/wsProtocol";
-import type { ComposerDraftRevision, ComposerDraftsByKey } from "./composerDrafts";
+import type {
+  ComposerDraftRevision,
+  ComposerDraftRevisionFloor,
+  ComposerDraftsByKey,
+} from "./composerDrafts";
 import type { ReasoningEffortValue } from "./openaiCompatibleProviderOptions";
 import { buildContextPreamble, extractUsageStateFromTranscript } from "./store.feedMapping";
 import { createControlSocketHelpers } from "./store.helpers/controlSocket";
@@ -266,6 +270,8 @@ export type AppStoreState = {
   providerUiState: PersistedProviderUiState;
 
   composerDraftsByKey: ComposerDraftsByKey;
+  composerDraftRevisionFloorByKey: Record<string, ComposerDraftRevisionFloor>;
+  composerAttachmentIngestionCountByKey: Record<string, number>;
   newChatLandingTarget: NewChatLandingTarget | null;
   injectContext: boolean;
   developerMode: boolean;
@@ -376,7 +382,7 @@ export type AppStoreState = {
   setComposerDraftReasoningEffort: (effort: ReasoningEffortValue | null) => void;
   clearComposerDraft: (owner: ComposerDraftRevision) => boolean;
   discardComposerDraft: (key?: string) => boolean;
-  pruneComposerDrafts: (nowMs?: number) => void;
+  pruneComposerDrafts: (nowMs?: number, maxAgeMs?: number) => void;
   setInjectContext: (v: boolean) => void;
   setDeveloperMode: (v: boolean) => void;
   setShowHiddenFiles: (v: boolean) => void;

--- a/apps/desktop/src/app/store.helpers/persistence.ts
+++ b/apps/desktop/src/app/store.helpers/persistence.ts
@@ -1,5 +1,10 @@
 import { saveState } from "../../lib/desktopCommands";
 import { getDesktopWindowMode } from "../../lib/windowMode";
+import {
+  pruneComposerDrafts,
+  resolveActiveComposerDraftKey,
+  serializeComposerDrafts,
+} from "../composerDrafts";
 import { saveDesktopStateCache } from "../localStateCache";
 import { normalizePersistedProviderState } from "../persistedProviderState";
 import { normalizePersistedProviderUiState } from "../providerUiState";
@@ -33,7 +38,10 @@ function buildPersistableThreads(state: AppStoreState) {
   return state.threads.filter((thread) => thread.draft !== true && !thread.taskId);
 }
 
-function buildPersistedState(state: AppStoreState): PersistedState {
+function buildPersistedState(
+  state: AppStoreState,
+  options: { includeDraftAttachmentData?: boolean } = {},
+): PersistedState {
   const providerState = normalizePersistedProviderState({
     statusByName: state.providerStatusByName,
     statusLastUpdatedAt: state.providerStatusLastUpdatedAt,
@@ -44,6 +52,21 @@ function buildPersistedState(state: AppStoreState): PersistedState {
     ...workspace,
     wsProtocol: "jsonrpc" as const,
   }));
+  const prunedDrafts = pruneComposerDrafts(state.composerDraftsByKey ?? {}, {
+    validThreadIds: new Set(threads.map((thread) => thread.id)),
+    validProjectWorkspaceIds: new Set(
+      workspaces
+        .filter((workspace) => workspace.workspaceKind !== "oneOffChat")
+        .map((workspace) => workspace.id),
+    ),
+    activeKey: resolveActiveComposerDraftKey(state),
+  }).drafts;
+  const composerDrafts = serializeComposerDrafts(prunedDrafts);
+  if (options.includeDraftAttachmentData === false) {
+    for (const draft of Object.values(composerDrafts)) {
+      draft.attachments = [];
+    }
+  }
 
   return {
     version: 2,
@@ -59,6 +82,7 @@ function buildPersistedState(state: AppStoreState): PersistedState {
     ...(providerState ? { providerState } : {}),
     providerUiState,
     onboarding: state.onboardingState,
+    composerDrafts,
   };
 }
 
@@ -82,6 +106,7 @@ function buildCachedDesktopUiState(state: AppStoreState): CachedDesktopUiState {
     contextSidebarWidth: state.contextSidebarWidth,
     canvasSidebarWidth: state.canvasSidebarWidth,
     messageBarHeight: state.messageBarHeight,
+    newChatLandingTarget: state.newChatLandingTarget,
   };
 }
 
@@ -92,7 +117,7 @@ function syncDesktopStateCacheState(state: AppStoreState): PersistedState {
   }
   saveDesktopStateCache({
     version: 2,
-    persistedState,
+    persistedState: buildPersistedState(state, { includeDraftAttachmentData: false }),
     ui: buildCachedDesktopUiState(state),
     sessionSnapshots: Object.fromEntries(RUNTIME.sessionSnapshots.entries()),
   });

--- a/apps/desktop/src/app/store.helpers/runtimeState.ts
+++ b/apps/desktop/src/app/store.helpers/runtimeState.ts
@@ -81,6 +81,8 @@ export type RuntimeMaps = {
   mcpOAuthRefreshPollGenerations: Map<string, number>;
   /** Per-workspace counter used to ignore stale subagent profile catalog reads after mutations. */
   agentProfilesCatalogGenerations: Map<string, number>;
+  /** Serializes persisted attachment conversion so cross-draft byte reservations cannot race. */
+  composerAttachmentIngestionTail: Promise<void> | null;
 };
 
 export const RUNTIME: RuntimeMaps = {
@@ -106,6 +108,7 @@ export const RUNTIME: RuntimeMaps = {
   providerStatusRefreshGeneration: 0,
   mcpOAuthRefreshPollGenerations: new Map(),
   agentProfilesCatalogGenerations: new Map(),
+  composerAttachmentIngestionTail: null,
 };
 
 export function getAgentProfilesCatalogGeneration(workspaceId: string): number {

--- a/apps/desktop/src/app/store.helpers/runtimeState.ts
+++ b/apps/desktop/src/app/store.helpers/runtimeState.ts
@@ -1,5 +1,6 @@
 import type { JsonRpcSocket } from "../../lib/agentSocket";
 import type { ProviderName, TurnReference } from "../../lib/wsProtocol";
+import type { ComposerDraftRevision } from "../composerDrafts";
 import type { ReasoningEffortValue } from "../openaiCompatibleProviderOptions";
 import {
   clearThreadModelStreamRuntime,
@@ -46,6 +47,7 @@ export type PendingThreadMessage = {
    * and the server echo dedups against it.
    */
   clientMessageId?: string;
+  draftSubmission?: ComposerDraftRevision;
 };
 
 export type RuntimeMaps = {
@@ -139,11 +141,16 @@ export function queuePendingThreadMessage(
   attachments?: import("./jsonRpcSocket").FileAttachmentInput[],
   references?: TurnReference[],
   clientMessageId?: string,
+  draftSubmission?: ComposerDraftRevision,
 ) {
   const trimmed = text.trim();
   if (!trimmed && (!attachments || attachments.length === 0)) return;
   const existing = RUNTIME.pendingThreadMessages.get(threadId) ?? [];
-  existing.push({ text: trimmed, ...(clientMessageId ? { clientMessageId } : {}) });
+  existing.push({
+    text: trimmed,
+    ...(clientMessageId ? { clientMessageId } : {}),
+    ...(draftSubmission ? { draftSubmission } : {}),
+  });
   RUNTIME.pendingThreadMessages.set(threadId, existing);
   const existingAttachments = RUNTIME.pendingThreadAttachments.get(threadId) ?? [];
   existingAttachments.push(attachments && attachments.length > 0 ? attachments : undefined);
@@ -197,11 +204,16 @@ export function prependPendingThreadMessageWithAttachments(
   attachments?: import("./jsonRpcSocket").FileAttachmentInput[],
   references?: TurnReference[],
   clientMessageId?: string,
+  draftSubmission?: ComposerDraftRevision,
 ) {
   const trimmed = text.trim();
   if (!trimmed && (!attachments || attachments.length === 0)) return;
   const existingMessages = RUNTIME.pendingThreadMessages.get(threadId) ?? [];
-  existingMessages.unshift({ text: trimmed, ...(clientMessageId ? { clientMessageId } : {}) });
+  existingMessages.unshift({
+    text: trimmed,
+    ...(clientMessageId ? { clientMessageId } : {}),
+    ...(draftSubmission ? { draftSubmission } : {}),
+  });
   RUNTIME.pendingThreadMessages.set(threadId, existingMessages);
   const existingAttachments = RUNTIME.pendingThreadAttachments.get(threadId) ?? [];
   existingAttachments.unshift(attachments && attachments.length > 0 ? attachments : undefined);

--- a/apps/desktop/src/app/store.helpers/threadEventReducer/handlers/lifecycleHandlers.ts
+++ b/apps/desktop/src/app/store.helpers/threadEventReducer/handlers/lifecycleHandlers.ts
@@ -317,19 +317,6 @@ export function handleLifecycleThreadEvent(
         };
       });
     }
-    const activeThreadId = get().selectedThreadId;
-    const composerText = get().composerText.trim();
-    if (
-      activeThreadId === threadId &&
-      composerText.length > 0 &&
-      composerText === evt.text.trim()
-    ) {
-      set((state) => {
-        const nextById = { ...state.composerTextByThreadId };
-        if (state.selectedThreadId) delete nextById[state.selectedThreadId];
-        return { composerText: "", composerTextByThreadId: nextById };
-      });
-    }
     return true;
   }
 

--- a/apps/desktop/src/app/store.helpers/threadEventReducer/messaging.ts
+++ b/apps/desktop/src/app/store.helpers/threadEventReducer/messaging.ts
@@ -1,6 +1,7 @@
 import { parseLmStudioUnreachableError } from "../../../lib/lmStudioLocalError";
 import type { TurnReference } from "../../../lib/wsProtocol";
 import { buildAttachmentSignature, buildUserInputDisplayText } from "../../attachmentInputs";
+import type { ComposerDraftRevision } from "../../composerDrafts";
 import type { StoreGet, StoreSet } from "../../store.helpers";
 import type { FeedItem, ThreadBusyPolicy } from "../../types";
 import {
@@ -251,6 +252,7 @@ export function createMessagingModule(
     clientMessageId: string,
     attachments?: FileAttachmentInput[],
     references?: TurnReference[],
+    draftSubmission?: ComposerDraftRevision,
   ) {
     void startJsonRpcTurn(
       get,
@@ -261,43 +263,47 @@ export function createMessagingModule(
       clientMessageId,
       attachments,
       references,
-    ).catch((error) => {
-      const lmStudio = parseLmStudioUnreachableError(error);
-      if (lmStudio) {
-        // The server rejected the turn before it reached the session, so the
-        // send is retry-safe: keep the optimistic bubble, unblock the
-        // composer, and open the start-LM-Studio modal holding the retry
-        // payload (same clientMessageId dedups the re-send).
-        set((s) => {
-          const rt = s.threadRuntimeById[threadId];
-          const pendingCleared =
-            rt && rt.pendingTurnStart?.clientMessageId === clientMessageId
-              ? {
-                  threadRuntimeById: {
-                    ...s.threadRuntimeById,
-                    [threadId]: { ...rt, pendingTurnStart: null },
-                  },
-                }
-              : {};
-          return {
-            ...pendingCleared,
-            lmStudioStartModal: {
-              threadId,
-              workspaceId,
-              baseUrl: lmStudio.baseUrl,
-              installed: lmStudio.installed,
-              canAutoStart: lmStudio.canAutoStart,
-              phase: "prompt",
-              retry: { text, clientMessageId, attachments, references },
-            },
-          };
+    )
+      .then(() => {
+        if (draftSubmission) get().clearComposerDraft(draftSubmission);
+      })
+      .catch((error) => {
+        const lmStudio = parseLmStudioUnreachableError(error);
+        if (lmStudio) {
+          // The server rejected the turn before it reached the session, so the
+          // send is retry-safe: keep the optimistic bubble, unblock the
+          // composer, and open the start-LM-Studio modal holding the retry
+          // payload (same clientMessageId dedups the re-send).
+          set((s) => {
+            const rt = s.threadRuntimeById[threadId];
+            const pendingCleared =
+              rt && rt.pendingTurnStart?.clientMessageId === clientMessageId
+                ? {
+                    threadRuntimeById: {
+                      ...s.threadRuntimeById,
+                      [threadId]: { ...rt, pendingTurnStart: null },
+                    },
+                  }
+                : {};
+            return {
+              ...pendingCleared,
+              lmStudioStartModal: {
+                threadId,
+                workspaceId,
+                baseUrl: lmStudio.baseUrl,
+                installed: lmStudio.installed,
+                canAutoStart: lmStudio.canAutoStart,
+                phase: "prompt",
+                retry: { text, clientMessageId, attachments, references, draftSubmission },
+              },
+            };
+          });
+          return;
+        }
+        surfaceJsonRpcTurnSendFailure(set, threadId, {
+          pendingTurnStartClientMessageId: clientMessageId,
         });
-        return;
-      }
-      surfaceJsonRpcTurnSendFailure(set, threadId, {
-        pendingTurnStartClientMessageId: clientMessageId,
       });
-    });
   }
 
   function dispatchJsonRpcTurnSteer(
@@ -311,6 +317,7 @@ export function createMessagingModule(
     clientMessageId: string,
     attachments?: FileAttachmentInput[],
     references?: TurnReference[],
+    draftSubmission?: ComposerDraftRevision,
   ) {
     void steerJsonRpcTurn(
       get,
@@ -322,9 +329,13 @@ export function createMessagingModule(
       clientMessageId,
       attachments,
       references,
-    ).catch(() => {
-      surfaceJsonRpcTurnSendFailure(set, threadId, { clientMessageId });
-    });
+    )
+      .then(() => {
+        if (draftSubmission) get().clearComposerDraft(draftSubmission);
+      })
+      .catch(() => {
+        surfaceJsonRpcTurnSendFailure(set, threadId, { clientMessageId });
+      });
   }
 
   // `true` means the reducer accepted the message locally; JSON-RPC failures
@@ -338,6 +349,7 @@ export function createMessagingModule(
     attachments?: FileAttachmentInput[],
     references?: TurnReference[],
     presetClientMessageId?: string,
+    draftSubmission?: ComposerDraftRevision,
   ): boolean {
     const trimmed = text.trim();
     const hasAttachments = attachments && attachments.length > 0;
@@ -362,7 +374,14 @@ export function createMessagingModule(
 
     if (rt.busy) {
       if (busyPolicy === "queue") {
-        queuePendingThreadMessage(threadId, trimmed, attachments, references);
+        queuePendingThreadMessage(
+          threadId,
+          trimmed,
+          attachments,
+          references,
+          undefined,
+          draftSubmission,
+        );
         return true;
       }
 
@@ -422,6 +441,7 @@ export function createMessagingModule(
           clientMessageId,
           attachments,
           references,
+          draftSubmission,
         );
         return true;
       }
@@ -481,6 +501,7 @@ export function createMessagingModule(
       clientMessageId,
       attachments,
       references,
+      draftSubmission,
     );
     return true;
   }
@@ -502,6 +523,7 @@ export function createMessagingModule(
       queuedAttachments,
       queuedReferences,
       next.clientMessageId,
+      next.draftSubmission,
     );
     if (!accepted) {
       prependPendingThreadMessageWithAttachments(
@@ -510,6 +532,7 @@ export function createMessagingModule(
         queuedAttachments,
         queuedReferences,
         next.clientMessageId,
+        next.draftSubmission,
       );
     }
     return accepted;

--- a/apps/desktop/src/app/store.ts
+++ b/apps/desktop/src/app/store.ts
@@ -70,8 +70,7 @@ const initialState: AppStoreDataState = {
   providerLastAuthResult: null,
   providerUiState: DEFAULT_PROVIDER_UI_STATE,
 
-  composerText: "",
-  composerTextByThreadId: {},
+  composerDraftsByKey: {},
   newChatLandingTarget: null,
   injectContext: false,
   developerMode: false,

--- a/apps/desktop/src/app/store.ts
+++ b/apps/desktop/src/app/store.ts
@@ -71,6 +71,8 @@ const initialState: AppStoreDataState = {
   providerUiState: DEFAULT_PROVIDER_UI_STATE,
 
   composerDraftsByKey: {},
+  composerDraftRevisionFloorByKey: {},
+  composerAttachmentIngestionCountByKey: {},
   newChatLandingTarget: null,
   injectContext: false,
   developerMode: false,

--- a/apps/desktop/src/app/types.ts
+++ b/apps/desktop/src/app/types.ts
@@ -25,6 +25,7 @@ import {
   type PersistedPrivacyTelemetrySettings,
   type PrivacyTelemetrySettings,
 } from "../../../../src/telemetry/config";
+import type { NewChatLandingTarget } from "../lib/newChatLanding";
 import { normalizeQuickChatShortcutAccelerator } from "../lib/quickChatShortcut";
 import type {
   ApprovalRiskCode,
@@ -44,6 +45,7 @@ import type {
   SkillUpdateCheckResult,
   TurnReference,
 } from "../lib/wsProtocol";
+import type { ComposerDraftRevision, PersistedComposerDrafts } from "./composerDrafts";
 import type {
   ReasoningEffortValue,
   WorkspaceProviderOptions,
@@ -355,6 +357,7 @@ export type CachedDesktopUiState = {
   contextSidebarWidth?: number;
   canvasSidebarWidth?: number;
   messageBarHeight?: number;
+  newChatLandingTarget?: NewChatLandingTarget | null;
 };
 
 export type DesktopStateCache = {
@@ -390,6 +393,7 @@ export type PersistedState = {
   providerState?: PersistedProviderState;
   providerUiState?: PersistedProviderUiState;
   onboarding?: PersistedOnboardingState;
+  composerDrafts?: PersistedComposerDrafts;
 };
 
 type TranscriptDirection = "server" | "client";
@@ -660,6 +664,7 @@ export type LmStudioStartModalState = {
     clientMessageId: string;
     attachments?: FileAttachmentInput[];
     references?: TurnReference[];
+    draftSubmission?: ComposerDraftRevision;
   } | null;
 };
 

--- a/apps/desktop/src/lib/composerAttachments.ts
+++ b/apps/desktop/src/lib/composerAttachments.ts
@@ -15,27 +15,17 @@ export type ComposerAttachmentFile = {
   mimeType: string;
   size: number;
   file: File;
-  previewUrl?: string;
   signature: string;
 };
 
 export function createComposerAttachmentFile(file: File): ComposerAttachmentFile {
-  const previewUrl =
-    file.type.startsWith("image/") && file instanceof Blob ? URL.createObjectURL(file) : undefined;
   return {
     filename: file.name,
     mimeType: file.type || "application/octet-stream",
     size: file.size,
     file,
-    previewUrl,
     signature: `${file.name}\u0000${file.type}\u0000${file.size}\u0000${file.lastModified}`,
   };
-}
-
-export function revokeComposerAttachmentPreview(attachment: ComposerAttachmentFile) {
-  if (attachment.previewUrl) {
-    URL.revokeObjectURL(attachment.previewUrl);
-  }
 }
 
 export function buildComposerAttachmentSignature(

--- a/apps/desktop/src/ui/ChatView.tsx
+++ b/apps/desktop/src/ui/ChatView.tsx
@@ -13,6 +13,12 @@ import {
   getAttachmentPickerValidationMessage,
 } from "../app/attachmentInputs";
 import {
+  type ComposerDraftAttachment,
+  type ComposerDraftRevision,
+  resolveActiveComposerDraftKey,
+  selectActiveComposerDraft,
+} from "../app/composerDrafts";
+import {
   getWorkspaceGoogleReasoningEffort,
   type ReasoningEffortValue,
 } from "../app/openaiCompatibleProviderOptions";
@@ -26,10 +32,7 @@ import { Button } from "../components/ui/button";
 import {
   appendAttachmentSkippedNotes,
   buildComposerAttachmentSignature,
-  type ComposerAttachmentFile,
-  createComposerAttachmentFile,
   resolveComposerAttachmentsForWorkspace,
-  revokeComposerAttachmentPreview,
 } from "../lib/composerAttachments";
 import { modelDisplayNamesFromCatalog, reasoningConfigFromCatalog } from "../lib/modelChoices";
 import type { ProviderName } from "../lib/wsProtocol";
@@ -117,7 +120,10 @@ export function ChatView({ readOnlyNotice }: ChatViewProps = {}) {
     if (!s.selectedThreadId) return null;
     return s.threadRuntimeById[s.selectedThreadId] ?? null;
   });
-  const composerText = useAppStore((s) => s.composerText);
+  const composerDraft = useAppStore(selectActiveComposerDraft);
+  const composerDraftKey = useAppStore(resolveActiveComposerDraftKey);
+  const composerText = composerDraft.text;
+  const pendingAttachments = composerDraft.attachments;
   const composerWorkspaceId = thread?.workspaceId ?? "";
   const workspaceSkills = useAppStore((s) => s.workspaceRuntimeById[composerWorkspaceId]?.skills);
   const workspacePluginsCatalog = useAppStore(
@@ -206,18 +212,66 @@ export function ChatView({ readOnlyNotice }: ChatViewProps = {}) {
     Map<string, CitationSource[]>
   >(() => new Map());
   const [cancelScopeDialogOpen, setCancelScopeDialogOpen] = useState(false);
-  const [pendingAttachments, setPendingAttachments] = useState<ComposerAttachmentFile[]>([]);
-  const [attachmentPickerError, setAttachmentPickerError] = useState<string | null>(null);
-  const [preparingAttachments, setPreparingAttachments] = useState(false);
+  const [attachmentPickerErrors, setAttachmentPickerErrors] = useState<Record<string, string>>({});
+  const [preparingDraftKeys, setPreparingDraftKeys] = useState<Set<string>>(() => new Set());
   const [composerOverlayHeight, setComposerOverlayHeight] = useState(composerOverlayMinHeight);
-  const [submittedAttachmentSignature, setSubmittedAttachmentSignature] = useState<string | null>(
-    null,
+  const [submittedAttachmentSignatures, setSubmittedAttachmentSignatures] = useState<
+    Record<string, string>
+  >({});
+  const attachmentPickerError = attachmentPickerErrors[composerDraftKey] ?? null;
+  const preparingAttachments = preparingDraftKeys.has(composerDraftKey);
+  const submittedAttachmentSignature = submittedAttachmentSignatures[composerDraftKey] ?? null;
+  const setAttachmentPickerError = useCallback(
+    (message: string | null) => {
+      setAttachmentPickerErrors((current) => {
+        if (message === null) {
+          if (!(composerDraftKey in current)) return current;
+          const next = { ...current };
+          delete next[composerDraftKey];
+          return next;
+        }
+        return { ...current, [composerDraftKey]: message };
+      });
+    },
+    [composerDraftKey],
   );
-
+  const setPreparingAttachments = useCallback(
+    (preparing: boolean) => {
+      setPreparingDraftKeys((current) => {
+        const next = new Set(current);
+        if (preparing) next.add(composerDraftKey);
+        else next.delete(composerDraftKey);
+        return next;
+      });
+    },
+    [composerDraftKey],
+  );
+  const setSubmittedAttachmentSignature = useCallback(
+    (signature: string | null) => {
+      setSubmittedAttachmentSignatures((current) => {
+        if (signature === null) {
+          if (!(composerDraftKey in current)) return current;
+          const next = { ...current };
+          delete next[composerDraftKey];
+          return next;
+        }
+        return { ...current, [composerDraftKey]: signature };
+      });
+    },
+    [composerDraftKey],
+  );
   const pendingTurnStart = rt?.pendingTurnStart ?? null;
   const isUploading = preparingAttachments || pendingTurnStart?.status === "sending";
 
   const setComposerText = useAppStore((s) => s.setComposerText);
+  const updateComposerText = useCallback(
+    (text: string) => {
+      setComposerText(text, extractReferencesFromText(text, mentionCatalog));
+    },
+    [mentionCatalog, setComposerText],
+  );
+  const addComposerAttachments = useAppStore((s) => s.addComposerAttachments);
+  const removeComposerAttachment = useAppStore((s) => s.removeComposerAttachment);
   const sendMessage = useAppStore((s) => s.sendMessage);
   const cancelThread = useAppStore((s) => s.cancelThread);
   const setThreadReasoningEffort = useAppStore((s) => s.setThreadReasoningEffort);
@@ -240,19 +294,13 @@ export function ChatView({ readOnlyNotice }: ChatViewProps = {}) {
 
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
-  const submitInFlightRef = useRef(false);
+  const submitInFlightRef = useRef(new Set<string>());
   const [messageBarOverlayElement, setMessageBarOverlayElement] = useState<HTMLDivElement | null>(
     null,
   );
   const messageBarOverlayRef = useCallback((element: HTMLDivElement | null) => {
     setMessageBarOverlayElement(element);
   }, []);
-  const pendingAttachmentsRef = useRef<ComposerAttachmentFile[]>([]);
-
-  useEffect(() => {
-    pendingAttachmentsRef.current = pendingAttachments;
-  }, [pendingAttachments]);
-
   useLayoutEffect(() => {
     const el = messageBarOverlayElement;
     if (!el) {
@@ -278,26 +326,6 @@ export function ChatView({ readOnlyNotice }: ChatViewProps = {}) {
     return () => observer.disconnect();
   }, [composerOverlayMinHeight, messageBarOverlayElement, readOnlyNotice, sourceTask]);
 
-  useEffect(() => {
-    return () => {
-      pendingAttachmentsRef.current.forEach(revokeComposerAttachmentPreview);
-    };
-  }, []);
-
-  const clearPendingAttachments = useCallback(() => {
-    setPendingAttachments((current) => {
-      current.forEach(revokeComposerAttachmentPreview);
-      return [];
-    });
-    setSubmittedAttachmentSignature(null);
-  }, []);
-
-  useEffect(() => {
-    clearPendingAttachments();
-    setAttachmentPickerError(null);
-    setPreparingAttachments(false);
-  }, [clearPendingAttachments, selectedThreadId]);
-
   const ingestAttachmentFiles = useCallback(
     async (selectedFiles: File[]) => {
       if (selectedFiles.length === 0) return;
@@ -313,12 +341,14 @@ export function ChatView({ readOnlyNotice }: ChatViewProps = {}) {
 
       setAttachmentPickerError(null);
       setSubmittedAttachmentSignature(null);
-      setPendingAttachments((prev) => [
-        ...prev,
-        ...selectedFiles.map(createComposerAttachmentFile),
-      ]);
+      await addComposerAttachments(selectedFiles);
     },
-    [pendingAttachments],
+    [
+      addComposerAttachments,
+      pendingAttachments,
+      setAttachmentPickerError,
+      setSubmittedAttachmentSignature,
+    ],
   );
 
   const handleFileSelect = useCallback(
@@ -331,18 +361,14 @@ export function ChatView({ readOnlyNotice }: ChatViewProps = {}) {
     [ingestAttachmentFiles],
   );
 
-  const removeAttachment = useCallback((index: number) => {
-    setAttachmentPickerError(null);
-    setSubmittedAttachmentSignature(null);
-    setPendingAttachments((prev) => {
-      const next = [...prev];
-      const [removed] = next.splice(index, 1);
-      if (removed) {
-        revokeComposerAttachmentPreview(removed);
-      }
-      return next;
-    });
-  }, []);
+  const removeAttachment = useCallback(
+    (index: number) => {
+      setAttachmentPickerError(null);
+      setSubmittedAttachmentSignature(null);
+      removeComposerAttachment(index);
+    },
+    [removeComposerAttachment, setAttachmentPickerError, setSubmittedAttachmentSignature],
+  );
 
   const feed = rt?.feed ?? [];
   const normalizedFeed = useMemo(
@@ -577,7 +603,7 @@ export function ChatView({ readOnlyNotice }: ChatViewProps = {}) {
     async (
       workspaceId: string,
       threadId: string,
-      attachments: readonly ComposerAttachmentFile[],
+      attachments: readonly ComposerDraftAttachment[],
     ): Promise<{ attachments: FileAttachmentInput[]; skippedNotes: string[] }> => {
       // Soft-skip failed attachments (same policy as NewChatLanding): keep successful
       // uploads and append skip notes to the message instead of hard-failing the send.
@@ -601,37 +627,39 @@ export function ChatView({ readOnlyNotice }: ChatViewProps = {}) {
   const submitComposer = useCallback(
     (busyPolicy: "reject" | "steer") => {
       if (!thread) return;
-      if (submitInFlightRef.current) return;
+      if (submitInFlightRef.current.has(composerDraftKey)) return;
       if (preparingAttachments) return;
       if (pendingTurnStart?.status === "sending") return;
       if (!composerText.trim() && pendingAttachments.length === 0) return;
 
       const targetThreadId = thread.id;
       const targetWorkspaceId = thread.workspaceId;
-      submitInFlightRef.current = true;
+      const draftSubmission: ComposerDraftRevision = {
+        key: composerDraftKey,
+        revision: composerDraft.revision,
+      };
+      const submittedText = composerText;
+      const submittedAttachments = [...pendingAttachments];
+      const submittedReferences = composerDraft.references.map((reference) => ({ ...reference }));
+      submitInFlightRef.current.add(composerDraftKey);
       setPreparingAttachments(true);
       setAttachmentPickerError(null);
       void (async () => {
         try {
-          let messageText = composerText;
+          let messageText = submittedText;
           let attachments: FileAttachmentInput[] | undefined;
-          if (pendingAttachments.length > 0) {
+          if (submittedAttachments.length > 0) {
             const resolved = await resolvePendingAttachmentsForSend(
               targetWorkspaceId,
               targetThreadId,
-              pendingAttachments,
+              submittedAttachments,
             );
             attachments = resolved.attachments.length > 0 ? resolved.attachments : undefined;
-            messageText = appendAttachmentSkippedNotes(composerText, resolved.skippedNotes);
+            messageText = appendAttachmentSkippedNotes(submittedText, resolved.skippedNotes);
           }
           const attachmentSignature =
             attachments && attachments.length > 0 ? buildAttachmentSignature(attachments) : null;
           setSubmittedAttachmentSignature(attachmentSignature);
-
-          if (useAppStore.getState().selectedThreadId !== targetThreadId) {
-            setSubmittedAttachmentSignature(null);
-            return;
-          }
 
           // Soft-skip may leave only notes (no files and no user text). Still send so the
           // model learns what failed; otherwise require real content.
@@ -640,18 +668,13 @@ export function ChatView({ readOnlyNotice }: ChatViewProps = {}) {
             return;
           }
 
-          const references = extractReferencesFromText(composerText, mentionCatalog);
           const accepted = await sendMessage(
             messageText,
             busyPolicy,
             attachments,
-            references.length > 0 ? references : undefined,
+            submittedReferences.length > 0 ? submittedReferences : undefined,
+            { targetThreadId, draftSubmission },
           );
-          if (accepted && busyPolicy !== "steer") {
-            clearPendingAttachments();
-            setAttachmentPickerError(null);
-            return;
-          }
           if (!accepted) {
             setSubmittedAttachmentSignature(null);
           }
@@ -660,36 +683,26 @@ export function ChatView({ readOnlyNotice }: ChatViewProps = {}) {
           const message = error instanceof Error ? error.message : String(error);
           setAttachmentPickerError(message);
         } finally {
-          submitInFlightRef.current = false;
+          submitInFlightRef.current.delete(composerDraftKey);
           setPreparingAttachments(false);
         }
       })();
     },
     [
-      clearPendingAttachments,
+      composerDraft,
+      composerDraftKey,
       composerText,
-      mentionCatalog,
       pendingAttachments,
       pendingTurnStart?.status,
       preparingAttachments,
       resolvePendingAttachmentsForSend,
       sendMessage,
+      setAttachmentPickerError,
+      setPreparingAttachments,
+      setSubmittedAttachmentSignature,
       thread,
     ],
   );
-
-  useEffect(() => {
-    if (pendingAttachments.length === 0) return;
-    if (rt?.pendingSteer?.status !== "accepted") return;
-    if ((rt.pendingSteer.attachmentSignature ?? "") !== pendingAttachmentSignature) return;
-    clearPendingAttachments();
-    setAttachmentPickerError(null);
-  }, [
-    clearPendingAttachments,
-    pendingAttachmentSignature,
-    pendingAttachments.length,
-    rt?.pendingSteer,
-  ]);
 
   const onComposerKeyDown = useCallback(
     (event: ReactKeyboardEvent<HTMLTextAreaElement>) => {
@@ -739,7 +752,7 @@ export function ChatView({ readOnlyNotice }: ChatViewProps = {}) {
         const end = textarea.selectionEnd;
         const value = textarea.value;
         const newValue = `${value.substring(0, start)}\n${value.substring(end)}`;
-        setComposerText(newValue);
+        updateComposerText(newValue);
         requestAnimationFrame(() => {
           textarea.selectionStart = textarea.selectionEnd = start + 1;
         });
@@ -757,22 +770,19 @@ export function ChatView({ readOnlyNotice }: ChatViewProps = {}) {
       rt?.busy,
       rt?.pendingSteer,
       rt?.sessionId,
-      setComposerText,
       sourceTask,
       submitComposer,
       thread?.status,
+      updateComposerText,
     ],
   );
 
   const retryFailedTurn = useCallback(async (): Promise<boolean> => {
     if (!thread || useAppStore.getState().selectedThreadId !== thread.id) return false;
-    const draftBeforeRetry = useAppStore.getState().composerText;
-    const accepted = await sendMessage(HIDDEN_RETRY_TURN_PROMPT, "reject");
-    if (accepted && draftBeforeRetry && useAppStore.getState().composerText === "") {
-      setComposerText(draftBeforeRetry);
-    }
-    return accepted;
-  }, [sendMessage, setComposerText, thread]);
+    return sendMessage(HIDDEN_RETRY_TURN_PROMPT, "reject", undefined, undefined, {
+      targetThreadId: thread.id,
+    });
+  }, [sendMessage, thread]);
 
   if (!selectedThreadId || !thread) {
     return <NewChatLanding />;
@@ -917,7 +927,7 @@ export function ChatView({ readOnlyNotice }: ChatViewProps = {}) {
             composerSubmitState={composerSubmitState}
             attachmentPickerError={attachmentPickerError}
             composerText={composerText}
-            setComposerText={setComposerText}
+            setComposerText={updateComposerText}
             onComposerKeyDown={onComposerKeyDown}
             mentionCatalog={mentionCatalog}
             placeholder={placeholder}

--- a/apps/desktop/src/ui/ChatView.tsx
+++ b/apps/desktop/src/ui/ChatView.tsx
@@ -8,13 +8,11 @@ import {
   buildCitationSourcesByMessageId,
   buildCitationUrlsByMessageId,
 } from "../../../../src/shared/displayCitationMarkers";
-import {
-  buildAttachmentSignature,
-  getAttachmentPickerValidationMessage,
-} from "../app/attachmentInputs";
+import { buildAttachmentSignature } from "../app/attachmentInputs";
 import {
   type ComposerDraftAttachment,
   type ComposerDraftRevision,
+  getComposerDraftAttachmentValidationMessage,
   resolveActiveComposerDraftKey,
   selectActiveComposerDraft,
 } from "../app/composerDrafts";
@@ -122,6 +120,9 @@ export function ChatView({ readOnlyNotice }: ChatViewProps = {}) {
   });
   const composerDraft = useAppStore(selectActiveComposerDraft);
   const composerDraftKey = useAppStore(resolveActiveComposerDraftKey);
+  const attachmentIngestionPending = useAppStore(
+    (state) => (state.composerAttachmentIngestionCountByKey[composerDraftKey] ?? 0) > 0,
+  );
   const composerText = composerDraft.text;
   const pendingAttachments = composerDraft.attachments;
   const composerWorkspaceId = thread?.workspaceId ?? "";
@@ -219,7 +220,8 @@ export function ChatView({ readOnlyNotice }: ChatViewProps = {}) {
     Record<string, string>
   >({});
   const attachmentPickerError = attachmentPickerErrors[composerDraftKey] ?? null;
-  const preparingAttachments = preparingDraftKeys.has(composerDraftKey);
+  const preparingAttachments =
+    preparingDraftKeys.has(composerDraftKey) || attachmentIngestionPending;
   const submittedAttachmentSignature = submittedAttachmentSignatures[composerDraftKey] ?? null;
   const setAttachmentPickerError = useCallback(
     (message: string | null) => {
@@ -330,8 +332,9 @@ export function ChatView({ readOnlyNotice }: ChatViewProps = {}) {
     async (selectedFiles: File[]) => {
       if (selectedFiles.length === 0) return;
 
-      const validationMessage = getAttachmentPickerValidationMessage(
-        pendingAttachments,
+      const validationMessage = getComposerDraftAttachmentValidationMessage(
+        useAppStore.getState().composerDraftsByKey,
+        composerDraftKey,
         selectedFiles,
       );
       if (validationMessage) {
@@ -341,11 +344,15 @@ export function ChatView({ readOnlyNotice }: ChatViewProps = {}) {
 
       setAttachmentPickerError(null);
       setSubmittedAttachmentSignature(null);
-      await addComposerAttachments(selectedFiles);
+      try {
+        await addComposerAttachments(selectedFiles);
+      } catch (error) {
+        setAttachmentPickerError(error instanceof Error ? error.message : String(error));
+      }
     },
     [
       addComposerAttachments,
-      pendingAttachments,
+      composerDraftKey,
       setAttachmentPickerError,
       setSubmittedAttachmentSignature,
     ],
@@ -629,6 +636,11 @@ export function ChatView({ readOnlyNotice }: ChatViewProps = {}) {
       if (!thread) return;
       if (submitInFlightRef.current.has(composerDraftKey)) return;
       if (preparingAttachments) return;
+      if (
+        (useAppStore.getState().composerAttachmentIngestionCountByKey[composerDraftKey] ?? 0) > 0
+      ) {
+        return;
+      }
       if (pendingTurnStart?.status === "sending") return;
       if (!composerText.trim() && pendingAttachments.length === 0) return;
 

--- a/apps/desktop/src/ui/chat/NewChatLanding.tsx
+++ b/apps/desktop/src/ui/chat/NewChatLanding.tsx
@@ -12,6 +12,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { getAttachmentCountValidationMessage } from "../../../../../src/shared/attachments";
 import { buildAttachmentDisplayText } from "../../app/attachmentInputs";
 import {
+  type ComposerDraftRevision,
+  resolveActiveComposerDraftKey,
+  selectActiveComposerDraft,
+} from "../../app/composerDrafts";
+import {
   getWorkspaceGoogleReasoningEffort,
   type ReasoningEffortValue,
 } from "../../app/openaiCompatibleProviderOptions";
@@ -32,10 +37,7 @@ import {
 import { Popover, PopoverContent, PopoverTrigger } from "../../components/ui/popover";
 import {
   appendAttachmentSkippedNotes,
-  type ComposerAttachmentFile,
-  createComposerAttachmentFile,
   resolveComposerAttachmentsForWorkspace,
-  revokeComposerAttachmentPreview,
 } from "../../lib/composerAttachments";
 import { modelDisplayNamesFromCatalog, reasoningConfigFromCatalog } from "../../lib/modelChoices";
 import { resolveNewChatLandingTarget } from "../../lib/newChatLanding";
@@ -62,8 +64,15 @@ export function NewChatLanding() {
   const workspaceLifecycleEnabled = useAppStore(
     (s) => s.desktopFeatureFlags.workspaceLifecycle !== false,
   );
-  const composerText = useAppStore((s) => s.composerText);
+  const composerDraft = useAppStore(selectActiveComposerDraft);
+  const composerDraftKey = useAppStore(resolveActiveComposerDraftKey);
+  const composerText = composerDraft.text;
+  const pendingAttachments = composerDraft.attachments;
   const setComposerText = useAppStore((s) => s.setComposerText);
+  const addComposerAttachments = useAppStore((s) => s.addComposerAttachments);
+  const removeComposerAttachment = useAppStore((s) => s.removeComposerAttachment);
+  const setComposerDraftModel = useAppStore((s) => s.setComposerDraftModel);
+  const setComposerDraftReasoningEffort = useAppStore((s) => s.setComposerDraftReasoningEffort);
   const addWorkspace = useAppStore((s) => s.addWorkspace);
   const newThread = useAppStore((s) => s.newThread);
   const newChatLandingTarget = useAppStore((s) => s.newChatLandingTarget);
@@ -73,13 +82,37 @@ export function NewChatLanding() {
     [newChatLandingTarget, selectedWorkspaceId, workspaces],
   );
   const [selectorOpen, setSelectorOpen] = useState(false);
-  const [submitting, setSubmitting] = useState(false);
-  const [modelTouched, setModelTouched] = useState(false);
-  const [pendingAttachments, setPendingAttachments] = useState<ComposerAttachmentFile[]>([]);
-  const [attachmentPickerError, setAttachmentPickerError] = useState<string | null>(null);
+  const [submittingDraftKeys, setSubmittingDraftKeys] = useState<Set<string>>(() => new Set());
+  const [attachmentPickerErrors, setAttachmentPickerErrors] = useState<Record<string, string>>({});
+  const submitting = submittingDraftKeys.has(composerDraftKey);
+  const attachmentPickerError = attachmentPickerErrors[composerDraftKey] ?? null;
+  const setSubmitting = useCallback(
+    (next: boolean) => {
+      setSubmittingDraftKeys((current) => {
+        const updated = new Set(current);
+        if (next) updated.add(composerDraftKey);
+        else updated.delete(composerDraftKey);
+        return updated;
+      });
+    },
+    [composerDraftKey],
+  );
+  const setAttachmentPickerError = useCallback(
+    (message: string | null) => {
+      setAttachmentPickerErrors((current) => {
+        if (message === null) {
+          if (!(composerDraftKey in current)) return current;
+          const next = { ...current };
+          delete next[composerDraftKey];
+          return next;
+        }
+        return { ...current, [composerDraftKey]: message };
+      });
+    },
+    [composerDraftKey],
+  );
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
-  const pendingAttachmentsRef = useRef<ComposerAttachmentFile[]>([]);
 
   const projectWorkspaces = useMemo(
     () => workspaces.filter((workspace) => !isOneOffChatWorkspace(workspace)),
@@ -112,6 +145,12 @@ export function NewChatLanding() {
           preferred);
     return buildMentionCatalog(source?.skills, source?.pluginsCatalog ?? null);
   }, [workspaceRuntimeById, mentionSourceWorkspaceId]);
+  const updateComposerText = useCallback(
+    (text: string) => {
+      setComposerText(text, extractReferencesFromText(text, mentionCatalog));
+    },
+    [mentionCatalog, setComposerText],
+  );
 
   const trimmedComposerText = composerText.trim();
   const hasPendingAttachments = pendingAttachments.length > 0;
@@ -124,13 +163,10 @@ export function NewChatLanding() {
     () => resolveDefaultNewChatModel(fallbackModelWorkspace),
     [fallbackModelWorkspace],
   );
-  const [modelSelection, setModelSelection] =
-    useState<ComposerModelSelection>(defaultModelSelection);
-  const [reasoningOverride, setReasoningOverride] = useState<{
-    provider: ComposerModelSelection["provider"];
-    model: string;
-    effort: ReasoningEffortValue;
-  } | null>(null);
+  const modelSelection: ComposerModelSelection =
+    composerDraft.provider && composerDraft.model
+      ? { provider: composerDraft.provider, model: composerDraft.model }
+      : defaultModelSelection;
 
   const reasoningConfig = useMemo(
     () =>
@@ -147,36 +183,11 @@ export function NewChatLanding() {
           )
         : undefined;
   const reasoningEffort: ReasoningEffortValue | null = reasoningConfig
-    ? reasoningOverride?.provider === modelSelection.provider &&
-      reasoningOverride.model === modelSelection.model
-      ? reasoningOverride.effort
-      : (workspaceReasoningEffort ?? reasoningConfig.defaultEffort)
+    ? (composerDraft.reasoningEffort ?? workspaceReasoningEffort ?? reasoningConfig.defaultEffort)
     : null;
-  useEffect(() => {
-    if (!modelTouched) {
-      setModelSelection(defaultModelSelection);
-    }
-  }, [defaultModelSelection, modelTouched]);
 
   useEffect(() => {
     textareaRef.current?.focus();
-  }, []);
-
-  useEffect(() => {
-    pendingAttachmentsRef.current = pendingAttachments;
-  }, [pendingAttachments]);
-
-  useEffect(() => {
-    return () => {
-      pendingAttachmentsRef.current.forEach(revokeComposerAttachmentPreview);
-    };
-  }, []);
-
-  const clearPendingAttachments = useCallback(() => {
-    setPendingAttachments((current) => {
-      current.forEach(revokeComposerAttachmentPreview);
-      return [];
-    });
   }, []);
 
   const ingestAttachmentFiles = useCallback(
@@ -192,12 +203,9 @@ export function NewChatLanding() {
       }
 
       setAttachmentPickerError(null);
-      setPendingAttachments((prev) => [
-        ...prev,
-        ...selectedFiles.map(createComposerAttachmentFile),
-      ]);
+      await addComposerAttachments(selectedFiles);
     },
-    [pendingAttachments.length, submitting],
+    [addComposerAttachments, pendingAttachments.length, setAttachmentPickerError, submitting],
   );
 
   const handleFileSelect = useCallback(
@@ -210,17 +218,13 @@ export function NewChatLanding() {
     [ingestAttachmentFiles],
   );
 
-  const removeAttachment = useCallback((index: number) => {
-    setAttachmentPickerError(null);
-    setPendingAttachments((prev) => {
-      const next = [...prev];
-      const [removed] = next.splice(index, 1);
-      if (removed) {
-        revokeComposerAttachmentPreview(removed);
-      }
-      return next;
-    });
-  }, []);
+  const removeAttachment = useCallback(
+    (index: number) => {
+      setAttachmentPickerError(null);
+      removeComposerAttachment(index);
+    },
+    [removeComposerAttachment, setAttachmentPickerError],
+  );
 
   const submitNewChat = useCallback(
     async (event?: FormEvent<HTMLFormElement>) => {
@@ -232,51 +236,61 @@ export function NewChatLanding() {
       setSubmitting(true);
       setAttachmentPickerError(null);
 
+      const submittedTarget = target;
+      const submittedText = composerText;
+      const submittedAttachments = [...pendingAttachments];
+      const submittedModelSelection = modelSelection;
+      const submittedReasoningEffort = reasoningEffort;
+      const draftSubmission: ComposerDraftRevision = {
+        key: composerDraftKey,
+        revision: composerDraft.revision,
+      };
       const attachmentTitleHint = buildAttachmentDisplayText(
-        pendingAttachments.map((attachment) => ({ filename: attachment.filename })),
+        submittedAttachments.map((attachment) => ({ filename: attachment.filename })),
       );
-      const titleHint = trimmedComposerText || attachmentTitleHint || "New chat";
-      const references = extractReferencesFromText(composerText, mentionCatalog);
+      const titleHint = submittedText.trim() || attachmentTitleHint || "New chat";
+      const references = extractReferencesFromText(submittedText, mentionCatalog);
       const referencesArg = references.length > 0 ? references : undefined;
 
       try {
-        let firstMessage = trimmedComposerText;
+        let firstMessage = submittedText.trim();
         let attachments: FileAttachmentInput[] | undefined;
         let attachmentFiles: File[] | undefined;
 
-        if (hasPendingAttachments) {
-          if (target.kind === "project") {
+        if (submittedAttachments.length > 0) {
+          if (submittedTarget.kind === "project") {
             await ensureServerRunning(
               useAppStore.getState,
               useAppStore.setState,
-              target.workspaceId,
+              submittedTarget.workspaceId,
             );
             const resolved = await resolveComposerAttachmentsForWorkspace(
               useAppStore.getState,
               useAppStore.setState,
-              target.workspaceId,
-              pendingAttachments,
+              submittedTarget.workspaceId,
+              submittedAttachments,
             );
             attachments = resolved.attachments.length > 0 ? resolved.attachments : undefined;
             firstMessage = appendAttachmentSkippedNotes(firstMessage, resolved.skippedNotes);
           } else {
-            attachmentFiles = pendingAttachments.map((attachment) => attachment.file);
+            attachmentFiles = submittedAttachments.map((attachment) => attachment.file);
           }
         }
 
         const ok =
-          target.kind === "project"
+          submittedTarget.kind === "project"
             ? await newThread({
                 scope: "project",
-                workspaceId: target.workspaceId,
+                workspaceId: submittedTarget.workspaceId,
                 firstMessage,
                 titleHint,
                 mode: "session",
                 attachments,
                 references: referencesArg,
-                provider: modelSelection.provider,
-                model: modelSelection.model,
-                reasoningEffort: reasoningEffort ?? undefined,
+                provider: submittedModelSelection.provider,
+                model: submittedModelSelection.model,
+                reasoningEffort: submittedReasoningEffort ?? undefined,
+                draftSubmission,
               })
             : await newThread({
                 scope: "oneOff",
@@ -285,15 +299,13 @@ export function NewChatLanding() {
                 mode: "session",
                 attachmentFiles,
                 references: referencesArg,
-                provider: modelSelection.provider,
-                model: modelSelection.model,
-                reasoningEffort: reasoningEffort ?? undefined,
+                provider: submittedModelSelection.provider,
+                model: submittedModelSelection.model,
+                reasoningEffort: submittedReasoningEffort ?? undefined,
+                draftSubmission,
               });
 
-        if (ok) {
-          clearPendingAttachments();
-          setComposerText("");
-        } else {
+        if (!ok) {
           setSubmitting(false);
         }
       } catch (error) {
@@ -304,18 +316,18 @@ export function NewChatLanding() {
     },
     [
       canSubmitNewChat,
-      clearPendingAttachments,
+      composerDraft,
+      composerDraftKey,
       composerText,
-      hasPendingAttachments,
       mentionCatalog,
       modelSelection,
       newThread,
       pendingAttachments,
       reasoningEffort,
-      setComposerText,
+      setAttachmentPickerError,
+      setSubmitting,
       submitting,
       target,
-      trimmedComposerText,
     ],
   );
 
@@ -385,7 +397,7 @@ export function NewChatLanding() {
               disabled={submitting}
               className="h-8 rounded-full border-border/60 bg-background/70 px-3 text-xs font-medium text-muted-foreground hover:bg-background hover:text-foreground"
               onClick={() => {
-                setComposerText(starter.prompt);
+                updateComposerText(starter.prompt);
                 requestAnimationFrame(() => textareaRef.current?.focus());
               }}
             >
@@ -419,7 +431,7 @@ export function NewChatLanding() {
               <ComposerMentionInput
                 textareaRef={textareaRef}
                 value={composerText}
-                setValue={setComposerText}
+                setValue={updateComposerText}
                 disabled={submitting}
                 placeholder="Message Cowork..."
                 catalog={mentionCatalog}
@@ -451,7 +463,7 @@ export function NewChatLanding() {
                     const end = textarea.selectionEnd;
                     const value = textarea.value;
                     const newValue = `${value.substring(0, start)}\n${value.substring(end)}`;
-                    setComposerText(newValue);
+                    updateComposerText(newValue);
                     requestAnimationFrame(() => {
                       textarea.selectionStart = textarea.selectionEnd = start + 1;
                     });
@@ -574,8 +586,7 @@ export function NewChatLanding() {
                       modelDisplayNames={modelDisplayNames}
                       disabled={submitting}
                       onChange={(selection) => {
-                        setModelTouched(true);
-                        setModelSelection(selection);
+                        setComposerDraftModel(selection.provider, selection.model);
                       }}
                     />
                     {reasoningConfig && reasoningEffort ? (
@@ -583,13 +594,7 @@ export function NewChatLanding() {
                         value={reasoningEffort}
                         options={reasoningConfig.availableEfforts}
                         disabled={submitting}
-                        onChange={(effort) => {
-                          setReasoningOverride({
-                            provider: modelSelection.provider,
-                            model: modelSelection.model,
-                            effort,
-                          });
-                        }}
+                        onChange={setComposerDraftReasoningEffort}
                       />
                     ) : null}
                   </>

--- a/apps/desktop/src/ui/chat/NewChatLanding.tsx
+++ b/apps/desktop/src/ui/chat/NewChatLanding.tsx
@@ -9,10 +9,10 @@ import {
 } from "lucide-react";
 import type { ChangeEvent, FormEvent, KeyboardEvent as ReactKeyboardEvent } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { getAttachmentCountValidationMessage } from "../../../../../src/shared/attachments";
 import { buildAttachmentDisplayText } from "../../app/attachmentInputs";
 import {
   type ComposerDraftRevision,
+  getComposerDraftAttachmentValidationMessage,
   resolveActiveComposerDraftKey,
   selectActiveComposerDraft,
 } from "../../app/composerDrafts";
@@ -66,6 +66,9 @@ export function NewChatLanding() {
   );
   const composerDraft = useAppStore(selectActiveComposerDraft);
   const composerDraftKey = useAppStore(resolveActiveComposerDraftKey);
+  const attachmentIngestionPending = useAppStore(
+    (state) => (state.composerAttachmentIngestionCountByKey[composerDraftKey] ?? 0) > 0,
+  );
   const composerText = composerDraft.text;
   const pendingAttachments = composerDraft.attachments;
   const setComposerText = useAppStore((s) => s.setComposerText);
@@ -85,6 +88,7 @@ export function NewChatLanding() {
   const [submittingDraftKeys, setSubmittingDraftKeys] = useState<Set<string>>(() => new Set());
   const [attachmentPickerErrors, setAttachmentPickerErrors] = useState<Record<string, string>>({});
   const submitting = submittingDraftKeys.has(composerDraftKey);
+  const composerLocked = submitting || attachmentIngestionPending;
   const attachmentPickerError = attachmentPickerErrors[composerDraftKey] ?? null;
   const setSubmitting = useCallback(
     (next: boolean) => {
@@ -154,7 +158,8 @@ export function NewChatLanding() {
 
   const trimmedComposerText = composerText.trim();
   const hasPendingAttachments = pendingAttachments.length > 0;
-  const canSubmitNewChat = Boolean(trimmedComposerText || hasPendingAttachments);
+  const canSubmitNewChat =
+    !attachmentIngestionPending && Boolean(trimmedComposerText || hasPendingAttachments);
   const modelDisplayNames = useMemo(
     () => modelDisplayNamesFromCatalog(providerCatalog),
     [providerCatalog],
@@ -192,10 +197,12 @@ export function NewChatLanding() {
 
   const ingestAttachmentFiles = useCallback(
     async (selectedFiles: File[]) => {
-      if (selectedFiles.length === 0 || submitting) return;
+      if (selectedFiles.length === 0 || composerLocked) return;
 
-      const validationMessage = getAttachmentCountValidationMessage(
-        pendingAttachments.length + selectedFiles.length,
+      const validationMessage = getComposerDraftAttachmentValidationMessage(
+        useAppStore.getState().composerDraftsByKey,
+        composerDraftKey,
+        selectedFiles,
       );
       if (validationMessage) {
         setAttachmentPickerError(validationMessage);
@@ -203,9 +210,13 @@ export function NewChatLanding() {
       }
 
       setAttachmentPickerError(null);
-      await addComposerAttachments(selectedFiles);
+      try {
+        await addComposerAttachments(selectedFiles);
+      } catch (error) {
+        setAttachmentPickerError(error instanceof Error ? error.message : String(error));
+      }
     },
-    [addComposerAttachments, pendingAttachments.length, setAttachmentPickerError, submitting],
+    [addComposerAttachments, composerDraftKey, composerLocked, setAttachmentPickerError],
   );
 
   const handleFileSelect = useCallback(
@@ -230,6 +241,11 @@ export function NewChatLanding() {
     async (event?: FormEvent<HTMLFormElement>) => {
       event?.preventDefault();
       if (!canSubmitNewChat || submitting) {
+        return;
+      }
+      if (
+        (useAppStore.getState().composerAttachmentIngestionCountByKey[composerDraftKey] ?? 0) > 0
+      ) {
         return;
       }
 
@@ -394,7 +410,7 @@ export function NewChatLanding() {
               type="button"
               variant="outline"
               size="sm"
-              disabled={submitting}
+              disabled={composerLocked}
               className="h-8 rounded-full border-border/60 bg-background/70 px-3 text-xs font-medium text-muted-foreground hover:bg-background hover:text-foreground"
               onClick={() => {
                 updateComposerText(starter.prompt);
@@ -432,7 +448,7 @@ export function NewChatLanding() {
                 textareaRef={textareaRef}
                 value={composerText}
                 setValue={updateComposerText}
-                disabled={submitting}
+                disabled={composerLocked}
                 placeholder="Message Cowork..."
                 catalog={mentionCatalog}
                 ariaLabel="New chat message"
@@ -485,7 +501,7 @@ export function NewChatLanding() {
                   variant="ghost"
                   size="icon"
                   onClick={() => fileInputRef.current?.click()}
-                  disabled={submitting}
+                  disabled={composerLocked}
                   className="rounded-full text-muted-foreground hover:bg-muted/45 hover:text-foreground"
                   aria-label="Attach files"
                   title="Attach files"
@@ -500,7 +516,7 @@ export function NewChatLanding() {
                       size="sm"
                       className="h-8 min-w-0 max-w-full gap-1.5 rounded-md px-2 text-sm font-medium text-muted-foreground/90 hover:bg-muted/35 hover:text-foreground"
                       aria-label="Select chat target"
-                      disabled={submitting}
+                      disabled={composerLocked}
                     >
                       {target.kind === "project" ? (
                         <FolderIcon className="size-4 shrink-0" />
@@ -584,7 +600,7 @@ export function NewChatLanding() {
                       provider={modelSelection.provider}
                       model={modelSelection.model}
                       modelDisplayNames={modelDisplayNames}
-                      disabled={submitting}
+                      disabled={composerLocked}
                       onChange={(selection) => {
                         setComposerDraftModel(selection.provider, selection.model);
                       }}
@@ -593,7 +609,7 @@ export function NewChatLanding() {
                       <ComposerReasoningSelector
                         value={reasoningEffort}
                         options={reasoningConfig.availableEfforts}
-                        disabled={submitting}
+                        disabled={composerLocked}
                         onChange={setComposerDraftReasoningEffort}
                       />
                     ) : null}
@@ -601,8 +617,8 @@ export function NewChatLanding() {
                 ) : null}
               </MessageComposerTools>
               <MessageComposerSubmit
-                status={submitting ? "pending" : "ready"}
-                disabled={!canSubmitNewChat || submitting}
+                status={composerLocked ? "pending" : "ready"}
+                disabled={!canSubmitNewChat || composerLocked}
               />
             </MessageComposerFooter>
           </MessageComposerForm>

--- a/apps/desktop/src/ui/sidebar/SidebarOneOffChatItem.tsx
+++ b/apps/desktop/src/ui/sidebar/SidebarOneOffChatItem.tsx
@@ -1,4 +1,6 @@
 import { type MouseEvent, memo, type RefObject } from "react";
+import { composerDraftKeyForThread, hasComposerDraftContent } from "../../app/composerDrafts";
+import { useAppStore } from "../../app/store";
 import type { ThreadRecord, ThreadRuntime } from "../../app/types";
 import { Button } from "../../components/ui/button";
 import { Input } from "../../components/ui/input";
@@ -56,6 +58,9 @@ export const SidebarOneOffChatItem = memo(function SidebarOneOffChatItem({
   const isEditing = editingThreadId === thread.id;
   const displayTitle = thread.title || "New chat";
   const ageLabel = formatSidebarRelativeAge(thread.lastMessageAt);
+  const hasDraft = useAppStore((state) =>
+    hasComposerDraftContent(state.composerDraftsByKey[composerDraftKeyForThread(thread.id)]),
+  );
 
   if (isEditing) {
     return (
@@ -109,6 +114,13 @@ export const SidebarOneOffChatItem = memo(function SidebarOneOffChatItem({
             <span
               className="h-1.5 w-1.5 rounded-full bg-primary animate-pulse"
               aria-hidden="true"
+            />
+          ) : hasDraft ? (
+            <span
+              className="size-1.5 rounded-full bg-muted-foreground/70"
+              role="status"
+              aria-label="Unsent draft"
+              title="Unsent draft"
             />
           ) : ageLabel ? (
             <span

--- a/apps/desktop/src/ui/sidebar/SidebarWorkspaceItem.tsx
+++ b/apps/desktop/src/ui/sidebar/SidebarWorkspaceItem.tsx
@@ -16,6 +16,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { composerDraftKeyForThread, hasComposerDraftContent } from "../../app/composerDrafts";
 import { useAppStore } from "../../app/store";
 import type { TaskSummary, ThreadRecord, ThreadRuntime, WorkspaceRecord } from "../../app/types";
 import { Button } from "../../components/ui/button";
@@ -136,6 +137,7 @@ export const SidebarWorkspaceItem = memo(function SidebarWorkspaceItem({
   const [renderThreadRegion, setRenderThreadRegion] = useState(expanded);
   const [threadRegionOpen, setThreadRegionOpen] = useState(expanded);
   const tasksEnabled = useAppStore((s) => s.desktopFeatureFlags?.tasks === true);
+  const composerDraftsByKey = useAppStore((s) => s.composerDraftsByKey);
   const visibleTasks = tasksEnabled ? tasks : EMPTY_TASK_SUMMARIES;
 
   useLayoutEffect(() => {
@@ -356,6 +358,9 @@ export const SidebarWorkspaceItem = memo(function SidebarWorkspaceItem({
                       const isEditing = editingThreadId === thread.id;
                       const displayTitle = thread.title || "New chat";
                       const ageLabel = formatSidebarRelativeAge(thread.lastMessageAt);
+                      const hasDraft = hasComposerDraftContent(
+                        composerDraftsByKey[composerDraftKeyForThread(thread.id)],
+                      );
 
                       return isEditing ? (
                         <div
@@ -410,6 +415,13 @@ export const SidebarWorkspaceItem = memo(function SidebarWorkspaceItem({
                                 <span
                                   className="h-1.5 w-1.5 rounded-full bg-primary animate-pulse"
                                   aria-hidden="true"
+                                />
+                              ) : hasDraft ? (
+                                <span
+                                  className="size-1.5 rounded-full bg-muted-foreground/70"
+                                  role="status"
+                                  aria-label="Unsent draft"
+                                  title="Unsent draft"
                                 />
                               ) : ageLabel ? (
                                 <span

--- a/apps/desktop/test/bootstrap-cache.test.ts
+++ b/apps/desktop/test/bootstrap-cache.test.ts
@@ -1,6 +1,12 @@
 import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { TaskRecord, TaskSummary } from "../../../src/shared/tasks";
+import {
+  composerDraftKeyForNewChatTarget,
+  composerDraftKeyForThread,
+  createComposerDraftAttachment,
+  createEmptyComposerDraft,
+} from "../src/app/composerDrafts";
 import { createDesktopCommandsMock } from "./helpers/mockDesktopCommands";
 
 const DESKTOP_STATE_CACHE_KEY = "cowork.desktop.state-cache.v2";
@@ -502,7 +508,7 @@ function resetStoreToCachedSeed(value: unknown = cachedState) {
     providerLastAuthChallenge: null,
     providerLastAuthResult: null,
     providerUiState: { lmstudio: { enabled: false, hiddenModels: [] } },
-    composerText: "",
+    composerDraftsByKey: {},
     injectContext: false,
     developerMode: false,
     showHiddenFiles: false,
@@ -676,6 +682,92 @@ describe("desktop bootstrap cache", () => {
       cloudSyncEnabled: false,
     });
     expect(seed?.threadRuntimeById?.["thread-cached"]?.hydrating).toBeUndefined();
+  });
+
+  test("buildCachedDesktopStateSeed restores a complete New Chat target draft", async () => {
+    const key = composerDraftKeyForNewChatTarget({
+      kind: "project",
+      workspaceId: "ws-cached",
+    });
+    const seed = buildCachedDesktopStateSeed({
+      ...cachedState,
+      persistedState: {
+        ...cachedState.persistedState,
+        composerDrafts: {
+          [key]: {
+            revision: 8,
+            generation: 2,
+            updatedAt: "2099-03-20T00:00:00.000Z",
+            text: "restored project draft",
+            attachments: [
+              {
+                filename: "notes.txt",
+                mimeType: "text/plain",
+                size: 10,
+                lastModified: 42,
+                signature: "notes",
+                contentBase64: "ZHJhZnQgZmlsZQ==",
+              },
+            ],
+            references: [{ kind: "skill", name: "documents" }],
+            provider: "openai",
+            model: "gpt-5.4",
+            reasoningEffort: "high",
+          },
+        },
+      },
+      ui: {
+        ...cachedState.ui,
+        view: "chat",
+        selectedWorkspaceId: "ws-cached",
+        selectedThreadId: null,
+        newChatLandingTarget: { kind: "project", workspaceId: "ws-cached" },
+      },
+    });
+
+    expect(seed?.selectedThreadId).toBeNull();
+    expect(seed?.newChatLandingTarget).toEqual({
+      kind: "project",
+      workspaceId: "ws-cached",
+    });
+    expect(seed?.composerDraftsByKey?.[key]).toMatchObject({
+      revision: 8,
+      generation: 2,
+      text: "restored project draft",
+      references: [{ kind: "skill", name: "documents" }],
+      provider: "openai",
+      model: "gpt-5.4",
+      reasoningEffort: "high",
+    });
+    expect(await seed?.composerDraftsByKey?.[key]?.attachments[0]?.file.text()).toBe("draft file");
+  });
+
+  test("durable persistence includes attachment bytes while the fast cache omits them", async () => {
+    resetStoreToCachedSeed();
+    const key = composerDraftKeyForThread("thread-cached");
+    const attachment = await createComposerDraftAttachment(
+      new File(["persist me"], "draft.txt", { type: "text/plain", lastModified: 7 }),
+    );
+    useAppStore.setState({
+      composerDraftsByKey: {
+        [key]: {
+          ...createEmptyComposerDraft("2099-03-20T00:00:00.000Z"),
+          revision: 3,
+          text: "persisted text",
+          attachments: [attachment],
+        },
+      },
+    });
+
+    const persisted = syncDesktopStateCacheNow(useAppStore.getState);
+    expect(persisted.composerDrafts?.[key]?.attachments[0]).toMatchObject({
+      filename: "draft.txt",
+      contentBase64: "cGVyc2lzdCBtZQ==",
+    });
+    const cached = JSON.parse(localStorageMock.getItem(DESKTOP_STATE_CACHE_KEY) ?? "{}") as {
+      persistedState?: { composerDrafts?: Record<string, { attachments?: unknown[] }> };
+    };
+    expect(cached.persistedState?.composerDrafts?.[key]?.attachments).toEqual([]);
   });
 
   test("buildCachedDesktopStateSeed preserves an explicitly selected task", () => {

--- a/apps/desktop/test/chat-view.stability.test.tsx
+++ b/apps/desktop/test/chat-view.stability.test.tsx
@@ -140,6 +140,8 @@ describe("desktop chat view stability", () => {
       tasksById: {},
       taskSummariesByWorkspaceId: {},
       composerDraftsByKey: {},
+      composerDraftRevisionFloorByKey: {},
+      composerAttachmentIngestionCountByKey: {},
       newChatLandingTarget: null,
     });
   });
@@ -1621,6 +1623,161 @@ describe("desktop chat view stability", () => {
           root.unmount();
         });
       }
+      harness.restore();
+    }
+  });
+
+  test("blocks an immediate submit until selected attachment ingestion completes", async () => {
+    const originalState = useAppStore.getState();
+    let releaseRead: ((buffer: ArrayBuffer) => void) | undefined;
+    const readGate = new Promise<ArrayBuffer>((resolve) => {
+      releaseRead = resolve;
+    });
+    const readFile = mock(() => readGate);
+    const sendMessage = mock(
+      async (
+        text: string,
+        _busyPolicy?: "reject" | "steer",
+        attachments?: Array<{ filename: string; contentBase64: string; mimeType: string }>,
+      ) => {
+        expect(text).toBe("send with attachment");
+        expect(attachments).toEqual([
+          {
+            filename: "slow.txt",
+            contentBase64: "AQID",
+            mimeType: "text/plain",
+          },
+        ]);
+        return true;
+      },
+    );
+    const draftKey = composerDraftKeyForThread("thread-1");
+
+    useAppStore.setState({
+      ready: true,
+      startupError: null,
+      view: "chat",
+      selectedWorkspaceId: "ws-1",
+      selectedThreadId: "thread-1",
+      workspaces: [
+        {
+          id: "ws-1",
+          name: "Workspace 1",
+          path: "/tmp/workspace-1",
+          createdAt: "2026-03-12T00:00:00.000Z",
+          lastOpenedAt: "2026-03-12T00:00:00.000Z",
+          defaultEnableMcp: true,
+          defaultBackupsEnabled: true,
+          yolo: false,
+        },
+      ],
+      threads: [
+        {
+          id: "thread-1",
+          workspaceId: "ws-1",
+          title: "Thread 1",
+          createdAt: "2026-03-12T00:00:00.000Z",
+          lastMessageAt: "2026-03-12T00:00:00.000Z",
+          status: "active",
+          sessionId: "session-1",
+          lastEventSeq: 0,
+        },
+      ],
+      threadRuntimeById: {
+        "thread-1": {
+          wsUrl: null,
+          connected: true,
+          sessionId: "session-1",
+          config: { provider: "openai", model: "gpt-5.4" },
+          sessionConfig: null,
+          sessionUsage: null,
+          lastTurnUsage: null,
+          enableMcp: true,
+          busy: false,
+          busySince: null,
+          feed: [],
+          pendingSteer: null,
+          pendingTurnStart: null,
+          transcriptOnly: false,
+          activeTurnId: null,
+        },
+      },
+      composerDraftsByKey: composerDraftsWithText(draftKey, "send with attachment"),
+      composerAttachmentIngestionCountByKey: {},
+      sendMessage,
+    } as never);
+
+    const harness = setupChatViewJsdom();
+    let root: ReturnType<typeof createRoot> | null = null;
+    try {
+      const container = harness.dom.window.document.getElementById("root");
+      if (!container) throw new Error("missing root");
+      root = createRoot(container);
+
+      await act(async () => {
+        root.render(createElement(StrictMode, null, createElement(ChatView)));
+      });
+
+      const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement | null;
+      const form = container.querySelector("form");
+      if (!fileInput || !form) throw new Error("missing composer controls");
+      const slowFile = {
+        name: "slow.txt",
+        type: "text/plain",
+        size: 3,
+        lastModified: 1,
+        arrayBuffer: readFile,
+      } as File;
+      Object.defineProperty(fileInput, "files", {
+        configurable: true,
+        value: [slowFile],
+      });
+
+      await act(async () => {
+        fileInput.dispatchEvent(new harness.dom.window.Event("change", { bubbles: true }));
+        form.dispatchEvent(
+          new harness.dom.window.Event("submit", { bubbles: true, cancelable: true }),
+        );
+        await Promise.resolve();
+      });
+
+      expect(sendMessage).not.toHaveBeenCalled();
+      expect(useAppStore.getState().composerAttachmentIngestionCountByKey[draftKey]).toBe(1);
+      expect(
+        (container.querySelector('[aria-label="Send message"]') as HTMLButtonElement | null)
+          ?.disabled,
+      ).toBe(true);
+
+      await act(async () => {
+        releaseRead?.(new Uint8Array([1, 2, 3]).buffer);
+        await readGate;
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(
+        useAppStore.getState().composerAttachmentIngestionCountByKey[draftKey],
+      ).toBeUndefined();
+      expect(useAppStore.getState().composerDraftsByKey[draftKey]?.attachments).toHaveLength(1);
+
+      await act(async () => {
+        form.dispatchEvent(
+          new harness.dom.window.Event("submit", { bubbles: true, cancelable: true }),
+        );
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(sendMessage).toHaveBeenCalledTimes(1);
+    } finally {
+      releaseRead?.(new Uint8Array([1, 2, 3]).buffer);
+      await readGate;
+      await Promise.resolve();
+      if (root) {
+        await act(async () => {
+          root.unmount();
+        });
+      }
+      useAppStore.setState(originalState, true);
       harness.restore();
     }
   });

--- a/apps/desktop/test/chat-view.stability.test.tsx
+++ b/apps/desktop/test/chat-view.stability.test.tsx
@@ -2,6 +2,11 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { act, createElement, StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { buildAttachmentSignature } from "../src/app/attachmentInputs";
+import {
+  composerDraftKeyForNewChatTarget,
+  composerDraftKeyForThread,
+  createEmptyComposerDraft,
+} from "../src/app/composerDrafts";
 import { DESKTOP_API_OVERRIDE_KEY } from "../src/lib/desktopApiOverride";
 import {
   clearJsonRpcSocketOverride,
@@ -29,6 +34,16 @@ const MOCK_UPDATE_STATE = {
   progress: null,
   error: null,
 };
+
+function composerDraftsWithText(key: string, text: string) {
+  return {
+    [key]: {
+      ...createEmptyComposerDraft("2026-03-12T00:00:00.000Z"),
+      revision: 1,
+      text,
+    },
+  };
+}
 
 class MockMutationObserver {
   observe() {}
@@ -124,6 +139,8 @@ describe("desktop chat view stability", () => {
       selectedTaskId: null,
       tasksById: {},
       taskSummariesByWorkspaceId: {},
+      composerDraftsByKey: {},
+      newChatLandingTarget: null,
     });
   });
 
@@ -176,7 +193,7 @@ describe("desktop chat view stability", () => {
         },
       ],
       providerConnected: ["openai"],
-      composerText: "",
+      composerDraftsByKey: {},
     });
 
     const harness = setupChatViewJsdom();
@@ -221,7 +238,10 @@ describe("desktop chat view stability", () => {
       threads: [],
       workspaceRuntimeById: {},
       threadRuntimeById: {},
-      composerText: "Draft a release note",
+      composerDraftsByKey: composerDraftsWithText(
+        composerDraftKeyForNewChatTarget({ kind: "oneOff" }),
+        "Draft a release note",
+      ),
       providerDefaultModelByProvider: {},
     });
 
@@ -296,7 +316,10 @@ describe("desktop chat view stability", () => {
       threads: [],
       workspaceRuntimeById: {},
       threadRuntimeById: {},
-      composerText: "Plan the onboarding flow",
+      composerDraftsByKey: composerDraftsWithText(
+        composerDraftKeyForNewChatTarget({ kind: "project", workspaceId: "ws-1" }),
+        "Plan the onboarding flow",
+      ),
     });
 
     const harness = setupChatViewJsdom();
@@ -395,7 +418,7 @@ describe("desktop chat view stability", () => {
           transcriptOnly: false,
         },
       },
-      composerText: "",
+      composerDraftsByKey: {},
     });
 
     const harness = setupChatViewJsdom();
@@ -491,7 +514,7 @@ describe("desktop chat view stability", () => {
           transcriptOnly: false,
         },
       },
-      composerText: "",
+      composerDraftsByKey: {},
     });
 
     const harness = setupChatViewJsdom();
@@ -578,7 +601,7 @@ describe("desktop chat view stability", () => {
           transcriptOnly: false,
         },
       },
-      composerText: "",
+      composerDraftsByKey: {},
       messageBarHeight: 144,
       developerMode: true,
     });
@@ -683,7 +706,7 @@ describe("desktop chat view stability", () => {
           transcriptOnly: false,
         },
       },
-      composerText: "",
+      composerDraftsByKey: {},
       messageBarHeight: 120,
     });
 
@@ -857,7 +880,7 @@ describe("desktop chat view stability", () => {
           transcriptOnly: false,
         },
       },
-      composerText: "",
+      composerDraftsByKey: {},
       messageBarHeight: 120,
     });
 
@@ -903,7 +926,7 @@ describe("desktop chat view stability", () => {
       });
 
       await act(async () => {
-        useAppStore.setState({ composerText: "draft after reading" });
+        useAppStore.getState().setComposerText("draft after reading");
         await new Promise((resolve) => setTimeout(resolve, 10));
       });
 
@@ -991,7 +1014,7 @@ describe("desktop chat view stability", () => {
         },
       ],
       providerConnected: ["openai"],
-      composerText: "",
+      composerDraftsByKey: {},
     });
 
     const harness = setupChatViewJsdom();
@@ -1125,7 +1148,7 @@ describe("desktop chat view stability", () => {
         },
       ],
       providerConnected: ["openai"],
-      composerText: "",
+      composerDraftsByKey: {},
     });
 
     const harness = setupChatViewJsdom();
@@ -1217,7 +1240,7 @@ describe("desktop chat view stability", () => {
           transcriptOnly: false,
         },
       },
-      composerText: "",
+      composerDraftsByKey: {},
     });
 
     const harness = setupChatViewJsdom();
@@ -1327,7 +1350,7 @@ describe("desktop chat view stability", () => {
           transcriptOnly: false,
         },
       },
-      composerText: "",
+      composerDraftsByKey: {},
     } as any);
 
     const harness = setupChatViewJsdom();
@@ -1408,7 +1431,7 @@ describe("desktop chat view stability", () => {
           activeTurnId: "turn-1",
         },
       },
-      composerText: "",
+      composerDraftsByKey: {},
     });
 
     const harness = setupChatViewJsdom();
@@ -1433,7 +1456,7 @@ describe("desktop chat view stability", () => {
       expect(statusRow?.textContent).toContain("Type guidance to add, or stop to cancel.");
 
       await act(async () => {
-        useAppStore.setState({ composerText: "tighten scope" });
+        useAppStore.getState().setComposerText("tighten scope");
       });
 
       // Stop remains available while typing a steer (audit P0).
@@ -1545,7 +1568,7 @@ describe("desktop chat view stability", () => {
           activeTurnId: "turn-1",
         },
       },
-      composerText: "",
+      composerDraftsByKey: {},
       messageBarHeight: 120,
       developerMode: true,
     });
@@ -1602,9 +1625,13 @@ describe("desktop chat view stability", () => {
     }
   });
 
-  test("keeps attachment-only steers pending until acceptance, then clears them", async () => {
+  test("keeps attachment-only steers until the captured submission succeeds", async () => {
     const originalState = useAppStore.getState();
     let submittedAttachmentSignature = "";
+    let resolveSend: (() => void) | undefined;
+    const sendGate = new Promise<void>((resolve) => {
+      resolveSend = resolve;
+    });
 
     useAppStore.setState({
       ready: true,
@@ -1657,18 +1684,24 @@ describe("desktop chat view stability", () => {
           activeTurnId: "turn-1",
         },
       },
-      composerText: "",
+      composerDraftsByKey: {},
       sendMessage: async (
         text: string,
         busyPolicy?: "reject" | "steer",
         attachments?: Array<{ filename: string; contentBase64: string; mimeType: string }>,
+        _references?: unknown,
+        options?: { draftSubmission?: { key: string; revision: number } },
       ) => {
         expect(text).toBe("");
         expect(busyPolicy).toBe("steer");
         submittedAttachmentSignature = buildAttachmentSignature(attachments);
+        await sendGate;
+        if (options?.draftSubmission) {
+          useAppStore.getState().clearComposerDraft(options.draftSubmission);
+        }
         return true;
       },
-    } as any);
+    } as never);
 
     const harness = setupChatViewJsdom();
 
@@ -1742,18 +1775,8 @@ describe("desktop chat view stability", () => {
       );
 
       await act(async () => {
-        useAppStore.setState((state) => ({
-          threadRuntimeById: {
-            ...state.threadRuntimeById,
-            "thread-1": {
-              ...state.threadRuntimeById["thread-1"]!,
-              pendingSteer: {
-                ...state.threadRuntimeById["thread-1"]!.pendingSteer!,
-                status: "accepted",
-              },
-            },
-          },
-        }));
+        resolveSend?.();
+        await sendGate;
         await Promise.resolve();
       });
 

--- a/apps/desktop/test/composer-draft-thread-switch.test.ts
+++ b/apps/desktop/test/composer-draft-thread-switch.test.ts
@@ -1,11 +1,23 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  composerDraftKeyForNewChatTarget,
+  composerDraftKeyForThread,
+  createEmptyComposerDraft,
+  selectActiveComposerDraft,
+} from "../src/app/composerDrafts";
 import { DESKTOP_API_OVERRIDE_KEY } from "../src/lib/desktopApiOverride";
 import { createDesktopApiMock } from "./helpers/mockDesktopCommands";
 
 const { useAppStore } = await import("../src/app/store");
-const { defaultThreadRuntime, defaultWorkspaceRuntime } = await import(
+const { RUNTIME, defaultThreadRuntime, defaultWorkspaceRuntime } = await import(
   "../src/app/store.helpers/runtimeState"
 );
+
+async function flushAsyncWork(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
 
 describe("composer draft clear after send", () => {
   let snapshot: ReturnType<typeof useAppStore.getState>;
@@ -56,14 +68,17 @@ describe("composer draft clear after send", () => {
         },
       ],
       workspaceRuntimeById: {
-        "ws-1": defaultWorkspaceRuntime(),
+        "ws-1": {
+          ...defaultWorkspaceRuntime(),
+          serverUrl: "ws://mock",
+        },
       },
       threadRuntimeById: {
         "thread-a": {
           ...defaultThreadRuntime(),
           sessionId: "session-a",
           connected: true,
-          transcriptOnly: true,
+          transcriptOnly: false,
         },
         "thread-b": {
           ...defaultThreadRuntime(),
@@ -71,10 +86,17 @@ describe("composer draft clear after send", () => {
           connected: true,
         },
       },
-      composerText: "send from A",
-      composerTextByThreadId: {
-        "thread-a": "send from A",
-        "thread-b": "draft for B",
+      composerDraftsByKey: {
+        [composerDraftKeyForThread("thread-a")]: {
+          ...createEmptyComposerDraft("2026-01-01T00:00:00.000Z"),
+          revision: 1,
+          text: "send from A",
+        },
+        [composerDraftKeyForThread("thread-b")]: {
+          ...createEmptyComposerDraft("2026-01-01T00:00:00.000Z"),
+          revision: 1,
+          text: "draft for B",
+        },
       },
       taskSummariesByWorkspaceId: {
         "ws-1": [],
@@ -84,81 +106,411 @@ describe("composer draft clear after send", () => {
   });
 
   afterEach(() => {
+    RUNTIME.jsonRpcSockets.delete("ws-1");
     useAppStore.setState(snapshot, true);
     Reflect.deleteProperty(globalThis, DESKTOP_API_OVERRIDE_KEY);
   });
 
-  test("preserves New Chat landing draft when selecting a chat and returning", async () => {
+  test("keeps existing-chat and New Chat target drafts independent", async () => {
     useAppStore.setState({
       selectedThreadId: null,
-      composerText: "landing draft",
-      composerTextByThreadId: {
-        "thread-a": "draft for A",
-        "thread-b": "draft for B",
-      },
+      newChatLandingTarget: { kind: "oneOff" },
+      composerDraftsByKey: {},
     } as never);
 
-    useAppStore.getState().setComposerText("landing draft");
-    expect(useAppStore.getState().composerTextByThreadId.__landing__).toBe("landing draft");
+    useAppStore.getState().setComposerText("one-off landing draft");
+    useAppStore.getState().setNewChatLandingTarget({
+      kind: "project",
+      workspaceId: "ws-1",
+    });
+    useAppStore.getState().setComposerText("project landing draft");
 
     await useAppStore.getState().selectThread("thread-a");
-    // selectThread hydrates; swap should restore thread-a draft when hydrate path runs.
-    // Force a pure swap via openNewChatLanding after manually selecting A.
-    useAppStore.setState({
-      selectedThreadId: "thread-a",
-      composerText: "draft for A",
-      composerTextByThreadId: {
-        __landing__: "landing draft",
-        "thread-a": "draft for A",
-        "thread-b": "draft for B",
-      },
-    } as never);
+    useAppStore.getState().setComposerText("draft for A");
 
     await useAppStore.getState().openNewChatLanding({ defaultTargetKind: "oneOff" });
     const state = useAppStore.getState();
     expect(state.selectedThreadId).toBeNull();
-    expect(state.composerText).toBe("landing draft");
-    expect(state.composerTextByThreadId.__landing__).toBe("landing draft");
+    expect(selectActiveComposerDraft(state).text).toBe("one-off landing draft");
+    expect(
+      state.composerDraftsByKey[
+        composerDraftKeyForNewChatTarget({ kind: "project", workspaceId: "ws-1" })
+      ]?.text,
+    ).toBe("project landing draft");
+    expect(state.composerDraftsByKey[composerDraftKeyForThread("thread-a")]?.text).toBe(
+      "draft for A",
+    );
   });
 
-  test("keeps the newly selected thread draft when send resolves after a switch", async () => {
-    let releaseNewThread: (() => void) | null = null;
-    const newThreadGate = new Promise<boolean>((resolve) => {
-      releaseNewThread = () => resolve(true);
+  test("a delayed clear from A clears only its captured revision and never B", async () => {
+    const owner = {
+      key: composerDraftKeyForThread("thread-a"),
+      revision: useAppStore.getState().composerDraftsByKey[composerDraftKeyForThread("thread-a")]
+        ?.revision as number,
+    };
+    let releaseClear: (() => void) | undefined;
+    const gate = new Promise<void>((resolve) => {
+      releaseClear = resolve;
     });
+    const delayedClear = (async () => {
+      await gate;
+      return useAppStore.getState().clearComposerDraft(owner);
+    })();
 
-    const previousNewThread = useAppStore.getState().newThread;
-    useAppStore.setState({
-      newThread: async () => {
-        await newThreadGate;
-        return true;
+    useAppStore.setState({ selectedThreadId: "thread-b" });
+    useAppStore.getState().setComposerText("new text in B");
+    releaseClear?.();
+
+    expect(await delayedClear).toBe(true);
+    const afterClear = useAppStore.getState();
+    expect(afterClear.composerDraftsByKey[composerDraftKeyForThread("thread-a")]?.text).toBe("");
+    expect(afterClear.composerDraftsByKey[composerDraftKeyForThread("thread-b")]?.text).toBe(
+      "new text in B",
+    );
+
+    useAppStore.setState({ selectedThreadId: "thread-a" });
+    useAppStore.getState().setComposerText("newer text in A");
+    expect(useAppStore.getState().clearComposerDraft(owner)).toBe(false);
+    expect(
+      useAppStore.getState().composerDraftsByKey[composerDraftKeyForThread("thread-a")]?.text,
+    ).toBe("newer text in A");
+  });
+
+  test("clears the submitted revision only after turn/start succeeds", async () => {
+    let resolveTurnStart: (() => void) | undefined;
+    const turnStartGate = new Promise<void>((resolve) => {
+      resolveTurnStart = resolve;
+    });
+    RUNTIME.jsonRpcSockets.set("ws-1", {
+      __coworkUrl: "ws://mock",
+      __coworkOpened: true,
+      connect: () => {},
+      request: async (method: string) => {
+        if (method === "turn/start") await turnStartGate;
+        return {};
       },
     } as never);
+    const owner = {
+      key: composerDraftKeyForThread("thread-a"),
+      revision: useAppStore.getState().composerDraftsByKey[composerDraftKeyForThread("thread-a")]
+        ?.revision as number,
+    };
+
+    expect(
+      await useAppStore.getState().sendMessage("send from A", "reject", undefined, undefined, {
+        targetThreadId: "thread-a",
+        draftSubmission: owner,
+      }),
+    ).toBe(true);
+    expect(
+      useAppStore.getState().composerDraftsByKey[composerDraftKeyForThread("thread-a")]?.text,
+    ).toBe("send from A");
+
+    useAppStore.setState({ selectedThreadId: "thread-b" });
+    useAppStore.getState().setComposerText("new text in B");
+    resolveTurnStart?.();
+    await flushAsyncWork();
+
+    const state = useAppStore.getState();
+    expect(state.composerDraftsByKey[composerDraftKeyForThread("thread-a")]?.text).toBe("");
+    expect(state.composerDraftsByKey[composerDraftKeyForThread("thread-b")]?.text).toBe(
+      "new text in B",
+    );
+  });
+
+  test("a delayed task command clears only A while B receives new text", async () => {
+    let resolveCommand: (() => void) | undefined;
+    const commandGate = new Promise<void>((resolve) => {
+      resolveCommand = resolve;
+    });
+    RUNTIME.jsonRpcSockets.set("ws-1", {
+      __coworkUrl: "ws://mock",
+      __coworkOpened: true,
+      connect: () => {},
+      request: async (method: string) => {
+        if (method === "command/execute") await commandGate;
+        return {};
+      },
+    } as never);
+    useAppStore.getState().setComposerText("/task investigate the race");
+    const key = composerDraftKeyForThread("thread-a");
+    const owner = {
+      key,
+      revision: useAppStore.getState().composerDraftsByKey[key]?.revision as number,
+    };
+
+    const send = useAppStore
+      .getState()
+      .sendMessage("/task investigate the race", "reject", undefined, undefined, {
+        targetThreadId: "thread-a",
+        draftSubmission: owner,
+      });
+    useAppStore.setState({ selectedThreadId: "thread-b" });
+    useAppStore.getState().setComposerText("B changed while task creation was pending");
+    resolveCommand?.();
+
+    expect(await send).toBe(true);
+    expect(useAppStore.getState().composerDraftsByKey[key]?.text).toBe("");
+    expect(
+      useAppStore.getState().composerDraftsByKey[composerDraftKeyForThread("thread-b")]?.text,
+    ).toBe("B changed while task creation was pending");
+  });
+
+  test("retains the full draft after failure and clears it after retry succeeds", async () => {
+    RUNTIME.jsonRpcSockets.set("ws-1", {
+      __coworkUrl: "ws://mock",
+      __coworkOpened: true,
+      connect: () => {},
+      request: async (method: string) => {
+        if (method === "turn/start") throw new Error("offline");
+        return {};
+      },
+    } as never);
+    await useAppStore
+      .getState()
+      .addComposerAttachments([
+        new File(["retry bytes"], "retry.txt", { type: "text/plain", lastModified: 30 }),
+      ]);
+    const key = composerDraftKeyForThread("thread-a");
+    const failedOwner = {
+      key,
+      revision: useAppStore.getState().composerDraftsByKey[key]?.revision as number,
+    };
+    const wireAttachment = {
+      filename: "retry.txt",
+      mimeType: "text/plain",
+      contentBase64: "cmV0cnkgYnl0ZXM=",
+    };
+
+    expect(
+      await useAppStore
+        .getState()
+        .sendMessage("send from A", "reject", [wireAttachment], undefined, {
+          targetThreadId: "thread-a",
+          draftSubmission: failedOwner,
+        }),
+    ).toBe(true);
+    await flushAsyncWork();
+    expect(useAppStore.getState().composerDraftsByKey[key]).toMatchObject({
+      revision: failedOwner.revision,
+      text: "send from A",
+      attachments: [{ filename: "retry.txt" }],
+    });
+
+    RUNTIME.jsonRpcSockets.set("ws-1", {
+      __coworkUrl: "ws://mock",
+      __coworkOpened: true,
+      connect: () => {},
+      request: async () => ({}),
+    } as never);
+    expect(
+      await useAppStore
+        .getState()
+        .sendMessage("send from A", "reject", [wireAttachment], undefined, {
+          targetThreadId: "thread-a",
+          draftSubmission: failedOwner,
+        }),
+    ).toBe(true);
+    await flushAsyncWork();
+    expect(useAppStore.getState().composerDraftsByKey[key]).toMatchObject({
+      revision: failedOwner.revision + 1,
+      text: "",
+      attachments: [],
+    });
+  });
+
+  test("preserves exact attachments across switches and revokes only on removal", async () => {
+    const originalCreateObjectURL = URL.createObjectURL;
+    const originalRevokeObjectURL = URL.revokeObjectURL;
+    const createObjectURL = mock(() => "blob:thread-a-preview");
+    const revokeObjectURL = mock(() => {});
+    URL.createObjectURL = createObjectURL;
+    URL.revokeObjectURL = revokeObjectURL;
 
     try {
-      const sendPromise = useAppStore.getState().sendMessage("send from A");
+      const image = new File(["image bytes"], "diagram.png", {
+        type: "image/png",
+        lastModified: 1_720_000_000_000,
+      });
+      await useAppStore.getState().addComposerAttachments([image]);
 
-      // User switches chats while the send path is still awaiting network work.
-      useAppStore.setState({
-        selectedThreadId: "thread-b",
-        composerText: "draft for B",
-        composerTextByThreadId: {
-          "thread-a": "send from A",
-          "thread-b": "draft for B",
-        },
-      } as never);
+      useAppStore.setState({ selectedThreadId: "thread-b" });
+      useAppStore.getState().setComposerText("updated B");
+      expect(revokeObjectURL).not.toHaveBeenCalled();
 
-      releaseNewThread?.();
-      const accepted = await sendPromise;
-      expect(accepted).toBe(true);
+      useAppStore.setState({ selectedThreadId: "thread-a" });
+      const restored = selectActiveComposerDraft(useAppStore.getState());
+      expect(restored.attachments).toHaveLength(1);
+      expect(restored.attachments[0]).toMatchObject({
+        filename: "diagram.png",
+        mimeType: "image/png",
+        previewUrl: "blob:thread-a-preview",
+      });
+      expect(await restored.attachments[0]?.file.text()).toBe("image bytes");
+      expect(createObjectURL).toHaveBeenCalledTimes(1);
+      expect(revokeObjectURL).not.toHaveBeenCalled();
 
-      const state = useAppStore.getState();
-      expect(state.selectedThreadId).toBe("thread-b");
-      expect(state.composerText).toBe("draft for B");
-      expect(state.composerTextByThreadId["thread-a"]).toBeUndefined();
-      expect(state.composerTextByThreadId["thread-b"]).toBe("draft for B");
+      useAppStore.getState().removeComposerAttachment(0);
+      expect(revokeObjectURL).toHaveBeenCalledTimes(1);
+      expect(revokeObjectURL).toHaveBeenCalledWith("blob:thread-a-preview");
     } finally {
-      useAppStore.setState({ newThread: previousNewThread } as never);
+      URL.createObjectURL = originalCreateObjectURL;
+      URL.revokeObjectURL = originalRevokeObjectURL;
+    }
+  });
+
+  test("revokes completed previews when another file in the batch cannot be read", async () => {
+    const originalCreateObjectURL = URL.createObjectURL;
+    const originalRevokeObjectURL = URL.revokeObjectURL;
+    const revokeObjectURL = mock(() => {});
+    URL.createObjectURL = () => "blob:completed-preview";
+    URL.revokeObjectURL = revokeObjectURL;
+    const unreadable = new File(["bad"], "bad.txt", {
+      type: "text/plain",
+      lastModified: 2,
+    });
+    Object.defineProperty(unreadable, "arrayBuffer", {
+      value: async () => {
+        throw new Error("read failed");
+      },
+    });
+
+    try {
+      await expect(
+        useAppStore
+          .getState()
+          .addComposerAttachments([
+            new File(["image"], "good.png", { type: "image/png", lastModified: 1 }),
+            unreadable,
+          ]),
+      ).rejects.toThrow("read failed");
+
+      expect(selectActiveComposerDraft(useAppStore.getState()).attachments).toEqual([]);
+      expect(revokeObjectURL).toHaveBeenCalledTimes(1);
+      expect(revokeObjectURL).toHaveBeenCalledWith("blob:completed-preview");
+    } finally {
+      URL.createObjectURL = originalCreateObjectURL;
+      URL.revokeObjectURL = originalRevokeObjectURL;
+    }
+  });
+
+  test("restores the complete draft unit for each New Chat target", async () => {
+    useAppStore.setState({
+      selectedThreadId: null,
+      newChatLandingTarget: { kind: "project", workspaceId: "ws-1" },
+      composerDraftsByKey: {},
+    });
+    useAppStore.getState().setComposerText("project text", [{ kind: "skill", name: "documents" }]);
+    useAppStore.getState().setComposerDraftModel("openai", "gpt-5.4");
+    useAppStore.getState().setComposerDraftReasoningEffort("high");
+    await useAppStore
+      .getState()
+      .addComposerAttachments([
+        new File(["project file"], "project.txt", { type: "text/plain", lastModified: 10 }),
+      ]);
+
+    useAppStore.getState().setNewChatLandingTarget({ kind: "oneOff" });
+    useAppStore.getState().setComposerText("one-off text");
+    useAppStore.getState().setComposerDraftModel("google", "gemini-2.5-pro");
+
+    const oneOff = selectActiveComposerDraft(useAppStore.getState());
+    expect(oneOff).toMatchObject({
+      text: "one-off text",
+      attachments: [],
+      provider: "google",
+      model: "gemini-2.5-pro",
+      reasoningEffort: null,
+    });
+
+    useAppStore.getState().setNewChatLandingTarget({
+      kind: "project",
+      workspaceId: "ws-1",
+    });
+    const project = selectActiveComposerDraft(useAppStore.getState());
+    expect(project).toMatchObject({
+      text: "project text",
+      references: [{ kind: "skill", name: "documents" }],
+      provider: "openai",
+      model: "gpt-5.4",
+      reasoningEffort: "high",
+    });
+    expect(project.attachments).toHaveLength(1);
+    expect(await project.attachments[0]?.file.text()).toBe("project file");
+  });
+
+  test("workspace removal prunes its New Chat draft and revokes the preview", async () => {
+    const originalRevokeObjectURL = URL.revokeObjectURL;
+    const revokeObjectURL = mock(() => {});
+    URL.revokeObjectURL = revokeObjectURL;
+    const key = composerDraftKeyForNewChatTarget({ kind: "project", workspaceId: "ws-1" });
+    const file = new File(["image"], "project.png", {
+      type: "image/png",
+      lastModified: 40,
+    });
+    useAppStore.setState({
+      selectedThreadId: null,
+      newChatLandingTarget: { kind: "project", workspaceId: "ws-1" },
+      composerDraftsByKey: {
+        [key]: {
+          ...createEmptyComposerDraft("2026-07-10T20:00:00.000Z"),
+          revision: 1,
+          attachments: [
+            {
+              filename: file.name,
+              mimeType: file.type,
+              size: file.size,
+              lastModified: file.lastModified,
+              file,
+              previewUrl: "blob:removed-workspace-preview",
+              signature: "project.png\u0000image/png\u00005\u000040",
+              contentBase64: "aW1hZ2U=",
+            },
+          ],
+        },
+      },
+    });
+
+    try {
+      await useAppStore.getState().removeWorkspace("ws-1");
+
+      expect(useAppStore.getState().composerDraftsByKey[key]).toBeUndefined();
+      expect(revokeObjectURL).toHaveBeenCalledWith("blob:removed-workspace-preview");
+    } finally {
+      URL.revokeObjectURL = originalRevokeObjectURL;
+    }
+  });
+
+  test("does not resurrect an attachment after its draft is discarded mid-read", async () => {
+    const originalCreateObjectURL = URL.createObjectURL;
+    const originalRevokeObjectURL = URL.revokeObjectURL;
+    const revokeObjectURL = mock(() => {});
+    URL.createObjectURL = () => "blob:stale-preview";
+    URL.revokeObjectURL = revokeObjectURL;
+    let releaseRead: ((buffer: ArrayBuffer) => void) | undefined;
+    const readGate = new Promise<ArrayBuffer>((resolve) => {
+      releaseRead = resolve;
+    });
+    const file = new File([new Uint8Array([1, 2, 3, 4])], "slow.png", {
+      type: "image/png",
+      lastModified: 20,
+    });
+    Object.defineProperty(file, "arrayBuffer", {
+      value: () => readGate,
+    });
+
+    try {
+      useAppStore.setState({ composerDraftsByKey: {} });
+      const addPromise = useAppStore.getState().addComposerAttachments([file]);
+      expect(useAppStore.getState().discardComposerDraft()).toBe(true);
+      releaseRead?.(new Uint8Array([1, 2, 3, 4]).buffer);
+      await addPromise;
+
+      const draft = selectActiveComposerDraft(useAppStore.getState());
+      expect(draft.attachments).toEqual([]);
+      expect(revokeObjectURL).toHaveBeenCalledWith("blob:stale-preview");
+    } finally {
+      URL.createObjectURL = originalCreateObjectURL;
+      URL.revokeObjectURL = originalRevokeObjectURL;
     }
   });
 });

--- a/apps/desktop/test/composer-draft-thread-switch.test.ts
+++ b/apps/desktop/test/composer-draft-thread-switch.test.ts
@@ -3,8 +3,14 @@ import {
   composerDraftKeyForNewChatTarget,
   composerDraftKeyForThread,
   createEmptyComposerDraft,
+  MAX_COMPOSER_DRAFT_ATTACHMENT_BYTE_SIZE,
+  MAX_COMPOSER_DRAFT_ATTACHMENT_COUNT,
+  MAX_COMPOSER_DRAFT_TOTAL_ATTACHMENT_BYTES,
+  MAX_PERSISTED_COMPOSER_DRAFT_ATTACHMENT_BYTES,
   selectActiveComposerDraft,
 } from "../src/app/composerDrafts";
+import { syncDesktopStateCacheNow } from "../src/app/store.helpers/persistence";
+import { createComposerAttachmentFile } from "../src/lib/composerAttachments";
 import { DESKTOP_API_OVERRIDE_KEY } from "../src/lib/desktopApiOverride";
 import { createDesktopApiMock } from "./helpers/mockDesktopCommands";
 
@@ -98,6 +104,8 @@ describe("composer draft clear after send", () => {
           text: "draft for B",
         },
       },
+      composerDraftRevisionFloorByKey: {},
+      composerAttachmentIngestionCountByKey: {},
       taskSummariesByWorkspaceId: {
         "ws-1": [],
       },
@@ -107,6 +115,7 @@ describe("composer draft clear after send", () => {
 
   afterEach(() => {
     RUNTIME.jsonRpcSockets.delete("ws-1");
+    RUNTIME.composerAttachmentIngestionTail = null;
     useAppStore.setState(snapshot, true);
     Reflect.deleteProperty(globalThis, DESKTOP_API_OVERRIDE_KEY);
   });
@@ -163,7 +172,7 @@ describe("composer draft clear after send", () => {
 
     expect(await delayedClear).toBe(true);
     const afterClear = useAppStore.getState();
-    expect(afterClear.composerDraftsByKey[composerDraftKeyForThread("thread-a")]?.text).toBe("");
+    expect(afterClear.composerDraftsByKey[composerDraftKeyForThread("thread-a")]).toBeUndefined();
     expect(afterClear.composerDraftsByKey[composerDraftKeyForThread("thread-b")]?.text).toBe(
       "new text in B",
     );
@@ -212,7 +221,7 @@ describe("composer draft clear after send", () => {
     await flushAsyncWork();
 
     const state = useAppStore.getState();
-    expect(state.composerDraftsByKey[composerDraftKeyForThread("thread-a")]?.text).toBe("");
+    expect(state.composerDraftsByKey[composerDraftKeyForThread("thread-a")]).toBeUndefined();
     expect(state.composerDraftsByKey[composerDraftKeyForThread("thread-b")]?.text).toBe(
       "new text in B",
     );
@@ -250,7 +259,7 @@ describe("composer draft clear after send", () => {
     resolveCommand?.();
 
     expect(await send).toBe(true);
-    expect(useAppStore.getState().composerDraftsByKey[key]?.text).toBe("");
+    expect(useAppStore.getState().composerDraftsByKey[key]).toBeUndefined();
     expect(
       useAppStore.getState().composerDraftsByKey[composerDraftKeyForThread("thread-b")]?.text,
     ).toBe("B changed while task creation was pending");
@@ -312,11 +321,7 @@ describe("composer draft clear after send", () => {
         }),
     ).toBe(true);
     await flushAsyncWork();
-    expect(useAppStore.getState().composerDraftsByKey[key]).toMatchObject({
-      revision: failedOwner.revision + 1,
-      text: "",
-      attachments: [],
-    });
+    expect(useAppStore.getState().composerDraftsByKey[key]).toBeUndefined();
   });
 
   test("preserves exact attachments across switches and revokes only on removal", async () => {
@@ -391,6 +396,129 @@ describe("composer draft clear after send", () => {
     } finally {
       URL.createObjectURL = originalCreateObjectURL;
       URL.revokeObjectURL = originalRevokeObjectURL;
+    }
+  });
+
+  test("rejects count, per-file, per-draft, and persisted aggregate limits before reading files", async () => {
+    const readFile = mock(async () => new Uint8Array([1]).buffer);
+    const sizedFile = (name: string, size: number) =>
+      ({
+        name,
+        type: "application/octet-stream",
+        size,
+        lastModified: 1,
+        arrayBuffer: readFile,
+      }) as File;
+
+    await expect(
+      useAppStore
+        .getState()
+        .addComposerAttachments(
+          Array.from({ length: MAX_COMPOSER_DRAFT_ATTACHMENT_COUNT + 1 }, (_, index) =>
+            sizedFile(`count-${index}.bin`, 0),
+          ),
+        ),
+    ).rejects.toThrow(`max ${MAX_COMPOSER_DRAFT_ATTACHMENT_COUNT}`);
+    await expect(
+      useAppStore
+        .getState()
+        .addComposerAttachments([
+          sizedFile("oversized.bin", MAX_COMPOSER_DRAFT_ATTACHMENT_BYTE_SIZE + 1),
+        ]),
+    ).rejects.toThrow("File too large");
+    await expect(
+      useAppStore
+        .getState()
+        .addComposerAttachments([
+          sizedFile(
+            "aggregate-a.bin",
+            Math.floor(MAX_COMPOSER_DRAFT_TOTAL_ATTACHMENT_BYTES / 2) + 1,
+          ),
+          sizedFile(
+            "aggregate-b.bin",
+            Math.floor(MAX_COMPOSER_DRAFT_TOTAL_ATTACHMENT_BYTES / 2) + 1,
+          ),
+        ]),
+    ).rejects.toThrow("Draft attachments too large in total");
+
+    const existingFile = new File(["x"], "existing.bin", {
+      type: "application/octet-stream",
+      lastModified: 1,
+    });
+    useAppStore.setState((state) => ({
+      selectedThreadId: "thread-b",
+      composerDraftsByKey: {
+        ...state.composerDraftsByKey,
+        [composerDraftKeyForThread("thread-a")]: {
+          ...state.composerDraftsByKey[composerDraftKeyForThread("thread-a")]!,
+          attachments: [
+            {
+              filename: existingFile.name,
+              mimeType: existingFile.type,
+              size: MAX_PERSISTED_COMPOSER_DRAFT_ATTACHMENT_BYTES - 1,
+              lastModified: existingFile.lastModified,
+              file: existingFile,
+              signature: "existing",
+              contentBase64: "eA==",
+            },
+          ],
+        },
+      },
+    }));
+    await expect(
+      useAppStore.getState().addComposerAttachments([sizedFile("global-overflow.bin", 2)]),
+    ).rejects.toThrow("Saved draft attachments too large in total");
+
+    expect(readFile).not.toHaveBeenCalled();
+    expect(useAppStore.getState().composerAttachmentIngestionCountByKey).toEqual({});
+  });
+
+  test("serializes concurrent ingestion batches before validating their combined count", async () => {
+    const firstBatch = Array.from(
+      { length: 5 },
+      (_, index) => new File([], `first-${index}.txt`, { type: "text/plain", lastModified: index }),
+    );
+    const secondBatch = Array.from(
+      { length: 4 },
+      (_, index) =>
+        new File([], `second-${index}.txt`, { type: "text/plain", lastModified: index }),
+    );
+
+    const firstIngestion = useAppStore.getState().addComposerAttachments(firstBatch);
+    const secondIngestion = useAppStore.getState().addComposerAttachments(secondBatch);
+
+    expect(
+      useAppStore.getState().composerAttachmentIngestionCountByKey[
+        composerDraftKeyForThread("thread-a")
+      ],
+    ).toBe(2);
+    await firstIngestion;
+    await expect(secondIngestion).rejects.toThrow(`max ${MAX_COMPOSER_DRAFT_ATTACHMENT_COUNT}`);
+    expect(
+      useAppStore.getState().composerDraftsByKey[composerDraftKeyForThread("thread-a")]
+        ?.attachments,
+    ).toHaveLength(5);
+    expect(useAppStore.getState().composerAttachmentIngestionCountByKey).toEqual({});
+  });
+
+  test("one-off send adaptation does not allocate a duplicate image object URL", async () => {
+    const originalCreateObjectURL = URL.createObjectURL;
+    const createObjectURL = mock(() => "blob:persistent-draft-preview");
+    URL.createObjectURL = createObjectURL;
+
+    try {
+      const file = new File(["image"], "one-off.png", {
+        type: "image/png",
+        lastModified: 1,
+      });
+      await useAppStore.getState().addComposerAttachments([file]);
+      expect(createObjectURL).toHaveBeenCalledTimes(1);
+
+      const transient = createComposerAttachmentFile(file);
+      expect(transient).not.toHaveProperty("previewUrl");
+      expect(createObjectURL).toHaveBeenCalledTimes(1);
+    } finally {
+      URL.createObjectURL = originalCreateObjectURL;
     }
   });
 
@@ -480,6 +608,86 @@ describe("composer draft clear after send", () => {
     }
   });
 
+  test("store pruning keeps memory and restart persistence aligned and revokes removed previews", () => {
+    const originalRevokeObjectURL = URL.revokeObjectURL;
+    const revokeObjectURL = mock(() => {});
+    URL.revokeObjectURL = revokeObjectURL;
+    const nowMs = Date.parse("2026-07-10T20:00:00.000Z");
+    const realThreads = Array.from({ length: 51 }, (_, index) => ({
+      id: `real-${index}`,
+      workspaceId: "ws-1",
+      title: `Real ${index}`,
+      status: "active" as const,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      lastMessageAt: "2026-01-01T00:00:00.000Z",
+      sessionId: `real-${index}`,
+      messageCount: 0,
+      lastEventSeq: 0,
+    }));
+    const tombstoneThreads = Array.from({ length: 20 }, (_, index) => ({
+      ...realThreads[0]!,
+      id: `tombstone-${index}`,
+      title: `Tombstone ${index}`,
+      sessionId: `tombstone-${index}`,
+    }));
+    const oldFile = new File(["x"], "old.png", { type: "image/png", lastModified: 1 });
+    const realDrafts = Object.fromEntries(
+      realThreads.map((thread, index) => [
+        composerDraftKeyForThread(thread.id),
+        {
+          ...createEmptyComposerDraft(new Date(nowMs - index * 1_000).toISOString()),
+          revision: index + 1,
+          text: `real draft ${index}`,
+          attachments:
+            index === 50
+              ? [
+                  {
+                    filename: oldFile.name,
+                    mimeType: oldFile.type,
+                    size: oldFile.size,
+                    lastModified: oldFile.lastModified,
+                    file: oldFile,
+                    previewUrl: "blob:pruned-store-preview",
+                    signature: "old.png\u0000image/png\u00001\u00001",
+                    contentBase64: "eA==",
+                  },
+                ]
+              : [],
+        },
+      ]),
+    );
+    const tombstones = Object.fromEntries(
+      tombstoneThreads.map((thread, index) => [
+        composerDraftKeyForThread(thread.id),
+        {
+          ...createEmptyComposerDraft(new Date(nowMs - index).toISOString()),
+          revision: index + 1,
+          generation: index + 1,
+        },
+      ]),
+    );
+
+    try {
+      useAppStore.setState({
+        selectedThreadId: "real-0",
+        threads: [...realThreads, ...tombstoneThreads],
+        composerDraftsByKey: { ...tombstones, ...realDrafts },
+        composerAttachmentIngestionCountByKey: {},
+      });
+      useAppStore.getState().pruneComposerDrafts(nowMs);
+      const persistedState = syncDesktopStateCacheNow(useAppStore.getState);
+
+      const memoryDraftKeys = Object.keys(useAppStore.getState().composerDraftsByKey);
+      const persistedDraftKeys = Object.keys(persistedState.composerDrafts ?? {});
+      expect(memoryDraftKeys).toHaveLength(50);
+      expect(memoryDraftKeys.every((key) => key.startsWith("thread:real-"))).toBe(true);
+      expect(persistedDraftKeys).toEqual(memoryDraftKeys);
+      expect(revokeObjectURL).toHaveBeenCalledWith("blob:pruned-store-preview");
+    } finally {
+      URL.revokeObjectURL = originalRevokeObjectURL;
+    }
+  });
+
   test("does not resurrect an attachment after its draft is discarded mid-read", async () => {
     const originalCreateObjectURL = URL.createObjectURL;
     const originalRevokeObjectURL = URL.revokeObjectURL;
@@ -490,17 +698,25 @@ describe("composer draft clear after send", () => {
     const readGate = new Promise<ArrayBuffer>((resolve) => {
       releaseRead = resolve;
     });
+    let markReadStarted: (() => void) | undefined;
+    const readStarted = new Promise<void>((resolve) => {
+      markReadStarted = resolve;
+    });
     const file = new File([new Uint8Array([1, 2, 3, 4])], "slow.png", {
       type: "image/png",
       lastModified: 20,
     });
     Object.defineProperty(file, "arrayBuffer", {
-      value: () => readGate,
+      value: () => {
+        markReadStarted?.();
+        return readGate;
+      },
     });
 
     try {
       useAppStore.setState({ composerDraftsByKey: {} });
       const addPromise = useAppStore.getState().addComposerAttachments([file]);
+      await readStarted;
       expect(useAppStore.getState().discardComposerDraft()).toBe(true);
       releaseRead?.(new Uint8Array([1, 2, 3, 4]).buffer);
       await addPromise;

--- a/apps/desktop/test/composer-drafts.test.ts
+++ b/apps/desktop/test/composer-drafts.test.ts
@@ -6,6 +6,7 @@ import {
   createComposerDraftAttachment,
   createEmptyComposerDraft,
   hydrateComposerDrafts,
+  MAX_COMPOSER_DRAFT_ATTACHMENT_BYTE_SIZE,
   MAX_COMPOSER_DRAFTS,
   pruneComposerDrafts,
   revokeComposerDraftAttachmentPreviews,
@@ -163,6 +164,68 @@ describe("composer draft ownership", () => {
     expect(result.removedKeys).toContain(missingKey);
   });
 
+  test("drops empty tombstones before capping real drafts and preserves that result on restart", () => {
+    const nowMs = Date.parse("2026-07-10T20:00:00.000Z");
+    const realDrafts = Object.fromEntries(
+      Array.from({ length: MAX_COMPOSER_DRAFTS + 1 }, (_, index) => [
+        composerDraftKeyForThread(`real-${index}`),
+        {
+          ...createEmptyComposerDraft(new Date(nowMs - index * 1_000).toISOString()),
+          revision: index + 1,
+          text: `real draft ${index}`,
+          attachments:
+            index === MAX_COMPOSER_DRAFTS
+              ? [
+                  {
+                    filename: "oldest.png",
+                    mimeType: "image/png",
+                    size: 1,
+                    lastModified: 1,
+                    file: new File(["x"], "oldest.png", { type: "image/png", lastModified: 1 }),
+                    previewUrl: "blob:oldest-preview",
+                    signature: "oldest.png\u0000image/png\u00001\u00001",
+                    contentBase64: "eA==",
+                  },
+                ]
+              : [],
+        },
+      ]),
+    );
+    const tombstones = Object.fromEntries(
+      Array.from({ length: 20 }, (_, index) => [
+        composerDraftKeyForThread(`tombstone-${index}`),
+        {
+          ...createEmptyComposerDraft(new Date(nowMs - index).toISOString()),
+          revision: index + 10,
+          generation: index + 10,
+        },
+      ]),
+    );
+    const validThreadIds = new Set([
+      ...Array.from({ length: MAX_COMPOSER_DRAFTS + 1 }, (_, index) => `real-${index}`),
+      ...Array.from({ length: 20 }, (_, index) => `tombstone-${index}`),
+    ]);
+
+    const result = pruneComposerDrafts(
+      { ...tombstones, ...realDrafts },
+      {
+        nowMs,
+        validThreadIds,
+        validProjectWorkspaceIds: new Set(),
+      },
+    );
+    const revokeObjectURL = mock(() => {});
+    revokeComposerDraftAttachmentPreviews(result.removedAttachments, revokeObjectURL);
+    const restored = hydrateComposerDrafts(serializeComposerDrafts(result.drafts));
+
+    expect(Object.keys(result.drafts)).toHaveLength(MAX_COMPOSER_DRAFTS);
+    expect(Object.keys(result.drafts).every((key) => key.startsWith("thread:real-"))).toBe(true);
+    expect(result.drafts[composerDraftKeyForThread(`real-${MAX_COMPOSER_DRAFTS}`)]).toBeUndefined();
+    expect(Object.keys(restored)).toEqual(Object.keys(result.drafts));
+    expect(revokeObjectURL).toHaveBeenCalledTimes(1);
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:oldest-preview");
+  });
+
   test("drops corrupt persisted attachments without allocating preview URLs", () => {
     const createObjectURL = mock(() => "blob:should-not-exist");
     const restored = hydrateComposerDrafts(
@@ -186,6 +249,37 @@ describe("composer draft ownership", () => {
 
     expect(restored[composerDraftKeyForThread("thread-a")]?.attachments).toEqual([]);
     expect(createObjectURL).not.toHaveBeenCalled();
+  });
+
+  test("rejects oversized persisted attachments before attempting base64 decoding", () => {
+    const originalAtob = globalThis.atob;
+    const decodeBase64 = mock(() => {
+      throw new Error("oversized payload should not be decoded");
+    });
+    globalThis.atob = decodeBase64;
+
+    try {
+      const restored = hydrateComposerDrafts({
+        [composerDraftKeyForThread("thread-a")]: {
+          ...createEmptyComposerDraft("2026-07-10T20:00:00.000Z"),
+          attachments: [
+            {
+              filename: "oversized.bin",
+              mimeType: "application/octet-stream",
+              size: MAX_COMPOSER_DRAFT_ATTACHMENT_BYTE_SIZE + 1,
+              lastModified: 1,
+              signature: "oversized",
+              contentBase64: "eA==",
+            },
+          ],
+        },
+      });
+
+      expect(restored[composerDraftKeyForThread("thread-a")]?.attachments).toEqual([]);
+      expect(decodeBase64).not.toHaveBeenCalled();
+    } finally {
+      globalThis.atob = originalAtob;
+    }
   });
 
   test("revokes every preview returned by pruning", async () => {

--- a/apps/desktop/test/composer-drafts.test.ts
+++ b/apps/desktop/test/composer-drafts.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, mock, test } from "bun:test";
+import {
+  clearComposerDraftRevision,
+  composerDraftKeyForNewChatTarget,
+  composerDraftKeyForThread,
+  createComposerDraftAttachment,
+  createEmptyComposerDraft,
+  hydrateComposerDrafts,
+  MAX_COMPOSER_DRAFTS,
+  pruneComposerDrafts,
+  revokeComposerDraftAttachmentPreviews,
+  serializeComposerDrafts,
+} from "../src/app/composerDrafts";
+
+describe("composer draft ownership", () => {
+  test("uses independent keys for threads and every New Chat target", () => {
+    expect(composerDraftKeyForThread("thread-a")).toBe("thread:thread-a");
+    expect(composerDraftKeyForThread("thread-b")).toBe("thread:thread-b");
+    expect(composerDraftKeyForNewChatTarget({ kind: "oneOff" })).toBe("new:oneOff");
+    expect(composerDraftKeyForNewChatTarget({ kind: "project", workspaceId: "workspace-a" })).toBe(
+      "new:project:workspace-a",
+    );
+    expect(composerDraftKeyForNewChatTarget({ kind: "project", workspaceId: "workspace-b" })).toBe(
+      "new:project:workspace-b",
+    );
+  });
+
+  test("clears only the captured owner revision", () => {
+    const original = {
+      [composerDraftKeyForThread("thread-a")]: {
+        ...createEmptyComposerDraft("2026-07-10T20:00:00.000Z"),
+        revision: 4,
+        text: "send from A",
+      },
+      [composerDraftKeyForThread("thread-b")]: {
+        ...createEmptyComposerDraft("2026-07-10T20:00:01.000Z"),
+        revision: 2,
+        text: "new text in B",
+      },
+    };
+
+    const stale = clearComposerDraftRevision(original, {
+      key: composerDraftKeyForThread("thread-a"),
+      revision: 3,
+    });
+    expect(stale.cleared).toBe(false);
+    expect(stale.drafts).toBe(original);
+
+    const current = clearComposerDraftRevision(original, {
+      key: composerDraftKeyForThread("thread-a"),
+      revision: 4,
+    });
+    expect(current.cleared).toBe(true);
+    expect(current.drafts[composerDraftKeyForThread("thread-a")]).toMatchObject({
+      revision: 5,
+      generation: 1,
+      text: "",
+      attachments: [],
+    });
+    expect(current.drafts[composerDraftKeyForThread("thread-b")]?.text).toBe("new text in B");
+    expect(serializeComposerDrafts(current.drafts)[composerDraftKeyForThread("thread-a")]).toBe(
+      undefined,
+    );
+  });
+
+  test("round-trips the complete draft and recreates one preview URL after restart", async () => {
+    const createObjectURL = mock(() => "blob:restored-preview");
+    const attachment = await createComposerDraftAttachment(
+      new File(["diagram bytes"], "diagram.png", {
+        type: "image/png",
+        lastModified: 1_720_000_000_000,
+      }),
+      { createObjectURL: () => "blob:original-preview" },
+    );
+    const key = composerDraftKeyForThread("thread-a");
+    const drafts = {
+      [key]: {
+        revision: 7,
+        generation: 2,
+        updatedAt: "2026-07-10T20:00:00.000Z",
+        text: "Review @documents with the image",
+        attachments: [attachment],
+        references: [{ kind: "skill" as const, name: "documents" }],
+        provider: "openai" as const,
+        model: "gpt-5.4",
+        reasoningEffort: "high" as const,
+      },
+    };
+
+    const restored = hydrateComposerDrafts(serializeComposerDrafts(drafts), {
+      createObjectURL,
+    });
+
+    expect(restored[key]).toMatchObject({
+      revision: 7,
+      generation: 2,
+      updatedAt: "2026-07-10T20:00:00.000Z",
+      text: "Review @documents with the image",
+      references: [{ kind: "skill", name: "documents" }],
+      provider: "openai",
+      model: "gpt-5.4",
+      reasoningEffort: "high",
+    });
+    expect(restored[key]?.attachments).toHaveLength(1);
+    expect(restored[key]?.attachments[0]).toMatchObject({
+      filename: "diagram.png",
+      mimeType: "image/png",
+      size: 13,
+      previewUrl: "blob:restored-preview",
+    });
+    expect(await restored[key]?.attachments[0]?.file.text()).toBe("diagram bytes");
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+  });
+
+  test("prunes invalid, expired, and overflow drafts deterministically", () => {
+    const nowMs = Date.parse("2026-07-10T20:00:00.000Z");
+    const recentDrafts = Object.fromEntries(
+      Array.from({ length: MAX_COMPOSER_DRAFTS + 2 }, (_, index) => [
+        composerDraftKeyForThread(`thread-${index}`),
+        {
+          ...createEmptyComposerDraft(new Date(nowMs - index * 1_000).toISOString()),
+          revision: index + 1,
+          text: `draft ${index}`,
+        },
+      ]),
+    );
+    const expiredKey = composerDraftKeyForThread("expired");
+    const missingKey = composerDraftKeyForThread("missing");
+    const activeExpiredKey = composerDraftKeyForThread("active-expired");
+    const drafts = {
+      ...recentDrafts,
+      [expiredKey]: {
+        ...createEmptyComposerDraft("2026-05-01T00:00:00.000Z"),
+        text: "expired",
+      },
+      [missingKey]: {
+        ...createEmptyComposerDraft("2026-07-10T19:00:00.000Z"),
+        text: "orphaned",
+      },
+      [activeExpiredKey]: {
+        ...createEmptyComposerDraft("2026-05-01T00:00:00.000Z"),
+        text: "active drafts survive age pruning",
+      },
+    };
+    const validThreadIds = new Set([
+      ...Array.from({ length: MAX_COMPOSER_DRAFTS + 2 }, (_, index) => `thread-${index}`),
+      "expired",
+      "active-expired",
+    ]);
+
+    const result = pruneComposerDrafts(drafts, {
+      nowMs,
+      validThreadIds,
+      validProjectWorkspaceIds: new Set(),
+      activeKey: activeExpiredKey,
+    });
+
+    expect(result.drafts[activeExpiredKey]?.text).toBe("active drafts survive age pruning");
+    expect(result.drafts[expiredKey]).toBeUndefined();
+    expect(result.drafts[missingKey]).toBeUndefined();
+    expect(Object.keys(result.drafts)).toHaveLength(MAX_COMPOSER_DRAFTS);
+    expect(result.removedKeys).toContain(expiredKey);
+    expect(result.removedKeys).toContain(missingKey);
+  });
+
+  test("drops corrupt persisted attachments without allocating preview URLs", () => {
+    const createObjectURL = mock(() => "blob:should-not-exist");
+    const restored = hydrateComposerDrafts(
+      {
+        [composerDraftKeyForThread("thread-a")]: {
+          ...createEmptyComposerDraft("2026-07-10T20:00:00.000Z"),
+          attachments: [
+            {
+              filename: "broken.png",
+              mimeType: "image/png",
+              size: 99,
+              lastModified: 1,
+              signature: "broken",
+              contentBase64: "bm90IDk5IGJ5dGVz",
+            },
+          ],
+        },
+      },
+      { createObjectURL },
+    );
+
+    expect(restored[composerDraftKeyForThread("thread-a")]?.attachments).toEqual([]);
+    expect(createObjectURL).not.toHaveBeenCalled();
+  });
+
+  test("revokes every preview returned by pruning", async () => {
+    const attachment = await createComposerDraftAttachment(
+      new File(["bytes"], "old.png", { type: "image/png", lastModified: 1 }),
+      { createObjectURL: () => "blob:old-preview" },
+    );
+    const key = composerDraftKeyForThread("removed");
+    const result = pruneComposerDrafts(
+      {
+        [key]: {
+          ...createEmptyComposerDraft("2026-07-10T20:00:00.000Z"),
+          attachments: [attachment],
+        },
+      },
+      {
+        nowMs: Date.parse("2026-07-10T20:00:00.000Z"),
+        validThreadIds: new Set(),
+        validProjectWorkspaceIds: new Set(),
+      },
+    );
+    const revokeObjectURL = mock(() => {});
+
+    revokeComposerDraftAttachmentPreviews(result.removedAttachments, revokeObjectURL);
+
+    expect(result.removedKeys).toEqual([key]);
+    expect(revokeObjectURL).toHaveBeenCalledTimes(1);
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:old-preview");
+  });
+});

--- a/apps/desktop/test/context-sidebar.test.tsx
+++ b/apps/desktop/test/context-sidebar.test.tsx
@@ -42,7 +42,7 @@ function resetAppStore(overrides: Record<string, unknown>) {
     providerAuthMethodsByProvider: {},
     providerLastAuthChallenge: null,
     providerLastAuthResult: null,
-    composerText: "",
+    composerDraftsByKey: {},
     injectContext: false,
     developerMode: false,
     showHiddenFiles: false,

--- a/apps/desktop/test/jsonrpc-single-connection.test.ts
+++ b/apps/desktop/test/jsonrpc-single-connection.test.ts
@@ -459,7 +459,7 @@ function seedActiveThreadState() {
         sessionId: "jsonrpc-thread-1",
       },
     },
-    composerText: "",
+    composerDraftsByKey: {},
   } as any);
 }
 
@@ -538,7 +538,7 @@ describe("desktop JSON-RPC single connection path", () => {
       providerAuthMethodsByProvider: {},
       providerLastAuthChallenge: null,
       providerLastAuthResult: null,
-      composerText: "",
+      composerDraftsByKey: {},
       injectContext: false,
       developerMode: false,
       showHiddenFiles: false,
@@ -888,7 +888,7 @@ describe("desktop JSON-RPC single connection path", () => {
       code: "internal_error",
       source: "protocol",
     });
-    expect(useAppStore.getState().composerText).toBe("");
+    expect(useAppStore.getState().composerDraftsByKey).toEqual({});
     expect(jsonRpcRequests.map((entry) => entry.method)).toContain("turn/start");
   });
 
@@ -1204,7 +1204,7 @@ describe("desktop JSON-RPC single connection path", () => {
           feed: [],
         },
       },
-      composerText: "",
+      composerDraftsByKey: {},
     } as any);
 
     const attachment = {

--- a/apps/desktop/test/persistence-state-sanitization.test.ts
+++ b/apps/desktop/test/persistence-state-sanitization.test.ts
@@ -126,6 +126,93 @@ describe("desktop persistence state validation", () => {
     expect(loaded.threads[0]?.id).toBe("thread_valid");
   });
 
+  test("saveState round-trips complete composer drafts and drops malformed attachments", async () => {
+    const persistence = new PersistenceService();
+    const validWorkspace = path.join(userDataDir, "workspace-drafts");
+    await fs.mkdir(validWorkspace, { recursive: true });
+
+    await persistence.saveState({
+      version: 2,
+      workspaces: [
+        {
+          id: "ws_drafts",
+          name: "Draft workspace",
+          path: validWorkspace,
+          createdAt: TS,
+          lastOpenedAt: TS,
+          defaultEnableMcp: true,
+          defaultBackupsEnabled: false,
+          yolo: false,
+        },
+      ],
+      threads: [
+        {
+          id: "thread_drafts",
+          workspaceId: "ws_drafts",
+          title: "Draft thread",
+          createdAt: TS,
+          lastMessageAt: TS,
+          status: "active",
+          sessionId: "session_drafts",
+          messageCount: 1,
+          lastEventSeq: 1,
+        },
+      ],
+      composerDrafts: {
+        "thread:thread_drafts": {
+          revision: 4,
+          generation: 1,
+          updatedAt: TS,
+          text: "persist me",
+          attachments: [
+            {
+              filename: "notes.txt",
+              mimeType: "text/plain",
+              size: 5,
+              lastModified: 7,
+              signature: "notes",
+              contentBase64: "bm90ZXM=",
+            },
+            {
+              filename: "broken.txt",
+              mimeType: "text/plain",
+              size: 50,
+              lastModified: 8,
+              signature: "broken",
+              contentBase64: "dG9vIHNob3J0",
+            },
+          ],
+          references: [{ kind: "skill", name: "documents" }],
+          provider: "openai",
+          model: "gpt-5.4",
+          reasoningEffort: "high",
+        },
+      },
+    });
+
+    const loaded = await persistence.loadState();
+    expect(loaded.composerDrafts?.["thread:thread_drafts"]).toEqual({
+      revision: 4,
+      generation: 1,
+      updatedAt: TS,
+      text: "persist me",
+      attachments: [
+        {
+          filename: "notes.txt",
+          mimeType: "text/plain",
+          size: 5,
+          lastModified: 7,
+          signature: "notes",
+          contentBase64: "bm90ZXM=",
+        },
+      ],
+      references: [{ kind: "skill", name: "documents" }],
+      provider: "openai",
+      model: "gpt-5.4",
+      reasoningEffort: "high",
+    });
+  });
+
   test("saveState preserves task-owned thread metadata and drops malformed ownership", async () => {
     const persistence = new PersistenceService();
     const validWorkspace = path.join(userDataDir, "workspace-valid");

--- a/apps/desktop/test/protocol-v2-events.test.ts
+++ b/apps/desktop/test/protocol-v2-events.test.ts
@@ -460,7 +460,7 @@ describe("desktop JSON-RPC event mapping", () => {
         providerAuthMethodsByProvider: {},
         providerLastAuthChallenge: null,
         providerLastAuthResult: null,
-        composerText: "",
+        composerDraftsByKey: {},
         injectContext: false,
         developerMode: false,
         showHiddenFiles: false,

--- a/apps/desktop/test/sidebar-ui.test.tsx
+++ b/apps/desktop/test/sidebar-ui.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { act, createElement } from "react";
 import { createRoot } from "react-dom/client";
+import { composerDraftKeyForThread, createEmptyComposerDraft } from "../src/app/composerDrafts";
 
 import { createDesktopCommandsMock } from "./helpers/mockDesktopCommands";
 import { setupJsdom } from "./jsdomHarness";
@@ -121,7 +122,7 @@ function resetAppStore(overrides: Record<string, unknown> = {}) {
     providerAuthMethodsByProvider: {},
     providerLastAuthChallenge: null,
     providerLastAuthResult: null,
-    composerText: "",
+    composerDraftsByKey: {},
     injectContext: false,
     developerMode: false,
     showHiddenFiles: false,
@@ -212,6 +213,42 @@ describe("desktop sidebar", () => {
 
   afterEach(() => {
     useAppStore.setState(defaultStoreState);
+  });
+
+  test.serial("shows a subtle indicator only for chats with unsent draft content", async () => {
+    const harness = setupSidebarJsdom();
+    let root: ReturnType<typeof createRoot> | null = null;
+
+    try {
+      const container = harness.dom.window.document.getElementById("root");
+      if (!container) throw new Error("missing root");
+      root = createRoot(container);
+      await act(async () => {
+        resetAppStore({
+          workspaces: [makeWorkspace()],
+          threads: makeThreads(2),
+          selectedWorkspaceId: "ws-1",
+          selectedThreadId: "thread-1",
+          composerDraftsByKey: {
+            [composerDraftKeyForThread("thread-2")]: {
+              ...createEmptyComposerDraft("2026-03-24T10:00:00.000Z"),
+              revision: 1,
+              text: "unsent",
+            },
+          },
+        });
+        root.render(createElement(Sidebar));
+      });
+
+      const indicators = container.querySelectorAll('[aria-label="Unsent draft"]');
+      expect(indicators).toHaveLength(1);
+      expect(indicators[0]?.closest(".sidebar-thread-item")?.textContent).toContain("Thread 2");
+    } finally {
+      if (root) {
+        await act(async () => root?.unmount());
+      }
+      harness.restore();
+    }
   });
 
   test.serial(

--- a/apps/desktop/test/thread-reconnect.test.ts
+++ b/apps/desktop/test/thread-reconnect.test.ts
@@ -426,7 +426,7 @@ function seedStore(
     providerAuthMethodsByProvider: {},
     providerLastAuthChallenge: null,
     providerLastAuthResult: null,
-    composerText: "",
+    composerDraftsByKey: {},
     injectContext: false,
     developerMode: false,
     showHiddenFiles: false,

--- a/apps/desktop/test/workspace-mcp-editor.test.ts
+++ b/apps/desktop/test/workspace-mcp-editor.test.ts
@@ -258,7 +258,7 @@ describe("workspace MCP editor flow", () => {
         providerAuthMethodsByProvider: {},
         providerLastAuthChallenge: null,
         providerLastAuthResult: null,
-        composerText: "",
+        composerDraftsByKey: {},
         injectContext: false,
         developerMode: false,
         showHiddenFiles: false,

--- a/apps/desktop/test/workspace-settings-sync.harness.ts
+++ b/apps/desktop/test/workspace-settings-sync.harness.ts
@@ -664,7 +664,7 @@ export function registerWorkspaceSettingsSyncLifecycleHooks() {
       providerAuthMethodsByProvider: {},
       providerLastAuthChallenge: null,
       providerLastAuthResult: null,
-      composerText: "",
+      composerDraftsByKey: {},
       injectContext: false,
       developerMode: false,
       showHiddenFiles: false,

--- a/apps/desktop/test/workspace-startup.test.ts
+++ b/apps/desktop/test/workspace-startup.test.ts
@@ -307,7 +307,7 @@ describe("workspace startup flow", () => {
       providerLastAuthChallenge: null,
       providerLastAuthResult: null,
       ...defaultProviderActions,
-      composerText: "",
+      composerDraftsByKey: {},
       injectContext: false,
       developerMode: false,
       showHiddenFiles: false,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What/why
Moves text and attachment drafts into store-owned per-chat units with revision-safe clearing, persistence, pruning, and preview lifecycle handling.

Fixes #212.

## Verification
- Full serial Bun suite
- Focused draft, persistence, bootstrap, and chat tests
- Electron quality gates
- Live Electron/CDP walkthrough

[per_chat_draft_restoration.mp4](https://cursor.com/agents/bc-2fe1a13d-c977-4764-9f33-e0042e2eeb81/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fper_chat_draft_restoration.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2fe1a13d-c977-4764-9f33-e0042e2eeb81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2fe1a13d-c977-4764-9f33-e0042e2eeb81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

