### PR TITLE
fix(navigation): preserve creation intent

### DIFF
--- a/apps/desktop/src/app/creationDrafts.ts
+++ b/apps/desktop/src/app/creationDrafts.ts
@@ -1,0 +1,223 @@
+import {
+  type ComposerDraft,
+  createEmptyComposerDraft,
+  hydrateComposerDrafts,
+  type PersistedComposerDraft,
+  serializeComposerDrafts,
+} from "./composerDrafts";
+
+const RESEARCH_DRAFT_KEY = "research:new";
+const MAX_TASK_WORK_ITEMS = 100;
+const MAX_DRAFT_STRING_LENGTH = 200_000;
+
+export type CreationDraftError = {
+  revision: number;
+  message: string;
+};
+
+export type TaskCreationDraftWorkItem = {
+  id: string;
+  key: string;
+  title: string;
+  description: string;
+  dependencies: string;
+  expectedOutputs: string;
+};
+
+export type TaskCreationDraft = {
+  revision: number;
+  updatedAt: string;
+  idempotencyKey: string;
+  workspaceId: string;
+  title: string;
+  objective: string;
+  context: string;
+  requirements: string;
+  constraints: string;
+  acceptanceCriteria: string;
+  decisions: string;
+  reviewRequired: boolean;
+  workItems: TaskCreationDraftWorkItem[];
+  workGraphCustomized: boolean;
+  showAdvancedWorkGraph: boolean;
+};
+
+export type PersistedCreationDrafts = {
+  research?: PersistedComposerDraft;
+  researchError?: CreationDraftError;
+  task?: TaskCreationDraft;
+  taskError?: CreationDraftError;
+};
+
+export type HydratedCreationDrafts = {
+  researchCreationDraft: ComposerDraft;
+  researchCreationError: CreationDraftError | null;
+  taskCreationDraft: TaskCreationDraft;
+  taskCreationError: CreationDraftError | null;
+};
+
+function makeDraftId(): string {
+  return crypto.randomUUID();
+}
+
+export function createEmptyTaskCreationDraft(revision = 0, workspaceId = ""): TaskCreationDraft {
+  const now = new Date().toISOString();
+  return {
+    revision,
+    updatedAt: now,
+    idempotencyKey: makeDraftId(),
+    workspaceId,
+    title: "",
+    objective: "",
+    context: "",
+    requirements: "",
+    constraints: "",
+    acceptanceCriteria: "",
+    decisions: "",
+    reviewRequired: true,
+    workItems: [
+      {
+        id: makeDraftId(),
+        key: "step-1",
+        title: "",
+        description: "",
+        dependencies: "",
+        expectedOutputs: "",
+      },
+    ],
+    workGraphCustomized: false,
+    showAdvancedWorkGraph: false,
+  };
+}
+
+export function createEmptyCreationDrafts(): HydratedCreationDrafts {
+  return {
+    researchCreationDraft: createEmptyComposerDraft(),
+    researchCreationError: null,
+    taskCreationDraft: createEmptyTaskCreationDraft(),
+    taskCreationError: null,
+  };
+}
+
+export function serializeCreationDrafts(
+  state: Partial<HydratedCreationDrafts>,
+): PersistedCreationDrafts {
+  const researchDraft = state.researchCreationDraft ?? createEmptyComposerDraft();
+  const taskDraft = state.taskCreationDraft ?? createEmptyTaskCreationDraft();
+  const research = serializeComposerDrafts({
+    [RESEARCH_DRAFT_KEY]: researchDraft,
+  })[RESEARCH_DRAFT_KEY];
+  const researchError =
+    state.researchCreationError?.revision === researchDraft.revision
+      ? state.researchCreationError
+      : null;
+  const taskError =
+    state.taskCreationError?.revision === taskDraft.revision ? state.taskCreationError : null;
+  return {
+    ...(research ? { research } : {}),
+    ...(researchError ? { researchError } : {}),
+    task: taskDraft,
+    ...(taskError ? { taskError } : {}),
+  };
+}
+
+export function hydrateCreationDrafts(value: unknown): HydratedCreationDrafts {
+  const record = isRecord(value) ? value : {};
+  const researchCreationDraft =
+    hydrateComposerDrafts({ [RESEARCH_DRAFT_KEY]: record.research })[RESEARCH_DRAFT_KEY] ??
+    createEmptyComposerDraft();
+  const taskCreationDraft = sanitizeTaskCreationDraft(record.task);
+  const researchCreationError = sanitizeCreationDraftError(
+    record.researchError,
+    researchCreationDraft.revision,
+  );
+  const taskCreationError = sanitizeCreationDraftError(
+    record.taskError,
+    taskCreationDraft.revision,
+  );
+  return {
+    researchCreationDraft,
+    researchCreationError,
+    taskCreationDraft,
+    taskCreationError,
+  };
+}
+
+function sanitizeTaskCreationDraft(value: unknown): TaskCreationDraft {
+  const fallback = createEmptyTaskCreationDraft();
+  if (!isRecord(value)) return fallback;
+  const revision = nonnegativeInteger(value.revision) ?? fallback.revision;
+  const workItems = Array.isArray(value.workItems)
+    ? value.workItems
+        .slice(0, MAX_TASK_WORK_ITEMS)
+        .map(sanitizeTaskCreationDraftWorkItem)
+        .filter((item): item is TaskCreationDraftWorkItem => item !== null)
+    : [];
+  return {
+    revision,
+    updatedAt: validIso(value.updatedAt) ?? fallback.updatedAt,
+    idempotencyKey: nonemptyString(value.idempotencyKey) ?? fallback.idempotencyKey,
+    workspaceId: draftString(value.workspaceId),
+    title: draftString(value.title),
+    objective: draftString(value.objective),
+    context: draftString(value.context),
+    requirements: draftString(value.requirements),
+    constraints: draftString(value.constraints),
+    acceptanceCriteria: draftString(value.acceptanceCriteria),
+    decisions: draftString(value.decisions),
+    reviewRequired: typeof value.reviewRequired === "boolean" ? value.reviewRequired : true,
+    workItems: workItems.length > 0 ? workItems : fallback.workItems,
+    workGraphCustomized:
+      typeof value.workGraphCustomized === "boolean" ? value.workGraphCustomized : false,
+    showAdvancedWorkGraph:
+      typeof value.showAdvancedWorkGraph === "boolean" ? value.showAdvancedWorkGraph : false,
+  };
+}
+
+function sanitizeTaskCreationDraftWorkItem(value: unknown): TaskCreationDraftWorkItem | null {
+  if (!isRecord(value)) return null;
+  const id = nonemptyString(value.id);
+  const key = nonemptyString(value.key);
+  if (!id || !key) return null;
+  return {
+    id,
+    key,
+    title: draftString(value.title),
+    description: draftString(value.description),
+    dependencies: draftString(value.dependencies),
+    expectedOutputs: draftString(value.expectedOutputs),
+  };
+}
+
+function sanitizeCreationDraftError(
+  value: unknown,
+  currentRevision: number,
+): CreationDraftError | null {
+  if (!isRecord(value)) return null;
+  const revision = nonnegativeInteger(value.revision);
+  const message = nonemptyString(value.message);
+  if (revision !== currentRevision || !message) return null;
+  return { revision, message };
+}
+
+function draftString(value: unknown): string {
+  return typeof value === "string" ? value.slice(0, MAX_DRAFT_STRING_LENGTH) : "";
+}
+
+function nonemptyString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed.slice(0, MAX_DRAFT_STRING_LENGTH) : null;
+}
+
+function nonnegativeInteger(value: unknown): number | null {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : null;
+}
+
+function validIso(value: unknown): string | null {
+  return typeof value === "string" && Number.isFinite(Date.parse(value)) ? value : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/apps/desktop/src/app/store.actions/bootstrap.ts
+++ b/apps/desktop/src/app/store.actions/bootstrap.ts
@@ -27,6 +27,7 @@ import {
   revokeComposerDraftAttachmentPreviews,
   sanitizePersistedComposerDrafts,
 } from "../composerDrafts";
+import { hydrateCreationDrafts } from "../creationDrafts";
 import { normalizeWorkspaceProviderOptions } from "../openaiCompatibleProviderOptions";
 import {
   deriveConnectedProviders,
@@ -515,6 +516,7 @@ const persistedStateSchema = z
         .optional(),
     ),
     composerDrafts: z.unknown().optional(),
+    creationDrafts: z.unknown().optional(),
   })
   .passthrough()
   .transform((state) => {
@@ -545,6 +547,7 @@ const persistedStateSchema = z
       providerUiState,
       onboarding,
       composerDrafts: sanitizePersistedComposerDrafts(state.composerDrafts),
+      creationDrafts: state.creationDrafts,
     };
   });
 
@@ -758,6 +761,7 @@ export function buildCachedDesktopStateSeed(value: unknown): Partial<AppStoreDat
     const connectedProviders = deriveConnectedProviders(
       state.providerState as PersistedProviderState | undefined,
     );
+    const creationDrafts = hydrateCreationDrafts(state.creationDrafts);
     return {
       ready: true,
       bootstrapPhase: "idle",
@@ -779,6 +783,7 @@ export function buildCachedDesktopStateSeed(value: unknown): Partial<AppStoreDat
           newChatLandingTarget: ui.newChatLandingTarget,
         },
       ),
+      ...creationDrafts,
       newChatLandingTarget: ui.newChatLandingTarget,
       providerStatusByName: state.providerState?.statusByName ?? {},
       providerStatusLastUpdatedAt: state.providerState?.statusLastUpdatedAt ?? null,
@@ -1065,6 +1070,8 @@ export function createBootstrapActions(
           revokeComposerDraftAttachmentPreviews(
             Object.values(previousDrafts).flatMap((draft) => draft.attachments),
           );
+          const creationDrafts = hydrateCreationDrafts(state.creationDrafts);
+          revokeComposerDraftAttachmentPreviews(get().researchCreationDraft.attachments);
           set({
             workspaces: state.workspaces,
             threads: finalThreads,
@@ -1074,6 +1081,7 @@ export function createBootstrapActions(
             composerDraftRevisionFloorByKey: {},
             composerAttachmentIngestionCountByKey: {},
             composerDraftsByKey: restoredComposerDrafts,
+            ...creationDrafts,
             newChatLandingTarget: ui.newChatLandingTarget,
             providerStatusByName: state.providerState?.statusByName ?? {},
             providerStatusLastUpdatedAt: state.providerState?.statusLastUpdatedAt ?? null,

--- a/apps/desktop/src/app/store.actions/bootstrap.ts
+++ b/apps/desktop/src/app/store.actions/bootstrap.ts
@@ -57,6 +57,7 @@ import {
   type BootstrapRunContext,
   createBootstrapCoordinator,
 } from "../store.helpers/bootstrapCoordinator";
+import { invalidateNavigationIntent } from "../store.helpers/operationIntent";
 import { waitForNextPaintOrTimeout } from "../store.helpers/paintScheduling";
 import { isStandardChatThread } from "../threadFilters";
 import { getThreadSelectionContext, getThreadSelectionIntent } from "../threadSelectionContext";
@@ -1170,6 +1171,7 @@ export function createBootstrapActions(
       }),
 
     openSettings: (page) => {
+      invalidateNavigationIntent();
       set((s) => ({
         view: "settings",
         settingsPage: normalizeSettingsPageId(
@@ -1183,6 +1185,7 @@ export function createBootstrapActions(
     },
 
     closeSettings: () => {
+      invalidateNavigationIntent();
       set((s) => ({
         view: s.lastNonSettingsView === "settings" ? "chat" : s.lastNonSettingsView,
       }));

--- a/apps/desktop/src/app/store.actions/research.ts
+++ b/apps/desktop/src/app/store.actions/research.ts
@@ -25,6 +25,14 @@ import {
   registerWorkspaceJsonRpcRouter,
   requestJsonRpc,
 } from "../store.helpers/jsonRpcSocket";
+import {
+  beginCreationOperationIntent,
+  type CreationOperationControl,
+  invalidateNavigationIntent,
+  isCreationNavigationIntentCurrent,
+  isOperationAbortError,
+  throwIfOperationAborted,
+} from "../store.helpers/operationIntent";
 import type { ResearchSettingsState } from "../types";
 
 const researchRouterCleanupByWorkspace = new Map<string, () => void>();
@@ -537,7 +545,11 @@ export function createResearchActions(
     }
   };
 
-  const ensureResearchTransportWorkspace = async (): Promise<string | null> => {
+  const ensureResearchTransportWorkspace = async (
+    options: CreationOperationControl = {},
+  ): Promise<string | null> => {
+    const canNavigate = () => !options.intent || isCreationNavigationIntentCurrent(options.intent);
+    throwIfOperationAborted(options.signal);
     let state = get();
     let workspaceId = state.researchTransportWorkspaceId;
     if (!workspaceId || !state.workspaces.some((workspace) => workspace.id === workspaceId)) {
@@ -553,7 +565,8 @@ export function createResearchActions(
         );
         return null;
       }
-      await get().addWorkspace();
+      await get().addWorkspace({ intent: options.intent });
+      throwIfOperationAborted(options.signal);
       state = get();
       workspaceId = state.selectedWorkspaceId ?? state.workspaces[0]?.id ?? null;
       if (!workspaceId) {
@@ -565,15 +578,17 @@ export function createResearchActions(
     bindResearchWorkspace(workspaceId);
     deps.ensureWorkspaceRuntime(get, set, workspaceId);
     await deps.ensureServerRunning(get, set, workspaceId);
+    throwIfOperationAborted(options.signal);
     deps.ensureControlSocket(get, set, workspaceId);
     const ready = await deps.waitForControlSession(get, set, workspaceId);
+    throwIfOperationAborted(options.signal);
     if (!ready) {
       throw new Error("Unable to connect to the research transport workspace.");
     }
 
     set((s) => ({
       researchTransportWorkspaceId: workspaceId,
-      selectedWorkspaceId: s.selectedWorkspaceId ?? workspaceId,
+      ...(canNavigate() ? { selectedWorkspaceId: s.selectedWorkspaceId ?? workspaceId } : {}),
     }));
     return workspaceId;
   };
@@ -600,14 +615,21 @@ export function createResearchActions(
       return {
         researchById,
         researchOrder,
-        selectedResearchId: opts?.select
-          ? research.id
-          : normalizeSelectedResearchId(s.selectedResearchId, researchOrder),
+        selectedResearchId:
+          opts?.select === true
+            ? research.id
+            : opts?.select === false
+              ? s.selectedResearchId
+              : normalizeSelectedResearchId(s.selectedResearchId, researchOrder),
       };
     });
   };
 
-  const ensureResearchSubscription = async (workspaceId: string, research: ResearchRecord) => {
+  const ensureResearchSubscription = async (
+    workspaceId: string,
+    research: ResearchRecord,
+    canSelect?: () => boolean,
+  ) => {
     if (
       get().researchSubscribedIds.includes(research.id) ||
       isResearchTerminalStatus(research.status)
@@ -620,7 +642,7 @@ export function createResearchActions(
     });
     const subscribedResearch = result.research ?? research;
     if (result.research) {
-      applyResearchRecord(result.research);
+      applyResearchRecord(result.research, canSelect ? { select: canSelect() } : undefined);
     }
     if (isResearchTerminalStatus(subscribedResearch.status)) {
       return;
@@ -632,11 +654,17 @@ export function createResearchActions(
     }));
   };
 
-  const uploadFiles = async (workspaceId: string, files: File[] | undefined): Promise<string[]> => {
+  const uploadFiles = async (
+    workspaceId: string,
+    files: File[] | undefined,
+    signal?: AbortSignal,
+  ): Promise<string[]> => {
     const fileIds: string[] = [];
     try {
       for (const file of files ?? []) {
+        throwIfOperationAborted(signal);
         const payload = await serializeFile(file);
+        throwIfOperationAborted(signal);
         const result = await requestResearchResult(
           deps,
           get,
@@ -646,6 +674,7 @@ export function createResearchActions(
           payload,
         );
         fileIds.push(result.file.fileId);
+        throwIfOperationAborted(signal);
       }
       return fileIds;
     } catch (error) {
@@ -741,6 +770,7 @@ export function createResearchActions(
         set({ researchListLoading: false, researchListError: null });
         return;
       }
+      invalidateNavigationIntent();
       set({
         view: "research",
         lastNonSettingsView: "research",
@@ -801,6 +831,7 @@ export function createResearchActions(
     },
 
     selectResearch: async (researchId) => {
+      invalidateNavigationIntent();
       set({ selectedResearchId: researchId });
       if (!researchId) {
         return;
@@ -826,26 +857,40 @@ export function createResearchActions(
       }
     },
 
-    startResearch: async ({ input, title, files, settings }) => {
+    startResearch: async ({ input, title, files, settings, intent, signal, onPhase }) => {
       if (!hasGoogleResearchAccess()) {
         notifyMissingGoogleApiKey();
         return null;
       }
+      const operationIntent = intent ?? beginCreationOperationIntent();
+      const canNavigate = () => isCreationNavigationIntentCurrent(operationIntent);
+      const reportPhase = onPhase ?? (() => {});
       let workspaceId: string | null = null;
       let attachedFileIds: string[] = [];
       let startRequested = false;
       try {
-        workspaceId = await ensureResearchTransportWorkspace();
+        reportPhase("starting-server");
+        workspaceId = await ensureResearchTransportWorkspace({
+          intent: operationIntent,
+          signal,
+        });
         if (!workspaceId) {
           return null;
         }
         set(() => ({
-          view: "research",
-          lastNonSettingsView: "research",
           researchTransportWorkspaceId: workspaceId,
+          ...(canNavigate()
+            ? {
+                view: "research" as const,
+                lastNonSettingsView: "research" as const,
+              }
+            : {}),
         }));
-        deps.syncDesktopStateCache(get);
-        attachedFileIds = await uploadFiles(workspaceId, files);
+        if (canNavigate()) deps.syncDesktopStateCache(get);
+        reportPhase(files && files.length > 0 ? "processing-attachments" : "creating");
+        attachedFileIds = await uploadFiles(workspaceId, files, signal);
+        throwIfOperationAborted(signal);
+        reportPhase("creating");
         startRequested = true;
         const result = await requestResearchResult(deps, get, set, workspaceId, "research/start", {
           input,
@@ -856,10 +901,22 @@ export function createResearchActions(
           },
           ...(attachedFileIds.length > 0 ? { attachedFileIds } : {}),
         });
-        applyResearchRecord(result.research, { select: true });
-        await ensureResearchSubscription(workspaceId, result.research);
+        applyResearchRecord(result.research, { select: canNavigate() && signal?.aborted !== true });
+        await ensureResearchSubscription(
+          workspaceId,
+          result.research,
+          () => canNavigate() && signal?.aborted !== true,
+        );
         return result.research;
       } catch (error) {
+        if (
+          isOperationAbortError(error) &&
+          workspaceId &&
+          !startRequested &&
+          attachedFileIds.length > 0
+        ) {
+          await discardUploadedFiles(workspaceId, attachedFileIds);
+        }
         if (
           workspaceId &&
           startRequested &&
@@ -868,6 +925,7 @@ export function createResearchActions(
         ) {
           await discardUploadedFiles(workspaceId, attachedFileIds);
         }
+        if (isOperationAbortError(error)) return null;
         notify(
           "error",
           "Unable to start research",

--- a/apps/desktop/src/app/store.actions/research.ts
+++ b/apps/desktop/src/app/store.actions/research.ts
@@ -7,6 +7,12 @@ import {
   type ResearchRecord,
 } from "../../../../../src/server/research/types";
 import { saveExportedFile } from "../../lib/desktopCommands";
+import {
+  type ComposerDraftAttachment,
+  createComposerDraftAttachment,
+  createEmptyComposerDraft,
+  revokeComposerDraftAttachmentPreviews,
+} from "../composerDrafts";
 import { hasGoogleApiKeyForResearch } from "../researchAvailability";
 import type { AppStoreActions, StoreGet, StoreSet } from "../store.helpers";
 import {
@@ -32,7 +38,9 @@ import {
   isCreationNavigationIntentCurrent,
   isOperationAbortError,
   throwIfOperationAborted,
+  waitForOperation,
 } from "../store.helpers/operationIntent";
+import { persist } from "../store.helpers/persistence";
 import type { ResearchSettingsState } from "../types";
 
 const researchRouterCleanupByWorkspace = new Map<string, () => void>();
@@ -61,6 +69,7 @@ type ResearchActionDeps = {
   ensureWorkspaceRuntime: typeof ensureWorkspaceRuntime;
   syncDesktopStateCache: typeof syncDesktopStateCache;
   waitForControlSession: typeof waitForControlSession;
+  persist: typeof persist;
 };
 
 const defaultResearchActionDeps: ResearchActionDeps = {
@@ -73,6 +82,7 @@ const defaultResearchActionDeps: ResearchActionDeps = {
   ensureWorkspaceRuntime,
   syncDesktopStateCache,
   waitForControlSession,
+  persist,
 };
 
 type ResearchResultMethod = keyof typeof jsonRpcResearchResultSchemas;
@@ -87,8 +97,11 @@ async function requestResearchResult<M extends ResearchResultMethod>(
   workspaceId: string,
   method: M,
   params: unknown,
+  options: { signal?: AbortSignal } = {},
 ): Promise<ResearchResult<M>> {
-  const result = await deps.requestJsonRpc(get, set, workspaceId, method, params);
+  const result = options.signal
+    ? await deps.requestJsonRpc(get, set, workspaceId, method, params, options)
+    : await deps.requestJsonRpc(get, set, workspaceId, method, params);
   return parseJsonRpcResult(
     method,
     jsonRpcResearchResultSchemas[method],
@@ -208,7 +221,10 @@ function buildResearchExportFileName(
   return `${baseName}.${extension}`;
 }
 
-async function serializeFile(file: File): Promise<{
+async function serializeFile(
+  file: File,
+  signal?: AbortSignal,
+): Promise<{
   filename: string;
   mimeType: string;
   contentBase64: string;
@@ -216,7 +232,8 @@ async function serializeFile(file: File): Promise<{
   if (file.size > MAX_RESEARCH_UPLOAD_BYTES) {
     throw new Error(`Research uploads are limited to ${MAX_RESEARCH_UPLOAD_BYTES} bytes.`);
   }
-  const arrayBuffer = await file.arrayBuffer();
+  const arrayBuffer = await waitForOperation(file.arrayBuffer(), signal);
+  throwIfOperationAborted(signal);
   return {
     filename: file.name || "upload.bin",
     mimeType: file.type || "application/octet-stream",
@@ -239,6 +256,11 @@ export function createResearchActions(
   | "deleteResearch"
   | "sendResearchFollowUp"
   | "setResearchDraftSettings"
+  | "setResearchCreationInput"
+  | "addResearchCreationAttachments"
+  | "removeResearchCreationAttachment"
+  | "setResearchCreationError"
+  | "clearResearchCreationDraft"
   | "exportResearch"
   | "approveResearchPlan"
   | "refineResearchPlan"
@@ -268,6 +290,40 @@ export function createResearchActions(
       "Google API key required",
       "Add a Google API key in Settings -> Providers to use Deep Research.",
     );
+  };
+  const setResearchCreationError = (revision: number, message: string | null): boolean => {
+    let applied = false;
+    set((state) => {
+      if (state.researchCreationDraft.revision !== revision) return {};
+      applied = true;
+      return {
+        researchCreationError: message ? { revision, message } : null,
+      };
+    });
+    if (applied) deps.persist(get);
+    return applied;
+  };
+  const clearResearchCreationDraft = (revision: number): boolean => {
+    let cleared = false;
+    let removedAttachments = get().researchCreationDraft.attachments;
+    set((state) => {
+      if (state.researchCreationDraft.revision !== revision) return {};
+      cleared = true;
+      removedAttachments = state.researchCreationDraft.attachments;
+      return {
+        researchCreationDraft: {
+          ...createEmptyComposerDraft(nowIso()),
+          revision: revision + 1,
+          generation: state.researchCreationDraft.generation + 1,
+        },
+        researchCreationError: null,
+      };
+    });
+    if (cleared) {
+      revokeComposerDraftAttachmentPreviews(removedAttachments);
+      deps.persist(get);
+    }
+    return cleared;
   };
 
   const bindResearchWorkspace = (workspaceId: string) => {
@@ -548,7 +604,9 @@ export function createResearchActions(
   const ensureResearchTransportWorkspace = async (
     options: CreationOperationControl = {},
   ): Promise<string | null> => {
-    const canNavigate = () => !options.intent || isCreationNavigationIntentCurrent(options.intent);
+    const canNavigate = () =>
+      options.signal?.aborted !== true &&
+      (!options.intent || isCreationNavigationIntentCurrent(options.intent));
     throwIfOperationAborted(options.signal);
     let state = get();
     let workspaceId = state.researchTransportWorkspaceId;
@@ -577,10 +635,12 @@ export function createResearchActions(
 
     bindResearchWorkspace(workspaceId);
     deps.ensureWorkspaceRuntime(get, set, workspaceId);
-    await deps.ensureServerRunning(get, set, workspaceId);
+    await deps.ensureServerRunning(get, set, workspaceId, { signal: options.signal });
     throwIfOperationAborted(options.signal);
     deps.ensureControlSocket(get, set, workspaceId);
-    const ready = await deps.waitForControlSession(get, set, workspaceId);
+    const ready = await deps.waitForControlSession(get, set, workspaceId, 3_000, {
+      signal: options.signal,
+    });
     throwIfOperationAborted(options.signal);
     if (!ready) {
       throw new Error("Unable to connect to the research transport workspace.");
@@ -629,6 +689,7 @@ export function createResearchActions(
     workspaceId: string,
     research: ResearchRecord,
     canSelect?: () => boolean,
+    signal?: AbortSignal,
   ) => {
     if (
       get().researchSubscribedIds.includes(research.id) ||
@@ -636,10 +697,18 @@ export function createResearchActions(
     ) {
       return;
     }
-    const result = await requestResearchResult(deps, get, set, workspaceId, "research/subscribe", {
-      researchId: research.id,
-      ...(research.lastEventId ? { afterEventId: research.lastEventId } : {}),
-    });
+    const result = await requestResearchResult(
+      deps,
+      get,
+      set,
+      workspaceId,
+      "research/subscribe",
+      {
+        researchId: research.id,
+        ...(research.lastEventId ? { afterEventId: research.lastEventId } : {}),
+      },
+      { signal },
+    );
     const subscribedResearch = result.research ?? research;
     if (result.research) {
       applyResearchRecord(result.research, canSelect ? { select: canSelect() } : undefined);
@@ -663,8 +732,7 @@ export function createResearchActions(
     try {
       for (const file of files ?? []) {
         throwIfOperationAborted(signal);
-        const payload = await serializeFile(file);
-        throwIfOperationAborted(signal);
+        const payload = await serializeFile(file, signal);
         const result = await requestResearchResult(
           deps,
           get,
@@ -672,6 +740,7 @@ export function createResearchActions(
           workspaceId,
           "research/uploadFile",
           payload,
+          { signal },
         );
         fileIds.push(result.file.fileId);
         throwIfOperationAborted(signal);
@@ -699,6 +768,81 @@ export function createResearchActions(
   };
 
   return {
+    setResearchCreationInput: (input) => {
+      set((state) => ({
+        researchCreationDraft: {
+          ...state.researchCreationDraft,
+          revision: state.researchCreationDraft.revision + 1,
+          updatedAt: nowIso(),
+          text: input,
+        },
+        researchCreationError: null,
+      }));
+      deps.persist(get);
+    },
+
+    addResearchCreationAttachments: async (files) => {
+      if (files.length === 0) return;
+      const generation = get().researchCreationDraft.generation;
+      const attachments: ComposerDraftAttachment[] = [];
+      try {
+        for (const file of files) {
+          if (file.size > MAX_RESEARCH_UPLOAD_BYTES) {
+            throw new Error(`Research uploads are limited to ${MAX_RESEARCH_UPLOAD_BYTES} bytes.`);
+          }
+          attachments.push(await createComposerDraftAttachment(file));
+        }
+      } catch (error) {
+        revokeComposerDraftAttachmentPreviews(attachments);
+        throw error;
+      }
+      let accepted = false;
+      set((state) => {
+        if (state.researchCreationDraft.generation !== generation) return {};
+        accepted = true;
+        return {
+          researchCreationDraft: {
+            ...state.researchCreationDraft,
+            revision: state.researchCreationDraft.revision + 1,
+            updatedAt: nowIso(),
+            attachments: [...state.researchCreationDraft.attachments, ...attachments],
+          },
+          researchCreationError: null,
+        };
+      });
+      if (!accepted) {
+        revokeComposerDraftAttachmentPreviews(attachments);
+        return;
+      }
+      deps.persist(get);
+    },
+
+    removeResearchCreationAttachment: (index) => {
+      let removed: ComposerDraftAttachment[] = [];
+      set((state) => {
+        const attachment = state.researchCreationDraft.attachments[index];
+        if (!attachment) return {};
+        removed = [attachment];
+        return {
+          researchCreationDraft: {
+            ...state.researchCreationDraft,
+            revision: state.researchCreationDraft.revision + 1,
+            updatedAt: nowIso(),
+            attachments: state.researchCreationDraft.attachments.filter(
+              (_candidate, candidateIndex) => candidateIndex !== index,
+            ),
+          },
+          researchCreationError: null,
+        };
+      });
+      if (removed.length === 0) return;
+      revokeComposerDraftAttachmentPreviews(removed);
+      deps.persist(get);
+    },
+
+    setResearchCreationError,
+    clearResearchCreationDraft,
+
     approveResearchPlan: async (researchId: string) => {
       try {
         const workspaceId = await ensureResearchTransportWorkspace();
@@ -857,17 +1001,30 @@ export function createResearchActions(
       }
     },
 
-    startResearch: async ({ input, title, files, settings, intent, signal, onPhase }) => {
+    startResearch: async ({
+      input,
+      title,
+      files,
+      settings,
+      draftRevision,
+      intent,
+      signal,
+      onPhase,
+    }) => {
       if (!hasGoogleResearchAccess()) {
         notifyMissingGoogleApiKey();
         return null;
       }
       const operationIntent = intent ?? beginCreationOperationIntent();
-      const canNavigate = () => isCreationNavigationIntentCurrent(operationIntent);
+      const canNavigate = () =>
+        isCreationNavigationIntentCurrent(operationIntent) && signal?.aborted !== true;
       const reportPhase = onPhase ?? (() => {});
       let workspaceId: string | null = null;
       let attachedFileIds: string[] = [];
       let startRequested = false;
+      if (draftRevision !== undefined) {
+        setResearchCreationError(draftRevision, null);
+      }
       try {
         reportPhase("starting-server");
         workspaceId = await ensureResearchTransportWorkspace({
@@ -892,21 +1049,28 @@ export function createResearchActions(
         throwIfOperationAborted(signal);
         reportPhase("creating");
         startRequested = true;
-        const result = await requestResearchResult(deps, get, set, workspaceId, "research/start", {
-          input,
-          ...(title ? { title } : {}),
-          settings: {
-            ...get().researchDraftSettings,
-            ...(settings ?? {}),
-          },
-          ...(attachedFileIds.length > 0 ? { attachedFileIds } : {}),
-        });
-        applyResearchRecord(result.research, { select: canNavigate() && signal?.aborted !== true });
-        await ensureResearchSubscription(
+        const result = await requestResearchResult(
+          deps,
+          get,
+          set,
           workspaceId,
-          result.research,
-          () => canNavigate() && signal?.aborted !== true,
+          "research/start",
+          {
+            input,
+            ...(title ? { title } : {}),
+            settings: {
+              ...get().researchDraftSettings,
+              ...(settings ?? {}),
+            },
+            ...(attachedFileIds.length > 0 ? { attachedFileIds } : {}),
+          },
+          { signal },
         );
+        applyResearchRecord(result.research, { select: canNavigate() });
+        await ensureResearchSubscription(workspaceId, result.research, canNavigate, signal);
+        if (draftRevision !== undefined && canNavigate()) {
+          clearResearchCreationDraft(draftRevision);
+        }
         return result.research;
       } catch (error) {
         if (
@@ -915,7 +1079,7 @@ export function createResearchActions(
           !startRequested &&
           attachedFileIds.length > 0
         ) {
-          await discardUploadedFiles(workspaceId, attachedFileIds);
+          void discardUploadedFiles(workspaceId, attachedFileIds);
         }
         if (
           workspaceId &&
@@ -925,7 +1089,21 @@ export function createResearchActions(
         ) {
           await discardUploadedFiles(workspaceId, attachedFileIds);
         }
-        if (isOperationAbortError(error)) return null;
+        if (isOperationAbortError(error)) {
+          if (draftRevision !== undefined) {
+            setResearchCreationError(
+              draftRevision,
+              "Research creation cancelled. Your draft was preserved.",
+            );
+          }
+          return null;
+        }
+        if (draftRevision !== undefined) {
+          setResearchCreationError(
+            draftRevision,
+            error instanceof Error ? error.message : String(error),
+          );
+        }
         notify(
           "error",
           "Unable to start research",

--- a/apps/desktop/src/app/store.actions/tasks.ts
+++ b/apps/desktop/src/app/store.actions/tasks.ts
@@ -32,6 +32,13 @@ import {
   syncDesktopStateCache,
 } from "../store.helpers";
 import { registerWorkspaceJsonRpcRouter, requestJsonRpc } from "../store.helpers/jsonRpcSocket";
+import {
+  beginCreationOperationIntent,
+  invalidateNavigationIntent,
+  isCreationNavigationIntentCurrent,
+  isOperationAbortError,
+  throwIfOperationAborted,
+} from "../store.helpers/operationIntent";
 import { isOneOffChatWorkspace, type ThreadRecord } from "../types";
 
 const taskRouterCleanupByWorkspace = new Map<string, () => void>();
@@ -290,6 +297,7 @@ function ensureTaskRouter(
       upsertTask(set, get, task, deps);
       const mainThread = task.threads[0];
       const workspaceId = workspaceIdForTask(get, task);
+      invalidateNavigationIntent();
       set({
         selectedWorkspaceId: workspaceId ?? get().selectedWorkspaceId,
         selectedTaskId: task.id,
@@ -514,6 +522,7 @@ export function createTaskActions(
   return {
     openNewTask: async (workspaceId) => {
       if (get().desktopFeatureFlags.tasks !== true) return;
+      invalidateNavigationIntent();
       const project =
         (workspaceId
           ? get().workspaces.find((item) => item.id === workspaceId)
@@ -590,13 +599,20 @@ export function createTaskActions(
       }
     },
 
-    startTask: async ({ workspaceId, task: rawTask }) => {
+    startTask: async ({ workspaceId, task: rawTask, intent, signal, onPhase }) => {
       if (get().desktopFeatureFlags.tasks !== true) return null;
       const workspace = get().workspaces.find((item) => item.id === workspaceId);
       if (!workspace || isOneOffChatWorkspace(workspace)) return null;
+      const operationIntent = intent ?? beginCreationOperationIntent();
+      const canNavigate = () =>
+        isCreationNavigationIntentCurrent(operationIntent) && signal?.aborted !== true;
+      const reportPhase = onPhase ?? (() => {});
       const task: TaskCreationInput = rawTask;
       try {
+        reportPhase("starting-server");
         await ensureTaskTransport(get, set, workspaceId, deps);
+        throwIfOperationAborted(signal);
+        reportPhase("creating");
         const result = await deps.requestJsonRpc(get, set, workspaceId, "task/create", {
           cwd: workspace.path,
           ...task,
@@ -605,15 +621,19 @@ export function createTaskActions(
         if (!parsed.success) throw new Error("Invalid task/create response");
         upsertTask(set, get, parsed.data, deps, result?.thread);
         const mainThread = parsed.data.threads[0];
-        set({
-          selectedWorkspaceId: workspaceId,
-          selectedTaskId: parsed.data.id,
-          selectedThreadId: mainThread?.sessionId ?? null,
-          newTaskWorkspaceId: null,
-          view: "task",
-          taskError: null,
-        });
-        if (mainThread) {
+        set(
+          canNavigate()
+            ? {
+                selectedWorkspaceId: workspaceId,
+                selectedTaskId: parsed.data.id,
+                selectedThreadId: mainThread?.sessionId ?? null,
+                newTaskWorkspaceId: null,
+                view: "task",
+                taskError: null,
+              }
+            : { taskError: null },
+        );
+        if (mainThread && canNavigate()) {
           await get().reconnectThread(mainThread.sessionId, undefined, {
             skipWorkspaceSelect: true,
             refreshSnapshot: true,
@@ -622,6 +642,7 @@ export function createTaskActions(
         deps.syncDesktopStateCache(get);
         return parsed.data;
       } catch (error) {
+        if (isOperationAbortError(error)) return null;
         notifyError(set, "Unable to create task", error);
         return null;
       }
@@ -630,6 +651,7 @@ export function createTaskActions(
     selectTask: async (taskId, options = {}) => {
       const isCurrent = () => options.signal?.aborted !== true;
       if (!isCurrent()) return;
+      invalidateNavigationIntent();
       if (get().desktopFeatureFlags.tasks !== true) return;
       const summaryEntry = Object.entries(get().taskSummariesByWorkspaceId).find(([, tasks]) =>
         tasks.some((task) => task.id === taskId),
@@ -683,6 +705,7 @@ export function createTaskActions(
       const task = get().tasksById[taskId];
       const thread = task?.threads.find((item) => item.id === taskThreadId);
       if (!task || !thread) return;
+      invalidateNavigationIntent();
       set({ selectedTaskId: taskId, selectedThreadId: thread.sessionId, view: "task" });
       await get().reconnectThread(thread.sessionId, undefined, {
         skipWorkspaceSelect: true,
@@ -690,8 +713,11 @@ export function createTaskActions(
       });
     },
 
-    createTaskThread: async (taskId, title, workItemId) => {
+    createTaskThread: async (taskId, title, workItemId, options = {}) => {
       if (get().desktopFeatureFlags.tasks !== true) return;
+      const operationIntent = options.intent ?? beginCreationOperationIntent();
+      const canNavigate = () =>
+        isCreationNavigationIntentCurrent(operationIntent) && options.signal?.aborted !== true;
       const task = get().tasksById[taskId];
       if (!task) return;
       const workspaceId = workspaceIdForTask(get, task);
@@ -700,7 +726,10 @@ export function createTaskActions(
         : null;
       if (!workspaceId || !workspace) return;
       try {
+        options.onPhase?.("starting-server");
         await ensureTaskTransport(get, set, workspaceId, deps);
+        throwIfOperationAborted(options.signal);
+        options.onPhase?.("creating");
         const result = await deps.requestJsonRpc(get, set, workspaceId, "task/thread/create", {
           cwd: workspace.path,
           taskId,
@@ -713,11 +742,12 @@ export function createTaskActions(
         upsertTask(set, get, parsed.data, deps, result?.thread);
         const previousIds = new Set(task.threads.map((item) => item.id));
         const created = parsed.data.threads.find((item) => !previousIds.has(item.id));
-        if (created) {
+        if (created && canNavigate()) {
           set({ selectedThreadId: created.sessionId, selectedTaskId: taskId, view: "task" });
           await get().reconnectThread(created.sessionId, undefined, { skipWorkspaceSelect: true });
         }
       } catch (error) {
+        if (isOperationAbortError(error)) return;
         notifyError(set, "Unable to create task thread", error);
       }
     },

--- a/apps/desktop/src/app/store.actions/tasks.ts
+++ b/apps/desktop/src/app/store.actions/tasks.ts
@@ -20,6 +20,7 @@ import {
   taskSummarySchema,
 } from "../../../../../src/shared/tasks";
 import { getDesktopPlatformInfo } from "../../lib/desktopPlatform";
+import { createEmptyTaskCreationDraft } from "../creationDrafts";
 import type { AbortableActionOptions, AppStoreActions, StoreGet, StoreSet } from "../store.helpers";
 import {
   ensureControlSocket,
@@ -37,8 +38,9 @@ import {
   invalidateNavigationIntent,
   isCreationNavigationIntentCurrent,
   isOperationAbortError,
-  throwIfOperationAborted,
+  isThreadNavigationIntentCurrent,
 } from "../store.helpers/operationIntent";
+import { persist } from "../store.helpers/persistence";
 import { isOneOffChatWorkspace, type ThreadRecord } from "../types";
 
 const taskRouterCleanupByWorkspace = new Map<string, () => void>();
@@ -50,6 +52,7 @@ export type TaskActionDependencies = {
   registerWorkspaceJsonRpcRouter: typeof registerWorkspaceJsonRpcRouter;
   requestJsonRpc: typeof requestJsonRpc;
   syncDesktopStateCache: typeof syncDesktopStateCache;
+  persist: typeof persist;
   persistNow: typeof persistNow;
 };
 
@@ -60,6 +63,7 @@ const defaultTaskActionDependencies: TaskActionDependencies = {
   registerWorkspaceJsonRpcRouter,
   requestJsonRpc,
   syncDesktopStateCache,
+  persist,
   persistNow,
 };
 
@@ -295,9 +299,24 @@ function ensureTaskRouter(
         void deps.persistNow(get);
       }
       upsertTask(set, get, task, deps);
+      const sourceSessionId =
+        typeof params.sourceSessionId === "string" ? params.sourceSessionId : null;
+      const sourceThread = sourceSessionId
+        ? get().threads.find(
+            (thread) => thread.id === sourceSessionId || thread.sessionId === sourceSessionId,
+          )
+        : null;
+      const canTakeOver =
+        sourceThread != null &&
+        get().view === "chat" &&
+        get().selectedThreadId === sourceThread.id &&
+        isThreadNavigationIntentCurrent(sourceThread.id);
+      if (!canTakeOver) {
+        deps.syncDesktopStateCache(get);
+        return;
+      }
       const mainThread = task.threads[0];
       const workspaceId = workspaceIdForTask(get, task);
-      invalidateNavigationIntent();
       set({
         selectedWorkspaceId: workspaceId ?? get().selectedWorkspaceId,
         selectedTaskId: task.id,
@@ -399,6 +418,9 @@ export function createTaskActions(
   | "openNewTask"
   | "refreshTasks"
   | "startTask"
+  | "setTaskCreationDraft"
+  | "setTaskCreationError"
+  | "clearTaskCreationDraft"
   | "selectTask"
   | "selectTaskThread"
   | "createTaskThread"
@@ -417,6 +439,34 @@ export function createTaskActions(
   | "acceptTaskArtifactVersion"
   | "startTaskArtifactRevision"
 > {
+  const setTaskCreationError = (revision: number, message: string | null): boolean => {
+    let applied = false;
+    set((state) => {
+      if (state.taskCreationDraft.revision !== revision) return {};
+      applied = true;
+      return {
+        taskCreationError: message ? { revision, message } : null,
+      };
+    });
+    if (applied) deps.persist(get);
+    return applied;
+  };
+  const clearTaskCreationDraft = (revision: number): boolean => {
+    let cleared = false;
+    set((state) => {
+      if (state.taskCreationDraft.revision !== revision) return {};
+      cleared = true;
+      return {
+        taskCreationDraft: createEmptyTaskCreationDraft(
+          revision + 1,
+          state.taskCreationDraft.workspaceId,
+        ),
+        taskCreationError: null,
+      };
+    });
+    if (cleared) deps.persist(get);
+    return cleared;
+  };
   const mutateLifecycle = async (
     taskId: string,
     method: TaskLifecycleMethod,
@@ -520,6 +570,22 @@ export function createTaskActions(
   };
 
   return {
+    setTaskCreationDraft: (patch) => {
+      set((state) => ({
+        taskCreationDraft: {
+          ...state.taskCreationDraft,
+          ...patch,
+          revision: state.taskCreationDraft.revision + 1,
+          updatedAt: nowIso(),
+        },
+        taskCreationError: null,
+      }));
+      deps.persist(get);
+    },
+
+    setTaskCreationError,
+    clearTaskCreationDraft,
+
     openNewTask: async (workspaceId) => {
       if (get().desktopFeatureFlags.tasks !== true) return;
       invalidateNavigationIntent();
@@ -599,7 +665,7 @@ export function createTaskActions(
       }
     },
 
-    startTask: async ({ workspaceId, task: rawTask, intent, signal, onPhase }) => {
+    startTask: async ({ workspaceId, task: rawTask, draftRevision, intent, signal, onPhase }) => {
       if (get().desktopFeatureFlags.tasks !== true) return null;
       const workspace = get().workspaces.find((item) => item.id === workspaceId);
       if (!workspace || isOneOffChatWorkspace(workspace)) return null;
@@ -608,15 +674,22 @@ export function createTaskActions(
         isCreationNavigationIntentCurrent(operationIntent) && signal?.aborted !== true;
       const reportPhase = onPhase ?? (() => {});
       const task: TaskCreationInput = rawTask;
+      if (draftRevision !== undefined) {
+        setTaskCreationError(draftRevision, null);
+      }
       try {
         reportPhase("starting-server");
-        await ensureTaskTransport(get, set, workspaceId, deps);
-        throwIfOperationAborted(signal);
+        await ensureTaskTransport(get, set, workspaceId, deps, { signal });
         reportPhase("creating");
-        const result = await deps.requestJsonRpc(get, set, workspaceId, "task/create", {
+        const requestParams = {
           cwd: workspace.path,
           ...task,
-        });
+        };
+        const result = signal
+          ? await deps.requestJsonRpc(get, set, workspaceId, "task/create", requestParams, {
+              signal,
+            })
+          : await deps.requestJsonRpc(get, set, workspaceId, "task/create", requestParams);
         const parsed = taskRecordSchema.safeParse(result?.task);
         if (!parsed.success) throw new Error("Invalid task/create response");
         upsertTask(set, get, parsed.data, deps, result?.thread);
@@ -639,10 +712,27 @@ export function createTaskActions(
             refreshSnapshot: true,
           });
         }
+        if (draftRevision !== undefined && canNavigate()) {
+          clearTaskCreationDraft(draftRevision);
+        }
         deps.syncDesktopStateCache(get);
         return parsed.data;
       } catch (error) {
-        if (isOperationAbortError(error)) return null;
+        if (isOperationAbortError(error)) {
+          if (draftRevision !== undefined) {
+            setTaskCreationError(
+              draftRevision,
+              "Task creation cancelled. Your brief was preserved.",
+            );
+          }
+          return null;
+        }
+        if (draftRevision !== undefined) {
+          setTaskCreationError(
+            draftRevision,
+            error instanceof Error ? error.message : String(error),
+          );
+        }
         notifyError(set, "Unable to create task", error);
         return null;
       }
@@ -727,16 +817,20 @@ export function createTaskActions(
       if (!workspaceId || !workspace) return;
       try {
         options.onPhase?.("starting-server");
-        await ensureTaskTransport(get, set, workspaceId, deps);
-        throwIfOperationAborted(options.signal);
+        await ensureTaskTransport(get, set, workspaceId, deps, options);
         options.onPhase?.("creating");
-        const result = await deps.requestJsonRpc(get, set, workspaceId, "task/thread/create", {
+        const requestParams = {
           cwd: workspace.path,
           taskId,
           expectedRevision: task.revision,
           title: title.trim(),
           ...(workItemId ? { workItemId } : {}),
-        });
+        };
+        const result = options.signal
+          ? await deps.requestJsonRpc(get, set, workspaceId, "task/thread/create", requestParams, {
+              signal: options.signal,
+            })
+          : await deps.requestJsonRpc(get, set, workspaceId, "task/thread/create", requestParams);
         const parsed = taskRecordSchema.safeParse(result?.task);
         if (!parsed.success) throw new Error("Invalid task/thread/create response");
         upsertTask(set, get, parsed.data, deps, result?.thread);

--- a/apps/desktop/src/app/store.actions/thread.ts
+++ b/apps/desktop/src/app/store.actions/thread.ts
@@ -65,6 +65,12 @@ import {
 import type { FileAttachmentInput } from "../store.helpers/jsonRpcSocket";
 import { requestJsonRpc } from "../store.helpers/jsonRpcSocket";
 import { createOneOffWorkspaceRecord } from "../store.helpers/oneOffWorkspaceRecord";
+import {
+  beginCreationOperationIntent,
+  invalidateNavigationIntent,
+  isCreationNavigationIntentCurrent,
+  isOperationAbortError,
+} from "../store.helpers/operationIntent";
 import { waitForNextPaintOrTimeout } from "../store.helpers/paintScheduling";
 import { persist } from "../store.helpers/persistence";
 import { MAX_FEED_ITEMS } from "../store.helpers/threadEventReducerContext";
@@ -914,6 +920,11 @@ export function createThreadActions(
     },
 
     newThread: async (opts) => {
+      const operationIntent = opts?.intent ?? beginCreationOperationIntent();
+      const canNavigate = () => isCreationNavigationIntentCurrent(operationIntent);
+      const reportPhase = opts?.onPhase ?? (() => {});
+      reportPhase("preparing");
+      if (opts?.signal?.aborted) return false;
       const explicitWorkspace = opts?.workspaceId
         ? (get().workspaces.find((workspace) => workspace.id === opts.workspaceId) ?? null)
         : null;
@@ -933,11 +944,14 @@ export function createThreadActions(
             get,
             opts?.titleHint ?? opts?.firstMessage,
           );
+          if (opts?.signal?.aborted) return false;
           workspaceId = oneOffWorkspace.id;
-          set((s) => ({
-            workspaces: [oneOffWorkspace, ...s.workspaces],
-            selectedWorkspaceId: oneOffWorkspace.id,
-          }));
+          set((s) => {
+            const next = {
+              workspaces: [oneOffWorkspace, ...s.workspaces],
+            };
+            return canNavigate() ? { ...next, selectedWorkspaceId: oneOffWorkspace.id } : next;
+          });
           ensureWorkspaceRuntime(get, set, oneOffWorkspace.id);
         } catch (error) {
           set((s) => ({
@@ -977,12 +991,12 @@ export function createThreadActions(
             }));
             return false;
           }
-          await get().addWorkspace();
+          await get().addWorkspace({ intent: operationIntent });
           workspaceId = projectWorkspaces()[0]?.id ?? null;
           if (!workspaceId) return false;
         }
 
-        if (get().selectedWorkspaceId !== workspaceId) {
+        if (canNavigate() && get().selectedWorkspaceId !== workspaceId) {
           set({ selectedWorkspaceId: workspaceId });
         }
 
@@ -991,12 +1005,14 @@ export function createThreadActions(
             (thread) => thread.workspaceId === workspaceId && thread.draft === true,
           );
           if (existingDraft) {
-            set({
-              selectedThreadId: existingDraft.id,
-              selectedTaskId: null,
-              view: "chat",
-              newChatLandingTarget: null,
-            });
+            if (canNavigate()) {
+              set({
+                selectedThreadId: existingDraft.id,
+                selectedTaskId: null,
+                view: "chat",
+                newChatLandingTarget: null,
+              });
+            }
             ensureThreadRuntime(get, set, existingDraft.id);
             await persistNow(get);
             return true;
@@ -1008,7 +1024,9 @@ export function createThreadActions(
 
       let url: string | null = null;
       if (createSessionImmediately) {
+        reportPhase("starting-server");
         await ensureServerRunning(get, set, workspaceId);
+        if (opts?.signal?.aborted) return false;
         ensureControlSocket(get, set, workspaceId);
 
         const wsRt = get().workspaceRuntimeById[workspaceId];
@@ -1028,6 +1046,27 @@ export function createThreadActions(
       }
 
       const threadId = makeId();
+      let firstMessage = opts?.firstMessage ?? "";
+      let resolvedAttachments = opts?.attachments;
+      if (opts?.attachmentFiles && opts.attachmentFiles.length > 0) {
+        reportPhase("processing-attachments");
+        try {
+          const resolved = await resolveComposerAttachmentsForWorkspace(
+            get,
+            set,
+            workspaceId,
+            opts.attachmentFiles.map(createComposerAttachmentFile),
+            { threadId, signal: opts.signal },
+          );
+          resolvedAttachments = resolved.attachments.length > 0 ? resolved.attachments : undefined;
+          firstMessage = appendAttachmentSkippedNotes(firstMessage, resolved.skippedNotes);
+        } catch (error) {
+          if (isOperationAbortError(error)) return false;
+          throw error;
+        }
+      }
+      if (opts?.signal?.aborted) return false;
+      reportPhase("creating");
       const createdAt = nowIso();
       const title = opts?.titleHint ? truncateTitle(opts.titleHint) : "New chat";
 
@@ -1062,14 +1101,20 @@ export function createThreadActions(
             };
           }
         }
-        return {
+        const next = {
           threads: [thread, ...s.threads],
-          selectedThreadId: threadId,
-          selectedTaskId: null,
-          view: "chat",
           composerDraftsByKey,
-          newChatLandingTarget: null,
         };
+        return canNavigate()
+          ? {
+              ...next,
+              selectedWorkspaceId: workspaceId,
+              selectedThreadId: threadId,
+              selectedTaskId: null,
+              view: "chat" as const,
+              newChatLandingTarget: null,
+            }
+          : next;
       });
       ensureThreadRuntime(get, set, threadId);
       set((s) => ({
@@ -1092,20 +1137,6 @@ export function createThreadActions(
 
       if (!url) {
         return false;
-      }
-
-      let firstMessage = opts?.firstMessage ?? "";
-      let resolvedAttachments = opts?.attachments;
-      if (opts?.attachmentFiles && opts.attachmentFiles.length > 0) {
-        const resolved = await resolveComposerAttachmentsForWorkspace(
-          get,
-          set,
-          workspaceId,
-          opts.attachmentFiles.map(createComposerAttachmentFile),
-          { threadId },
-        );
-        resolvedAttachments = resolved.attachments.length > 0 ? resolved.attachments : undefined;
-        firstMessage = appendAttachmentSkippedNotes(firstMessage, resolved.skippedNotes);
       }
 
       const hasFirstMessage = Boolean(firstMessage.trim());
@@ -1136,6 +1167,7 @@ export function createThreadActions(
       defaultTargetKind?: "project" | "oneOff";
       target?: NewChatLandingTarget;
     }) => {
+      invalidateNavigationIntent();
       const state = get();
       const landingTarget: NewChatLandingTarget =
         opts?.target ??
@@ -1153,12 +1185,14 @@ export function createThreadActions(
     },
 
     setNewChatLandingTarget: (target) => {
+      invalidateNavigationIntent();
       set({ newChatLandingTarget: target });
       syncDesktopStateCache(get);
     },
 
     selectThread: async (threadId: string, options = {}) => {
       if (options.signal?.aborted) return;
+      invalidateNavigationIntent();
       set({ newChatLandingTarget: null });
       if (options.signal?.aborted) return;
       await hydrateThreadSelection(get, set, threadId, {

--- a/apps/desktop/src/app/store.actions/thread.ts
+++ b/apps/desktop/src/app/store.actions/thread.ts
@@ -70,6 +70,8 @@ import {
   invalidateNavigationIntent,
   isCreationNavigationIntentCurrent,
   isOperationAbortError,
+  recordThreadNavigationIntent,
+  waitForOperation,
 } from "../store.helpers/operationIntent";
 import { waitForNextPaintOrTimeout } from "../store.helpers/paintScheduling";
 import { persist } from "../store.helpers/persistence";
@@ -940,11 +942,10 @@ export function createThreadActions(
       let workspaceId: string | null = null;
       if (scope === "oneOff") {
         try {
-          const oneOffWorkspace = await createOneOffWorkspaceRecord(
-            get,
-            opts?.titleHint ?? opts?.firstMessage,
+          const oneOffWorkspace = await waitForOperation(
+            createOneOffWorkspaceRecord(get, opts?.titleHint ?? opts?.firstMessage),
+            opts?.signal,
           );
-          if (opts?.signal?.aborted) return false;
           workspaceId = oneOffWorkspace.id;
           set((s) => {
             const next = {
@@ -954,6 +955,7 @@ export function createThreadActions(
           });
           ensureWorkspaceRuntime(get, set, oneOffWorkspace.id);
         } catch (error) {
+          if (isOperationAbortError(error)) return false;
           set((s) => ({
             notifications: pushNotification(s.notifications, {
               id: makeId(),
@@ -1025,8 +1027,12 @@ export function createThreadActions(
       let url: string | null = null;
       if (createSessionImmediately) {
         reportPhase("starting-server");
-        await ensureServerRunning(get, set, workspaceId);
-        if (opts?.signal?.aborted) return false;
+        try {
+          await ensureServerRunning(get, set, workspaceId, { signal: opts?.signal });
+        } catch (error) {
+          if (isOperationAbortError(error)) return false;
+          throw error;
+        }
         ensureControlSocket(get, set, workspaceId);
 
         const wsRt = get().workspaceRuntimeById[workspaceId];
@@ -1150,6 +1156,7 @@ export function createThreadActions(
           opts?.references,
           queuedDraftSubmission,
         );
+        recordThreadNavigationIntent(threadId, operationIntent);
       }
       ensureThreadSocket(
         get,
@@ -1320,6 +1327,7 @@ export function createThreadActions(
       const taskCommand = !hasAttachments ? trimmed.match(/^\/task(?:\s+([\s\S]*))?$/i) : null;
       if (taskCommand) {
         try {
+          recordThreadNavigationIntent(activeThreadId);
           await ensureServerRunning(get, set, thread.workspaceId);
           ensureControlSocket(get, set, thread.workspaceId);
           await requestJsonRpc(get, set, thread.workspaceId, "command/execute", {
@@ -1371,6 +1379,7 @@ export function createThreadActions(
           draftSubmission,
         });
         if (!reconnected) return false;
+        recordThreadNavigationIntent(activeThreadId);
         return true;
       }
 
@@ -1387,6 +1396,7 @@ export function createThreadActions(
         options?.retryToolItemIds,
       );
       if (!accepted) return false;
+      recordThreadNavigationIntent(activeThreadId);
       return true;
     },
 

--- a/apps/desktop/src/app/store.actions/workspace.ts
+++ b/apps/desktop/src/app/store.actions/workspace.ts
@@ -29,6 +29,10 @@ import {
   waitForWorkspaceServerRestartBackoff,
 } from "../store.helpers";
 import { resolveCurrentWorkspaceDefaultsSource } from "../store.helpers/oneOffWorkspaceRecord";
+import {
+  invalidateNavigationIntent,
+  isCreationNavigationIntentCurrent,
+} from "../store.helpers/operationIntent";
 import { isStandardChatThread } from "../threadFilters";
 import { getThreadSelectionIntent } from "../threadSelectionContext";
 import type { WorkspaceRecord } from "../types";
@@ -118,9 +122,12 @@ export function createWorkspaceActions(
   const isWorkspaceLifecycleEnabled = () => get().desktopFeatureFlags.workspaceLifecycle !== false;
 
   return {
-    addWorkspace: async () => {
+    addWorkspace: async (options = {}) => {
       if (!isWorkspaceLifecycleEnabled()) return;
       if (RUNTIME.workspacePickerOpen) return;
+      if (!options.intent) invalidateNavigationIntent();
+      const canNavigate = () =>
+        !options.intent || isCreationNavigationIntentCurrent(options.intent);
       RUNTIME.workspacePickerOpen = true;
 
       let dir: string | null = null;
@@ -133,7 +140,7 @@ export function createWorkspaceActions(
 
       const existing = get().workspaces.find((w) => w.path === dir);
       if (existing) {
-        await get().selectWorkspace(existing.id);
+        await get().selectWorkspace(existing.id, { intent: options.intent });
         return;
       }
 
@@ -172,11 +179,16 @@ export function createWorkspaceActions(
         yolo: source?.yolo ?? true,
       };
 
-      set((s) => ({
-        workspaces: [ws, ...s.workspaces],
-        selectedWorkspaceId: ws.id,
-        view: stayInSettings ? "settings" : "chat",
-      }));
+      set((s) => {
+        const next = { workspaces: [ws, ...s.workspaces] };
+        return canNavigate()
+          ? {
+              ...next,
+              selectedWorkspaceId: ws.id,
+              view: stayInSettings ? ("settings" as const) : ("chat" as const),
+            }
+          : next;
+      });
       captureProductEvent("workspace_added", {
         eventSource: "renderer",
         workspaceCount: get().workspaces.length,
@@ -278,7 +290,11 @@ export function createWorkspaceActions(
     },
 
     selectWorkspace: async (workspaceId: string, options = {}) => {
-      const isCurrent = () => options.signal?.aborted !== true;
+      if (options.signal?.aborted) return;
+      if (!options.intent) invalidateNavigationIntent();
+      const isCurrent = () =>
+        options.signal?.aborted !== true &&
+        (!options.intent || isCreationNavigationIntentCurrent(options.intent));
       if (!isCurrent()) return;
       const wasSelected = get().selectedWorkspaceId === workspaceId;
       const currentState = get();

--- a/apps/desktop/src/app/store.helpers.ts
+++ b/apps/desktop/src/app/store.helpers.ts
@@ -68,6 +68,10 @@ import {
   disposeWorkspaceJsonRpcSocketState,
   reactivateWorkspaceJsonRpcSocketState,
 } from "./store.helpers/jsonRpcSocket";
+import type {
+  CreationOperationControl,
+  CreationOperationIntent,
+} from "./store.helpers/operationIntent";
 import {
   persist,
   persistNow,
@@ -319,26 +323,31 @@ export type AppStoreState = {
   closeSettings: () => void;
   setSettingsPage: (page: SettingsPageId) => void;
 
-  addWorkspace: () => Promise<void>;
+  addWorkspace: (options?: { intent?: CreationOperationIntent }) => Promise<void>;
   removeWorkspace: (workspaceId: string) => Promise<void>;
-  selectWorkspace: (workspaceId: string, options?: AbortableActionOptions) => Promise<void>;
+  selectWorkspace: (
+    workspaceId: string,
+    options?: AbortableActionOptions & { intent?: CreationOperationIntent },
+  ) => Promise<void>;
   reorderWorkspaces: (sourceWorkspaceId: string, targetWorkspaceId: string) => Promise<void>;
   setWorkspacesOrder: (orderedIds: string[]) => Promise<void>;
 
-  newThread: (opts?: {
-    workspaceId?: string;
-    scope?: "oneOff" | "project";
-    titleHint?: string;
-    firstMessage?: string;
-    references?: import("../lib/wsProtocol").TurnReference[];
-    mode?: "draft" | "session";
-    attachments?: import("./store.helpers/jsonRpcSocket").FileAttachmentInput[];
-    attachmentFiles?: File[];
-    provider?: ProviderName;
-    model?: string;
-    reasoningEffort?: ReasoningEffortValue;
-    draftSubmission?: ComposerDraftRevision;
-  }) => Promise<boolean>;
+  newThread: (
+    opts?: {
+      workspaceId?: string;
+      scope?: "oneOff" | "project";
+      titleHint?: string;
+      firstMessage?: string;
+      references?: import("../lib/wsProtocol").TurnReference[];
+      mode?: "draft" | "session";
+      attachments?: import("./store.helpers/jsonRpcSocket").FileAttachmentInput[];
+      attachmentFiles?: File[];
+      provider?: ProviderName;
+      model?: string;
+      reasoningEffort?: ReasoningEffortValue;
+      draftSubmission?: ComposerDraftRevision;
+    } & CreationOperationControl,
+  ) => Promise<boolean>;
   openNewChatLanding: (opts?: {
     defaultTargetKind?: "project" | "oneOff";
     target?: NewChatLandingTarget;
@@ -465,13 +474,20 @@ export type AppStoreState = {
   }>;
   openNewTask: (workspaceId?: string) => Promise<void>;
   refreshTasks: (workspaceId?: string, options?: AbortableActionOptions) => Promise<void>;
-  startTask: (opts: { workspaceId: string; task: TaskCreationInput }) => Promise<TaskRecord | null>;
+  startTask: (
+    opts: { workspaceId: string; task: TaskCreationInput } & CreationOperationControl,
+  ) => Promise<TaskRecord | null>;
   selectTask: (
     taskId: string,
     options?: AbortableActionOptions & { preserveView?: boolean },
   ) => Promise<void>;
   selectTaskThread: (taskId: string, taskThreadId: string) => Promise<void>;
-  createTaskThread: (taskId: string, title: string, workItemId?: string) => Promise<void>;
+  createTaskThread: (
+    taskId: string,
+    title: string,
+    workItemId?: string,
+    options?: CreationOperationControl,
+  ) => Promise<void>;
   updateTaskBrief: (
     taskId: string,
     patch: { title?: string; objective?: string },
@@ -567,12 +583,14 @@ export type AppStoreState = {
 
   refreshResearchList: () => Promise<void>;
   selectResearch: (researchId: string | null) => Promise<void>;
-  startResearch: (opts: {
-    input: string;
-    title?: string;
-    files?: File[];
-    settings?: Partial<ResearchSettingsState>;
-  }) => Promise<ResearchCard | null>;
+  startResearch: (
+    opts: {
+      input: string;
+      title?: string;
+      files?: File[];
+      settings?: Partial<ResearchSettingsState>;
+    } & CreationOperationControl,
+  ) => Promise<ResearchCard | null>;
   cancelResearch: (researchId: string) => Promise<void>;
   renameResearch: (researchId: string, title: string) => Promise<void>;
   deleteResearch: (researchId: string) => Promise<boolean>;

--- a/apps/desktop/src/app/store.helpers.ts
+++ b/apps/desktop/src/app/store.helpers.ts
@@ -56,10 +56,12 @@ import type {
 } from "../lib/wsProtocol";
 import { PROVIDER_NAMES } from "../lib/wsProtocol";
 import type {
+  ComposerDraft,
   ComposerDraftRevision,
   ComposerDraftRevisionFloor,
   ComposerDraftsByKey,
 } from "./composerDrafts";
+import type { CreationDraftError, TaskCreationDraft } from "./creationDrafts";
 import type { ReasoningEffortValue } from "./openaiCompatibleProviderOptions";
 import { buildContextPreamble, extractUsageStateFromTranscript } from "./store.feedMapping";
 import { createControlSocketHelpers } from "./store.helpers/controlSocket";
@@ -72,6 +74,7 @@ import type {
   CreationOperationControl,
   CreationOperationIntent,
 } from "./store.helpers/operationIntent";
+import { throwIfOperationAborted, waitForOperation } from "./store.helpers/operationIntent";
 import {
   persist,
   persistNow,
@@ -284,6 +287,10 @@ export type AppStoreState = {
   composerDraftRevisionFloorByKey: Record<string, ComposerDraftRevisionFloor>;
   composerAttachmentIngestionCountByKey: Record<string, number>;
   newChatLandingTarget: NewChatLandingTarget | null;
+  researchCreationDraft: ComposerDraft;
+  researchCreationError: CreationDraftError | null;
+  taskCreationDraft: TaskCreationDraft;
+  taskCreationError: CreationDraftError | null;
   injectContext: boolean;
   developerMode: boolean;
   showHiddenFiles: boolean;
@@ -475,8 +482,17 @@ export type AppStoreState = {
   openNewTask: (workspaceId?: string) => Promise<void>;
   refreshTasks: (workspaceId?: string, options?: AbortableActionOptions) => Promise<void>;
   startTask: (
-    opts: { workspaceId: string; task: TaskCreationInput } & CreationOperationControl,
+    opts: {
+      workspaceId: string;
+      task: TaskCreationInput;
+      draftRevision?: number;
+    } & CreationOperationControl,
   ) => Promise<TaskRecord | null>;
+  setTaskCreationDraft: (
+    patch: Partial<Omit<TaskCreationDraft, "revision" | "updatedAt" | "idempotencyKey">>,
+  ) => void;
+  setTaskCreationError: (revision: number, message: string | null) => boolean;
+  clearTaskCreationDraft: (revision: number) => boolean;
   selectTask: (
     taskId: string,
     options?: AbortableActionOptions & { preserveView?: boolean },
@@ -589,8 +605,14 @@ export type AppStoreState = {
       title?: string;
       files?: File[];
       settings?: Partial<ResearchSettingsState>;
+      draftRevision?: number;
     } & CreationOperationControl,
   ) => Promise<ResearchCard | null>;
+  setResearchCreationInput: (input: string) => void;
+  addResearchCreationAttachments: (files: File[]) => Promise<void>;
+  removeResearchCreationAttachment: (index: number) => void;
+  setResearchCreationError: (revision: number, message: string | null) => boolean;
+  clearResearchCreationDraft: (revision: number) => boolean;
   cancelResearch: (researchId: string) => Promise<void>;
   renameResearch: (researchId: string, title: string) => Promise<void>;
   deleteResearch: (researchId: string) => Promise<boolean>;
@@ -1130,8 +1152,8 @@ async function ensureServerRunning(
   options: AbortableActionOptions = {},
 ) {
   const lifecycleGeneration = jsonRpcLifecycleGeneration;
-  const isCurrent = () =>
-    options.signal?.aborted !== true && jsonRpcLifecycleGeneration === lifecycleGeneration;
+  const isCurrent = () => jsonRpcLifecycleGeneration === lifecycleGeneration;
+  throwIfOperationAborted(options.signal);
   if (!isCurrent()) return;
   const ws = get().workspaces.find((workspace) => workspace.id === workspaceId);
   if (!ws) return;
@@ -1144,13 +1166,16 @@ async function ensureServerRunning(
   let forceRestart = false;
   if (rt.serverUrl && !rt.error) {
     if (!isCurrent()) return;
-    const status = await getWorkspaceServerStatus({ workspaceId }).catch((error) => ({
-      workspaceId,
-      running: false as const,
-      url: rt.serverUrl,
-      reason: "health_failed" as const,
-      error: error instanceof Error ? error.message : String(error),
-    }));
+    const status = await waitForOperation(
+      getWorkspaceServerStatus({ workspaceId }).catch((error) => ({
+        workspaceId,
+        running: false as const,
+        url: rt.serverUrl,
+        reason: "health_failed" as const,
+        error: error instanceof Error ? error.message : String(error),
+      })),
+      options.signal,
+    );
     if (!isCurrent()) return;
     if (status.running) {
       syncWorkspaceServerRunningUrl(get, set, workspaceId, status.url);
@@ -1170,14 +1195,15 @@ async function ensureServerRunning(
     if (status.reason === "health_failed") {
       if (!isCurrent()) return;
       try {
-        await stopWorkspaceServer({ workspaceId });
+        await waitForOperation(stopWorkspaceServer({ workspaceId }), options.signal);
       } catch {
+        throwIfOperationAborted(options.signal);
         // ignore; startup below will surface persistent failures
       }
       if (!isCurrent()) return;
     }
     if (!isCurrent()) return;
-    await waitForWorkspaceServerRestartBackoff(workspaceId);
+    await waitForOperation(waitForWorkspaceServerRestartBackoff(workspaceId), options.signal);
     if (!isCurrent()) return;
     reactivateWorkspaceJsonRpcState(workspaceId);
     forceRestart = status.reason === "health_failed";
@@ -1187,7 +1213,7 @@ async function ensureServerRunning(
   const inFlight = RUNTIME.workspaceStartPromises.get(workspaceId);
   const generation = getWorkspaceStartGeneration(workspaceId);
   if (inFlight && inFlight.generation === generation) {
-    await inFlight.promise;
+    await waitForOperation(inFlight.promise, options.signal);
     return;
   }
 
@@ -1259,19 +1285,15 @@ async function ensureServerRunning(
     }
   })();
 
-  if (!isCurrent()) {
-    await startPromise;
-    return;
-  }
   RUNTIME.workspaceStartPromises.set(workspaceId, { generation, promise: startPromise });
-  try {
-    await startPromise;
-  } finally {
+  const clearStartPromise = () => {
     const active = RUNTIME.workspaceStartPromises.get(workspaceId);
     if (active?.generation === generation && active.promise === startPromise) {
       RUNTIME.workspaceStartPromises.delete(workspaceId);
     }
-  }
+  };
+  void startPromise.then(clearStartPromise, clearStartPromise);
+  await waitForOperation(startPromise, options.signal);
 }
 
 export {

--- a/apps/desktop/src/app/store.helpers/controlSocket.ts
+++ b/apps/desktop/src/app/store.helpers/controlSocket.ts
@@ -24,6 +24,7 @@ import {
   requestJsonRpcThreadRead,
   type WorkspaceJsonRpcSocket,
 } from "./jsonRpcSocket";
+import { throwIfOperationAborted, waitForOperation } from "./operationIntent";
 import { getAgentProfilesCatalogGeneration, RUNTIME } from "./runtimeState";
 
 type ProviderStatusEvent = Extract<SessionEvent, { type: "provider_status" }>;
@@ -581,7 +582,9 @@ export function createControlSocketHelpers(
     set: StoreSet,
     workspaceId: string,
     timeoutMs = 3_000,
+    options: AbortableActionOptions = {},
   ): Promise<boolean> {
+    throwIfOperationAborted(options.signal);
     if (isWorkspaceDisposed(workspaceId)) {
       return false;
     }
@@ -595,7 +598,7 @@ export function createControlSocketHelpers(
         return false;
       }
       const startedAt = Date.now();
-      const ready = await waitForReady(socket, timeoutMs);
+      const ready = await waitForOperation(waitForReady(socket, timeoutMs), options.signal);
       if (!ready) {
         return false;
       }
@@ -611,7 +614,10 @@ export function createControlSocketHelpers(
       if (remainingMs <= 0) {
         return false;
       }
-      return await waitForPromiseCompletion(bootstrap, remainingMs);
+      return await waitForOperation(
+        waitForPromiseCompletion(bootstrap, remainingMs),
+        options.signal,
+      );
     });
   }
 

--- a/apps/desktop/src/app/store.helpers/jsonRpcSocket.ts
+++ b/apps/desktop/src/app/store.helpers/jsonRpcSocket.ts
@@ -18,9 +18,10 @@ import { JsonRpcSocket } from "../../lib/agentSocket";
 import { writeRendererLog } from "../../lib/desktopCommands";
 import { withBrowserAccessToken } from "../../lib/webAdapter";
 import type { TurnReference } from "../../lib/wsProtocol";
-import type { StoreGet, StoreSet } from "../store.helpers";
+import type { AbortableActionOptions, StoreGet, StoreSet } from "../store.helpers";
 import type { ThreadRuntime, WorkspaceRecord } from "../types";
 import { JSONRPC_SOCKET_OVERRIDE_KEY } from "./jsonRpcSocketOverride";
+import { throwIfOperationAborted, waitForOperation } from "./operationIntent";
 import {
   bumpWorkspaceJsonRpcSocketGeneration,
   getWorkspaceJsonRpcSocketGeneration,
@@ -523,12 +524,18 @@ export async function requestJsonRpc<T = Record<string, unknown>>(
   workspaceId: string,
   method: string,
   params?: unknown,
+  options: AbortableActionOptions = {},
 ): Promise<T> {
+  throwIfOperationAborted(options.signal);
   const socket = ensureWorkspaceJsonRpcSocket(get, set, workspaceId);
   if (!socket) {
     throw new Error("JSON-RPC workspace socket is unavailable");
   }
-  return (await socket.request(method, params, getJsonRpcRequestRetryOptions(method, params))) as T;
+  throwIfOperationAborted(options.signal);
+  return (await waitForOperation(
+    socket.request(method, params, getJsonRpcRequestRetryOptions(method, params)),
+    options.signal,
+  )) as T;
 }
 
 function hasStableStringKey(params: unknown, key: string): boolean {
@@ -738,13 +745,21 @@ export async function uploadJsonRpcWorkspaceFile(
   workspaceId: string,
   filename: string,
   contentBase64: string,
+  options: AbortableActionOptions = {},
 ): Promise<{ filename: string; path: string }> {
   const workspace = getWorkspaceById(get, workspaceId);
-  const result = await requestJsonRpc(get, set, workspaceId, "cowork/session/file/upload", {
-    cwd: workspace?.path,
-    filename,
-    contentBase64,
-  });
+  const result = await requestJsonRpc(
+    get,
+    set,
+    workspaceId,
+    "cowork/session/file/upload",
+    {
+      cwd: workspace?.path,
+      filename,
+      contentBase64,
+    },
+    options,
+  );
   const event = isRecord(result) && isRecord(result.event) ? result.event : null;
   return {
     filename: typeof event?.filename === "string" ? event.filename : filename,

--- a/apps/desktop/src/app/store.helpers/operationIntent.ts
+++ b/apps/desktop/src/app/store.helpers/operationIntent.ts
@@ -1,0 +1,60 @@
+export type CreationOperationIntent = {
+  operationId: number;
+  navigationIntentId: number;
+};
+
+export type CreationOperationPhase =
+  | "preparing"
+  | "starting-server"
+  | "processing-attachments"
+  | "creating";
+
+export type CreationOperationControl = {
+  intent?: CreationOperationIntent;
+  signal?: AbortSignal;
+  onPhase?: (phase: CreationOperationPhase) => void;
+};
+
+let nextOperationId = 0;
+let currentNavigationIntentId = 0;
+
+/**
+ * Starts a creation operation and grants it navigation authority. Starting a
+ * newer creation intentionally revokes that authority from every older
+ * operation without cancelling their background work.
+ */
+export function beginCreationOperationIntent(): CreationOperationIntent {
+  nextOperationId += 1;
+  currentNavigationIntentId += 1;
+  return {
+    operationId: nextOperationId,
+    navigationIntentId: currentNavigationIntentId,
+  };
+}
+
+/** Records an explicit user navigation that pending creations must respect. */
+export function invalidateNavigationIntent(): void {
+  currentNavigationIntentId += 1;
+}
+
+export function isCreationNavigationIntentCurrent(intent: CreationOperationIntent): boolean {
+  return intent.navigationIntentId === currentNavigationIntentId;
+}
+
+export function throwIfOperationAborted(signal?: AbortSignal): void {
+  if (!signal?.aborted) return;
+  const error = new Error("Creation cancelled.");
+  error.name = "AbortError";
+  throw error;
+}
+
+export function isOperationAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError";
+}
+
+export const __internalOperationIntent = {
+  reset(): void {
+    nextOperationId = 0;
+    currentNavigationIntentId = 0;
+  },
+};

--- a/apps/desktop/src/app/store.helpers/operationIntent.ts
+++ b/apps/desktop/src/app/store.helpers/operationIntent.ts
@@ -17,6 +17,7 @@ export type CreationOperationControl = {
 
 let nextOperationId = 0;
 let currentNavigationIntentId = 0;
+const navigationIntentIdByThreadId = new Map<string, number>();
 
 /**
  * Starts a creation operation and grants it navigation authority. Starting a
@@ -41,11 +42,65 @@ export function isCreationNavigationIntentCurrent(intent: CreationOperationInten
   return intent.navigationIntentId === currentNavigationIntentId;
 }
 
+/**
+ * Associates a user-submitted turn with the navigation intent active when it
+ * was sent. Task takeover notifications can then distinguish "still on this
+ * chat" from "navigated away and back to this chat."
+ */
+export function recordThreadNavigationIntent(
+  threadId: string,
+  intent?: CreationOperationIntent,
+): void {
+  navigationIntentIdByThreadId.set(
+    threadId,
+    intent?.navigationIntentId ?? currentNavigationIntentId,
+  );
+}
+
+export function isThreadNavigationIntentCurrent(threadId: string): boolean {
+  return navigationIntentIdByThreadId.get(threadId) === currentNavigationIntentId;
+}
+
 export function throwIfOperationAborted(signal?: AbortSignal): void {
   if (!signal?.aborted) return;
   const error = new Error("Creation cancelled.");
   error.name = "AbortError";
   throw error;
+}
+
+/**
+ * Stops waiting as soon as an operation is cancelled without cancelling the
+ * shared background work itself.
+ */
+export function waitForOperation<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+  throwIfOperationAborted(signal);
+  if (!signal) return promise;
+
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => {
+      signal.removeEventListener("abort", onAbort);
+      try {
+        throwIfOperationAborted(signal);
+      } catch (error) {
+        reject(error);
+      }
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    if (signal.aborted) {
+      onAbort();
+      return;
+    }
+    void promise.then(
+      (value) => {
+        signal.removeEventListener("abort", onAbort);
+        resolve(value);
+      },
+      (error: unknown) => {
+        signal.removeEventListener("abort", onAbort);
+        reject(error);
+      },
+    );
+  });
 }
 
 export function isOperationAbortError(error: unknown): boolean {
@@ -56,5 +111,6 @@ export const __internalOperationIntent = {
   reset(): void {
     nextOperationId = 0;
     currentNavigationIntentId = 0;
+    navigationIntentIdByThreadId.clear();
   },
 };

--- a/apps/desktop/src/app/store.helpers/persistence.ts
+++ b/apps/desktop/src/app/store.helpers/persistence.ts
@@ -5,6 +5,7 @@ import {
   resolveActiveComposerDraftKey,
   serializeComposerDrafts,
 } from "../composerDrafts";
+import { serializeCreationDrafts } from "../creationDrafts";
 import { saveDesktopStateCache } from "../localStateCache";
 import { normalizePersistedProviderState } from "../persistedProviderState";
 import { normalizePersistedProviderUiState } from "../providerUiState";
@@ -88,6 +89,7 @@ function buildPersistedState(
     providerUiState,
     onboarding: state.onboardingState,
     composerDrafts,
+    creationDrafts: serializeCreationDrafts(state),
   };
 }
 

--- a/apps/desktop/src/app/store.ts
+++ b/apps/desktop/src/app/store.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { onTranscriptDeliveryFailure } from "../lib/desktopCommands";
+import { createEmptyCreationDrafts } from "./creationDrafts";
 import { loadDesktopStateCacheRaw } from "./localStateCache";
 import { DEFAULT_PROVIDER_UI_STATE } from "./providerUiState";
 import { createAppActions } from "./store.actions";
@@ -17,6 +18,7 @@ import {
   normalizePrivacyTelemetrySettings,
 } from "./types";
 
+const initialCreationDrafts = createEmptyCreationDrafts();
 const initialState: AppStoreDataState = {
   ready: false,
   bootstrapPhase: "idle",
@@ -74,6 +76,7 @@ const initialState: AppStoreDataState = {
   composerDraftRevisionFloorByKey: {},
   composerAttachmentIngestionCountByKey: {},
   newChatLandingTarget: null,
+  ...initialCreationDrafts,
   injectContext: false,
   developerMode: false,
   showHiddenFiles: false,

--- a/apps/desktop/src/app/types.ts
+++ b/apps/desktop/src/app/types.ts
@@ -46,6 +46,7 @@ import type {
   TurnReference,
 } from "../lib/wsProtocol";
 import type { ComposerDraftRevision, PersistedComposerDrafts } from "./composerDrafts";
+import type { PersistedCreationDrafts } from "./creationDrafts";
 import type {
   ReasoningEffortValue,
   WorkspaceProviderOptions,
@@ -394,6 +395,7 @@ export type PersistedState = {
   providerUiState?: PersistedProviderUiState;
   onboarding?: PersistedOnboardingState;
   composerDrafts?: PersistedComposerDrafts;
+  creationDrafts?: PersistedCreationDrafts;
 };
 
 type TranscriptDirection = "server" | "client";

--- a/apps/desktop/src/lib/composerAttachments.ts
+++ b/apps/desktop/src/lib/composerAttachments.ts
@@ -9,6 +9,7 @@ import {
 import type { StoreGet, StoreSet } from "../app/store.helpers";
 import type { FileAttachmentInput } from "../app/store.helpers/jsonRpcSocket";
 import { uploadJsonRpcWorkspaceFile } from "../app/store.helpers/jsonRpcSocket";
+import { throwIfOperationAborted } from "../app/store.helpers/operationIntent";
 
 export type ComposerAttachmentFile = {
   filename: string;
@@ -70,6 +71,7 @@ type DesktopUploadAttempt =
 
 type ResolveComposerAttachmentOptions = {
   threadId?: string | null;
+  signal?: AbortSignal;
 };
 
 export async function resolveComposerAttachmentsForWorkspace(
@@ -84,6 +86,7 @@ export async function resolveComposerAttachmentsForWorkspace(
   const skippedNotes: string[] = [];
 
   for (const attachment of attachments) {
+    throwIfOperationAborted(options.signal);
     const uploadValidationMessage = getAttachmentUploadValidationMessage(attachment.size);
     if (uploadValidationMessage) {
       skippedNotes.push(buildAttachmentSkippedNote(attachment.filename, uploadValidationMessage));
@@ -95,6 +98,7 @@ export async function resolveComposerAttachmentsForWorkspace(
       inlineByteLength + attachment.size <= MAX_TURN_ATTACHMENT_TOTAL_INLINE_BYTE_SIZE;
     if (canInline) {
       const buffer = await attachment.file.arrayBuffer();
+      throwIfOperationAborted(options.signal);
       const base64 = encodeArrayBufferToBase64(buffer);
       inlineByteLength += attachment.size;
       resolvedAttachments.push({
@@ -111,6 +115,7 @@ export async function resolveComposerAttachmentsForWorkspace(
       attachment,
       options.threadId ?? null,
     );
+    throwIfOperationAborted(options.signal);
     let desktopUploadError: string | null = null;
     if (desktopUpload.attempted) {
       if ("uploaded" in desktopUpload) {
@@ -126,6 +131,7 @@ export async function resolveComposerAttachmentsForWorkspace(
     }
 
     const buffer = await attachment.file.arrayBuffer();
+    throwIfOperationAborted(options.signal);
     const base64 = encodeArrayBufferToBase64(buffer);
     const uploaded = await uploadJsonRpcWorkspaceFile(
       get,
@@ -134,6 +140,7 @@ export async function resolveComposerAttachmentsForWorkspace(
       attachment.filename,
       base64,
     );
+    throwIfOperationAborted(options.signal);
     if (!uploaded.path) {
       const reason = desktopUploadError
         ? `${desktopUploadError}; upload to the project folder failed`

--- a/apps/desktop/src/lib/composerAttachments.ts
+++ b/apps/desktop/src/lib/composerAttachments.ts
@@ -9,7 +9,7 @@ import {
 import type { StoreGet, StoreSet } from "../app/store.helpers";
 import type { FileAttachmentInput } from "../app/store.helpers/jsonRpcSocket";
 import { uploadJsonRpcWorkspaceFile } from "../app/store.helpers/jsonRpcSocket";
-import { throwIfOperationAborted } from "../app/store.helpers/operationIntent";
+import { throwIfOperationAborted, waitForOperation } from "../app/store.helpers/operationIntent";
 
 export type ComposerAttachmentFile = {
   filename: string;
@@ -97,7 +97,7 @@ export async function resolveComposerAttachmentsForWorkspace(
       attachment.size <= MAX_ATTACHMENT_INLINE_BYTE_SIZE &&
       inlineByteLength + attachment.size <= MAX_TURN_ATTACHMENT_TOTAL_INLINE_BYTE_SIZE;
     if (canInline) {
-      const buffer = await attachment.file.arrayBuffer();
+      const buffer = await waitForOperation(attachment.file.arrayBuffer(), options.signal);
       throwIfOperationAborted(options.signal);
       const base64 = encodeArrayBufferToBase64(buffer);
       inlineByteLength += attachment.size;
@@ -114,6 +114,7 @@ export async function resolveComposerAttachmentsForWorkspace(
       workspaceId,
       attachment,
       options.threadId ?? null,
+      options.signal,
     );
     throwIfOperationAborted(options.signal);
     let desktopUploadError: string | null = null;
@@ -130,7 +131,7 @@ export async function resolveComposerAttachmentsForWorkspace(
       }
     }
 
-    const buffer = await attachment.file.arrayBuffer();
+    const buffer = await waitForOperation(attachment.file.arrayBuffer(), options.signal);
     throwIfOperationAborted(options.signal);
     const base64 = encodeArrayBufferToBase64(buffer);
     const uploaded = await uploadJsonRpcWorkspaceFile(
@@ -139,6 +140,7 @@ export async function resolveComposerAttachmentsForWorkspace(
       workspaceId,
       attachment.filename,
       base64,
+      { signal: options.signal },
     );
     throwIfOperationAborted(options.signal);
     if (!uploaded.path) {
@@ -163,6 +165,7 @@ async function tryCopyDesktopAttachmentToWorkspaceUploads(
   workspaceId: string,
   attachment: ComposerAttachmentFile,
   threadId: string | null,
+  signal?: AbortSignal,
 ): Promise<DesktopUploadAttempt> {
   const desktopApi = typeof window === "undefined" ? undefined : window.cowork;
   if (!desktopApi?.getPathForFile || !desktopApi.copyFileToWorkspaceUploads) {
@@ -174,19 +177,28 @@ async function tryCopyDesktopAttachmentToWorkspaceUploads(
     return { attempted: false };
   }
 
-  const sourcePath = await desktopApi.getPathForFile(attachment.file);
+  const sourcePath = await waitForOperation(
+    Promise.resolve(desktopApi.getPathForFile(attachment.file)),
+    signal,
+  );
+  throwIfOperationAborted(signal);
   if (!sourcePath) {
     return { attempted: false };
   }
 
   try {
     const uploadsDirectory = resolveWorkspaceUploadsDirectory(get, workspaceId, threadId);
-    const uploaded = await desktopApi.copyFileToWorkspaceUploads({
-      workspacePath: workspace.path,
-      sourcePath,
-      filename: attachment.filename,
-      ...(uploadsDirectory ? { uploadsDirectory } : {}),
-    });
+    throwIfOperationAborted(signal);
+    const uploaded = await waitForOperation(
+      desktopApi.copyFileToWorkspaceUploads({
+        workspacePath: workspace.path,
+        sourcePath,
+        filename: attachment.filename,
+        ...(uploadsDirectory ? { uploadsDirectory } : {}),
+      }),
+      signal,
+    );
+    throwIfOperationAborted(signal);
     return { attempted: true, uploaded };
   } catch (error) {
     const detail = error instanceof Error ? error.message : String(error);

--- a/apps/desktop/src/ui/chat/NewChatLanding.tsx
+++ b/apps/desktop/src/ui/chat/NewChatLanding.tsx
@@ -21,8 +21,11 @@ import {
   type ReasoningEffortValue,
 } from "../../app/openaiCompatibleProviderOptions";
 import { useAppStore } from "../../app/store";
-import { ensureServerRunning } from "../../app/store.helpers";
-import type { FileAttachmentInput } from "../../app/store.helpers/jsonRpcSocket";
+import {
+  beginCreationOperationIntent,
+  type CreationOperationPhase,
+  isOperationAbortError,
+} from "../../app/store.helpers/operationIntent";
 import { isOneOffChatWorkspace } from "../../app/types";
 import { Button } from "../../components/ui/button";
 import {
@@ -35,10 +38,6 @@ import {
   CommandSeparator,
 } from "../../components/ui/command";
 import { Popover, PopoverContent, PopoverTrigger } from "../../components/ui/popover";
-import {
-  appendAttachmentSkippedNotes,
-  resolveComposerAttachmentsForWorkspace,
-} from "../../lib/composerAttachments";
 import { modelDisplayNamesFromCatalog, reasoningConfigFromCatalog } from "../../lib/modelChoices";
 import { resolveNewChatLandingTarget } from "../../lib/newChatLanding";
 import {
@@ -56,6 +55,25 @@ import { type ComposerModelSelection, ComposerModelSelector } from "./ComposerMo
 import { ComposerReasoningSelector } from "./ComposerReasoningToggle";
 import { buildMentionCatalog, extractReferencesFromText } from "./composerMentions";
 import { resolveDefaultNewChatModel } from "./newChatLandingModel";
+
+function creationPhaseLabel(phase: CreationOperationPhase | null): string | null {
+  switch (phase) {
+    case "preparing":
+      return "Preparing your chat...";
+    case "starting-server":
+      return "Starting the project server...";
+    case "processing-attachments":
+      return "Processing attachments...";
+    case "creating":
+      return "Creating your chat...";
+    case null:
+      return null;
+    default: {
+      const exhaustive: never = phase;
+      return exhaustive;
+    }
+  }
+}
 
 export function NewChatLanding() {
   const workspaces = useAppStore((s) => s.workspaces);
@@ -86,10 +104,15 @@ export function NewChatLanding() {
   );
   const [selectorOpen, setSelectorOpen] = useState(false);
   const [submittingDraftKeys, setSubmittingDraftKeys] = useState<Set<string>>(() => new Set());
+  const [creationPhaseByDraftKey, setCreationPhaseByDraftKey] = useState<
+    Record<string, CreationOperationPhase>
+  >({});
   const [attachmentPickerErrors, setAttachmentPickerErrors] = useState<Record<string, string>>({});
+  const submissionControllersRef = useRef<Map<string, AbortController>>(new Map());
   const submitting = submittingDraftKeys.has(composerDraftKey);
   const composerLocked = submitting || attachmentIngestionPending;
   const attachmentPickerError = attachmentPickerErrors[composerDraftKey] ?? null;
+  const creationPhase = creationPhaseByDraftKey[composerDraftKey] ?? null;
   const setSubmitting = useCallback(
     (next: boolean) => {
       setSubmittingDraftKeys((current) => {
@@ -115,6 +138,23 @@ export function NewChatLanding() {
     },
     [composerDraftKey],
   );
+  const setCreationPhase = useCallback(
+    (phase: CreationOperationPhase | null) => {
+      setCreationPhaseByDraftKey((current) => {
+        if (phase === null) {
+          if (!(composerDraftKey in current)) return current;
+          const next = { ...current };
+          delete next[composerDraftKey];
+          return next;
+        }
+        return { ...current, [composerDraftKey]: phase };
+      });
+    },
+    [composerDraftKey],
+  );
+  const cancelSubmission = useCallback(() => {
+    submissionControllersRef.current.get(composerDraftKey)?.abort();
+  }, [composerDraftKey]);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
@@ -249,8 +289,12 @@ export function NewChatLanding() {
         return;
       }
 
+      const operationIntent = beginCreationOperationIntent();
+      const controller = new AbortController();
+      submissionControllersRef.current.set(composerDraftKey, controller);
       setSubmitting(true);
       setAttachmentPickerError(null);
+      setCreationPhase("preparing");
 
       const submittedTarget = target;
       const submittedText = composerText;
@@ -267,50 +311,18 @@ export function NewChatLanding() {
       const titleHint = submittedText.trim() || attachmentTitleHint || "New chat";
       const references = extractReferencesFromText(submittedText, mentionCatalog);
       const referencesArg = references.length > 0 ? references : undefined;
+      const attachmentFiles =
+        submittedAttachments.length > 0
+          ? submittedAttachments.map((attachment) => attachment.file)
+          : undefined;
 
       try {
-        let firstMessage = submittedText.trim();
-        let attachments: FileAttachmentInput[] | undefined;
-        let attachmentFiles: File[] | undefined;
-
-        if (submittedAttachments.length > 0) {
-          if (submittedTarget.kind === "project") {
-            await ensureServerRunning(
-              useAppStore.getState,
-              useAppStore.setState,
-              submittedTarget.workspaceId,
-            );
-            const resolved = await resolveComposerAttachmentsForWorkspace(
-              useAppStore.getState,
-              useAppStore.setState,
-              submittedTarget.workspaceId,
-              submittedAttachments,
-            );
-            attachments = resolved.attachments.length > 0 ? resolved.attachments : undefined;
-            firstMessage = appendAttachmentSkippedNotes(firstMessage, resolved.skippedNotes);
-          } else {
-            attachmentFiles = submittedAttachments.map((attachment) => attachment.file);
-          }
-        }
-
         const ok =
           submittedTarget.kind === "project"
             ? await newThread({
                 scope: "project",
                 workspaceId: submittedTarget.workspaceId,
-                firstMessage,
-                titleHint,
-                mode: "session",
-                attachments,
-                references: referencesArg,
-                provider: submittedModelSelection.provider,
-                model: submittedModelSelection.model,
-                reasoningEffort: submittedReasoningEffort ?? undefined,
-                draftSubmission,
-              })
-            : await newThread({
-                scope: "oneOff",
-                firstMessage,
+                firstMessage: submittedText.trim(),
                 titleHint,
                 mode: "session",
                 attachmentFiles,
@@ -319,14 +331,45 @@ export function NewChatLanding() {
                 model: submittedModelSelection.model,
                 reasoningEffort: submittedReasoningEffort ?? undefined,
                 draftSubmission,
+                intent: operationIntent,
+                signal: controller.signal,
+                onPhase: setCreationPhase,
+              })
+            : await newThread({
+                scope: "oneOff",
+                firstMessage: submittedText.trim(),
+                titleHint,
+                mode: "session",
+                attachmentFiles,
+                references: referencesArg,
+                provider: submittedModelSelection.provider,
+                model: submittedModelSelection.model,
+                reasoningEffort: submittedReasoningEffort ?? undefined,
+                draftSubmission,
+                intent: operationIntent,
+                signal: controller.signal,
+                onPhase: setCreationPhase,
               });
 
         if (!ok) {
-          setSubmitting(false);
+          setAttachmentPickerError(
+            controller.signal.aborted
+              ? "Chat creation cancelled. Your draft was preserved."
+              : "Unable to create the chat. Your draft was preserved.",
+          );
         }
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = isOperationAbortError(error)
+          ? "Chat creation cancelled. Your draft was preserved."
+          : error instanceof Error
+            ? error.message
+            : String(error);
         setAttachmentPickerError(message);
+      } finally {
+        if (submissionControllersRef.current.get(composerDraftKey) === controller) {
+          submissionControllersRef.current.delete(composerDraftKey);
+        }
+        setCreationPhase(null);
         setSubmitting(false);
       }
     },
@@ -341,6 +384,7 @@ export function NewChatLanding() {
       pendingAttachments,
       reasoningEffort,
       setAttachmentPickerError,
+      setCreationPhase,
       setSubmitting,
       submitting,
       target,
@@ -433,7 +477,7 @@ export function NewChatLanding() {
           />
           <MessageComposerForm onSubmit={submitNewChat}>
             <MessageComposerStatus>
-              {submitting ? "Starting a new chat..." : null}
+              {submitting ? creationPhaseLabel(creationPhase) : null}
             </MessageComposerStatus>
             <MessageComposerBody>
               {attachmentPickerError ? (
@@ -616,6 +660,11 @@ export function NewChatLanding() {
                   </>
                 ) : null}
               </MessageComposerTools>
+              {submitting ? (
+                <Button type="button" variant="ghost" size="sm" onClick={cancelSubmission}>
+                  Cancel
+                </Button>
+              ) : null}
               <MessageComposerSubmit
                 status={composerLocked ? "pending" : "ready"}
                 disabled={!canSubmitNewChat || composerLocked}

--- a/apps/desktop/src/ui/research/NewResearchComposer.tsx
+++ b/apps/desktop/src/ui/research/NewResearchComposer.tsx
@@ -1,7 +1,12 @@
-import { PaperclipIcon, Settings2Icon } from "lucide-react";
+import { AlertTriangleIcon, PaperclipIcon, Settings2Icon } from "lucide-react";
 import { useRef, useState } from "react";
 
 import { useAppStore } from "../../app/store";
+import {
+  beginCreationOperationIntent,
+  type CreationOperationPhase,
+  isCreationNavigationIntentCurrent,
+} from "../../app/store.helpers/operationIntent";
 import { Button } from "../../components/ui/button";
 import {
   MessageComposerAttachments,
@@ -9,6 +14,7 @@ import {
   MessageComposerFooter,
   MessageComposerForm,
   MessageComposerRoot,
+  MessageComposerStatus,
   MessageComposerSubmit,
   MessageComposerTextarea,
   MessageComposerTools,
@@ -16,12 +22,34 @@ import {
 import { ResearchSettingsDialog } from "./ResearchSettingsPopover";
 import { useResearchAttachments } from "./useResearchAttachments";
 
+function researchPhaseLabel(phase: CreationOperationPhase | null): string | null {
+  switch (phase) {
+    case "preparing":
+      return "Preparing research...";
+    case "starting-server":
+      return "Starting the research service...";
+    case "processing-attachments":
+      return "Uploading research files...";
+    case "creating":
+      return "Starting research...";
+    case null:
+      return null;
+    default: {
+      const exhaustive: never = phase;
+      return exhaustive;
+    }
+  }
+}
+
 export function NewResearchComposer({ onSubmitted }: { onSubmitted?: () => void }) {
   const startResearch = useAppStore((s) => s.startResearch);
   const [input, setInput] = useState("");
   const [submitting, setSubmitting] = useState(false);
+  const [creationPhase, setCreationPhase] = useState<CreationOperationPhase | null>(null);
+  const [creationError, setCreationError] = useState<string | null>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const submissionControllerRef = useRef<AbortController | null>(null);
   const { attachments, attachmentPreviews, addFiles, removeAttachment, clearAttachments } =
     useResearchAttachments();
 
@@ -30,19 +58,43 @@ export function NewResearchComposer({ onSubmitted }: { onSubmitted?: () => void 
     if (!trimmed || submitting) {
       return;
     }
+    const operationIntent = beginCreationOperationIntent();
+    const controller = new AbortController();
+    submissionControllerRef.current = controller;
+    setCreationError(null);
+    setCreationPhase("preparing");
     setSubmitting(true);
     try {
       const created = await startResearch({
         input: trimmed,
         files: attachments.map((attachment) => attachment.file),
+        intent: operationIntent,
+        signal: controller.signal,
+        onPhase: setCreationPhase,
       });
-      if (created) {
+      if (
+        created &&
+        !controller.signal.aborted &&
+        isCreationNavigationIntentCurrent(operationIntent)
+      ) {
         setInput("");
         clearAttachments();
         setSettingsOpen(false);
         onSubmitted?.();
+      } else if (!created || controller.signal.aborted) {
+        setCreationError(
+          controller.signal.aborted
+            ? created
+              ? "Research started in the background before cancellation completed. Your draft was preserved."
+              : "Research creation cancelled. Your draft was preserved."
+            : "Unable to start research. Your draft was preserved.",
+        );
       }
     } finally {
+      if (submissionControllerRef.current === controller) {
+        submissionControllerRef.current = null;
+      }
+      setCreationPhase(null);
       setSubmitting(false);
     }
   };
@@ -72,13 +124,27 @@ export function NewResearchComposer({ onSubmitted }: { onSubmitted?: () => void 
         >
           <MessageComposerAttachments
             attachments={attachmentPreviews}
-            onRemove={removeAttachment}
+            onRemove={submitting ? () => {} : removeAttachment}
           />
 
+          <MessageComposerStatus>
+            {submitting ? researchPhaseLabel(creationPhase) : null}
+          </MessageComposerStatus>
           <MessageComposerBody>
+            {creationError ? (
+              <div className="flex min-w-0 items-start gap-1.5 px-1 pb-1 text-xs text-destructive">
+                <AlertTriangleIcon className="size-3.5 shrink-0" />
+                <span className="min-w-0 break-words [overflow-wrap:anywhere]">
+                  {creationError}
+                </span>
+              </div>
+            ) : null}
             <MessageComposerTextarea
               value={input}
-              onChange={(event) => setInput(event.target.value)}
+              onChange={(event) => {
+                setCreationError(null);
+                setInput(event.target.value);
+              }}
               placeholder="Investigate a market, compare vendors, summarize a benchmark run, or draft a cited brief."
               rows={4}
               disabled={submitting}
@@ -94,6 +160,7 @@ export function NewResearchComposer({ onSubmitted }: { onSubmitted?: () => void 
                 className="rounded-full"
                 onClick={() => setSettingsOpen(true)}
                 aria-label="Research settings"
+                disabled={submitting}
               >
                 <Settings2Icon className="h-4 w-4" />
               </Button>
@@ -104,10 +171,21 @@ export function NewResearchComposer({ onSubmitted }: { onSubmitted?: () => void 
                 className="rounded-full"
                 onClick={() => fileInputRef.current?.click()}
                 aria-label="Attach files"
+                disabled={submitting}
               >
                 <PaperclipIcon className="h-4 w-4" />
               </Button>
             </MessageComposerTools>
+            {submitting ? (
+              <Button
+                type="button"
+                size="sm"
+                variant="ghost"
+                onClick={() => submissionControllerRef.current?.abort()}
+              >
+                Cancel
+              </Button>
+            ) : null}
             <MessageComposerSubmit
               status={submitting ? "pending" : "ready"}
               disabled={!input.trim()}
@@ -123,6 +201,7 @@ export function NewResearchComposer({ onSubmitted }: { onSubmitted?: () => void 
         type="file"
         className="hidden"
         multiple
+        disabled={submitting}
         onChange={(event) => {
           const files = event.target.files ? Array.from(event.target.files) : [];
           addFiles(files);

--- a/apps/desktop/src/ui/research/NewResearchComposer.tsx
+++ b/apps/desktop/src/ui/research/NewResearchComposer.tsx
@@ -20,7 +20,6 @@ import {
   MessageComposerTools,
 } from "../composer/MessageComposer";
 import { ResearchSettingsDialog } from "./ResearchSettingsPopover";
-import { useResearchAttachments } from "./useResearchAttachments";
 
 function researchPhaseLabel(phase: CreationOperationPhase | null): string | null {
   switch (phase) {
@@ -43,31 +42,44 @@ function researchPhaseLabel(phase: CreationOperationPhase | null): string | null
 
 export function NewResearchComposer({ onSubmitted }: { onSubmitted?: () => void }) {
   const startResearch = useAppStore((s) => s.startResearch);
-  const [input, setInput] = useState("");
+  const draft = useAppStore((s) => s.researchCreationDraft);
+  const creationError = useAppStore((s) =>
+    s.researchCreationError?.revision === s.researchCreationDraft.revision
+      ? s.researchCreationError.message
+      : null,
+  );
+  const setResearchCreationInput = useAppStore((s) => s.setResearchCreationInput);
+  const addResearchCreationAttachments = useAppStore((s) => s.addResearchCreationAttachments);
+  const removeResearchCreationAttachment = useAppStore((s) => s.removeResearchCreationAttachment);
+  const setResearchCreationError = useAppStore((s) => s.setResearchCreationError);
   const [submitting, setSubmitting] = useState(false);
   const [creationPhase, setCreationPhase] = useState<CreationOperationPhase | null>(null);
-  const [creationError, setCreationError] = useState<string | null>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const submissionControllerRef = useRef<AbortController | null>(null);
-  const { attachments, attachmentPreviews, addFiles, removeAttachment, clearAttachments } =
-    useResearchAttachments();
+  const attachmentPreviews = draft.attachments.map((attachment) => ({
+    filename: attachment.filename,
+    mimeType: attachment.mimeType,
+    previewUrl: attachment.previewUrl,
+  }));
 
   const submit = async () => {
-    const trimmed = input.trim();
+    const trimmed = draft.text.trim();
     if (!trimmed || submitting) {
       return;
     }
+    const draftRevision = draft.revision;
     const operationIntent = beginCreationOperationIntent();
     const controller = new AbortController();
     submissionControllerRef.current = controller;
-    setCreationError(null);
+    setResearchCreationError(draftRevision, null);
     setCreationPhase("preparing");
     setSubmitting(true);
     try {
       const created = await startResearch({
         input: trimmed,
-        files: attachments.map((attachment) => attachment.file),
+        files: draft.attachments.map((attachment) => attachment.file),
+        draftRevision,
         intent: operationIntent,
         signal: controller.signal,
         onPhase: setCreationPhase,
@@ -77,18 +89,8 @@ export function NewResearchComposer({ onSubmitted }: { onSubmitted?: () => void 
         !controller.signal.aborted &&
         isCreationNavigationIntentCurrent(operationIntent)
       ) {
-        setInput("");
-        clearAttachments();
         setSettingsOpen(false);
         onSubmitted?.();
-      } else if (!created || controller.signal.aborted) {
-        setCreationError(
-          controller.signal.aborted
-            ? created
-              ? "Research started in the background before cancellation completed. Your draft was preserved."
-              : "Research creation cancelled. Your draft was preserved."
-            : "Unable to start research. Your draft was preserved.",
-        );
       }
     } finally {
       if (submissionControllerRef.current === controller) {
@@ -112,7 +114,14 @@ export function NewResearchComposer({ onSubmitted }: { onSubmitted?: () => void 
         fileDrop={{
           disabled: submitting,
           onFiles: async (files) => {
-            addFiles(files);
+            try {
+              await addResearchCreationAttachments(files);
+            } catch (error) {
+              setResearchCreationError(
+                draft.revision,
+                error instanceof Error ? error.message : String(error),
+              );
+            }
           },
         }}
       >
@@ -124,7 +133,7 @@ export function NewResearchComposer({ onSubmitted }: { onSubmitted?: () => void 
         >
           <MessageComposerAttachments
             attachments={attachmentPreviews}
-            onRemove={submitting ? () => {} : removeAttachment}
+            onRemove={submitting ? () => {} : removeResearchCreationAttachment}
           />
 
           <MessageComposerStatus>
@@ -140,10 +149,9 @@ export function NewResearchComposer({ onSubmitted }: { onSubmitted?: () => void 
               </div>
             ) : null}
             <MessageComposerTextarea
-              value={input}
+              value={draft.text}
               onChange={(event) => {
-                setCreationError(null);
-                setInput(event.target.value);
+                setResearchCreationInput(event.target.value);
               }}
               placeholder="Investigate a market, compare vendors, summarize a benchmark run, or draft a cited brief."
               rows={4}
@@ -188,7 +196,7 @@ export function NewResearchComposer({ onSubmitted }: { onSubmitted?: () => void 
             ) : null}
             <MessageComposerSubmit
               status={submitting ? "pending" : "ready"}
-              disabled={!input.trim()}
+              disabled={!draft.text.trim()}
             />
           </MessageComposerFooter>
         </MessageComposerForm>
@@ -204,7 +212,12 @@ export function NewResearchComposer({ onSubmitted }: { onSubmitted?: () => void 
         disabled={submitting}
         onChange={(event) => {
           const files = event.target.files ? Array.from(event.target.files) : [];
-          addFiles(files);
+          void addResearchCreationAttachments(files).catch((error: unknown) => {
+            setResearchCreationError(
+              draft.revision,
+              error instanceof Error ? error.message : String(error),
+            );
+          });
           event.currentTarget.value = "";
         }}
       />

--- a/apps/desktop/src/ui/tasks/NewTaskLanding.tsx
+++ b/apps/desktop/src/ui/tasks/NewTaskLanding.tsx
@@ -3,6 +3,10 @@ import { type FormEvent, useEffect, useMemo, useRef, useState } from "react";
 
 import { type TaskCreationInput, taskCreationInputSchema } from "../../../../../src/shared/tasks";
 import { useAppStore } from "../../app/store";
+import {
+  beginCreationOperationIntent,
+  type CreationOperationPhase,
+} from "../../app/store.helpers/operationIntent";
 import { isOneOffChatWorkspace } from "../../app/types";
 import { Badge } from "../../components/ui/badge";
 import { Button } from "../../components/ui/button";
@@ -36,6 +40,25 @@ type DraftWorkItem = {
   dependencies: string;
   expectedOutputs: string;
 };
+
+function taskCreationPhaseLabel(phase: CreationOperationPhase | null): string {
+  switch (phase) {
+    case "preparing":
+      return "Preparing task...";
+    case "starting-server":
+      return "Starting the project server...";
+    case "creating":
+      return "Creating task...";
+    case "processing-attachments":
+      return "Processing attachments...";
+    case null:
+      return "Create and start task";
+    default: {
+      const exhaustive: never = phase;
+      return exhaustive;
+    }
+  }
+}
 
 function lines(value: string): string[] {
   return value
@@ -100,6 +123,8 @@ export function NewTaskLanding() {
   const nextWorkItemNumber = useRef(2);
   const [validationError, setValidationError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  const [creationPhase, setCreationPhase] = useState<CreationOperationPhase | null>(null);
+  const submissionControllerRef = useRef<AbortController | null>(null);
   const previousNewTaskWorkspaceId = useRef(newTaskWorkspaceId);
   const previousNewTaskWorkspaceRequestId = useRef(newTaskWorkspaceRequestId);
 
@@ -207,10 +232,31 @@ export function NewTaskLanding() {
       return;
     }
     setValidationError(null);
+    const operationIntent = beginCreationOperationIntent();
+    const controller = new AbortController();
+    submissionControllerRef.current = controller;
+    setCreationPhase("preparing");
     setSubmitting(true);
     try {
-      await startTask({ workspaceId, task: parsed.data });
+      const created = await startTask({
+        workspaceId,
+        task: parsed.data,
+        intent: operationIntent,
+        signal: controller.signal,
+        onPhase: setCreationPhase,
+      });
+      if (controller.signal.aborted) {
+        setValidationError(
+          created
+            ? "Task started in the background before cancellation completed. Your brief was preserved."
+            : "Task creation cancelled. Your brief was preserved.",
+        );
+      }
     } finally {
+      if (submissionControllerRef.current === controller) {
+        submissionControllerRef.current = null;
+      }
+      setCreationPhase(null);
       setSubmitting(false);
     }
   };
@@ -527,10 +573,21 @@ export function NewTaskLanding() {
                   {validationError || taskError ? (
                     <FieldError>{validationError ?? taskError}</FieldError>
                   ) : null}
-                  <Button type="submit" className="w-full" disabled={!canSubmit}>
-                    Create and start task
-                    <ArrowRightIcon data-icon="inline-end" />
-                  </Button>
+                  <div className="flex gap-2">
+                    {submitting ? (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        onClick={() => submissionControllerRef.current?.abort()}
+                      >
+                        Cancel
+                      </Button>
+                    ) : null}
+                    <Button type="submit" className="flex-1" disabled={!canSubmit}>
+                      {taskCreationPhaseLabel(creationPhase)}
+                      {!submitting ? <ArrowRightIcon data-icon="inline-end" /> : null}
+                    </Button>
+                  </div>
                 </FieldGroup>
               </CardContent>
             </Card>

--- a/apps/desktop/src/ui/tasks/NewTaskLanding.tsx
+++ b/apps/desktop/src/ui/tasks/NewTaskLanding.tsx
@@ -2,10 +2,12 @@ import { ArrowRightIcon, ClipboardListIcon, PlusIcon, Trash2Icon } from "lucide-
 import { type FormEvent, useEffect, useMemo, useRef, useState } from "react";
 
 import { type TaskCreationInput, taskCreationInputSchema } from "../../../../../src/shared/tasks";
+import type { TaskCreationDraftWorkItem } from "../../app/creationDrafts";
 import { useAppStore } from "../../app/store";
 import {
   beginCreationOperationIntent,
   type CreationOperationPhase,
+  isCreationNavigationIntentCurrent,
 } from "../../app/store.helpers/operationIntent";
 import { isOneOffChatWorkspace } from "../../app/types";
 import { Badge } from "../../components/ui/badge";
@@ -31,15 +33,6 @@ import { Switch } from "../../components/ui/switch";
 import { Textarea } from "../../components/ui/textarea";
 import { cn } from "../../lib/utils";
 import { formatTaskStatus, taskStatusBadgeClassName } from "./taskPresentation";
-
-type DraftWorkItem = {
-  id: string;
-  key: string;
-  title: string;
-  description: string;
-  dependencies: string;
-  expectedOutputs: string;
-};
 
 function taskCreationPhaseLabel(phase: CreationOperationPhase | null): string {
   switch (phase) {
@@ -67,7 +60,7 @@ function lines(value: string): string[] {
     .filter(Boolean);
 }
 
-function newWorkItem(key: string): DraftWorkItem {
+function newWorkItem(key: string): TaskCreationDraftWorkItem {
   return {
     id: crypto.randomUUID(),
     key,
@@ -94,6 +87,14 @@ export function NewTaskLanding() {
   const taskSummariesByWorkspaceId = useAppStore((state) => state.taskSummariesByWorkspaceId);
   const taskListLoadingByWorkspaceId = useAppStore((state) => state.taskListLoadingByWorkspaceId);
   const taskError = useAppStore((state) => state.taskError);
+  const taskCreationDraft = useAppStore((state) => state.taskCreationDraft);
+  const validationError = useAppStore((state) =>
+    state.taskCreationError?.revision === state.taskCreationDraft.revision
+      ? state.taskCreationError.message
+      : null,
+  );
+  const setTaskCreationDraft = useAppStore((state) => state.setTaskCreationDraft);
+  const setTaskCreationError = useAppStore((state) => state.setTaskCreationError);
   const startTask = useAppStore((state) => state.startTask);
   const selectTask = useAppStore((state) => state.selectTask);
   const refreshTasks = useAppStore((state) => state.refreshTasks);
@@ -107,21 +108,21 @@ export function NewTaskLanding() {
       ? selectedWorkspaceId
       : projects[0]?.id) ??
     "";
-  const [workspaceId, setWorkspaceId] = useState(defaultWorkspaceId);
-  const [idempotencyKey] = useState(() => crypto.randomUUID());
-  const [title, setTitle] = useState("");
-  const [objective, setObjective] = useState("");
-  const [context, setContext] = useState("");
-  const [requirements, setRequirements] = useState("");
-  const [constraints, setConstraints] = useState("");
-  const [acceptanceCriteria, setAcceptanceCriteria] = useState("");
-  const [decisions, setDecisions] = useState("");
-  const [reviewRequired, setReviewRequired] = useState(true);
-  const [workItems, setWorkItems] = useState<DraftWorkItem[]>([newWorkItem("step-1")]);
-  const [workGraphCustomized, setWorkGraphCustomized] = useState(false);
-  const [showAdvancedWorkGraph, setShowAdvancedWorkGraph] = useState(false);
-  const nextWorkItemNumber = useRef(2);
-  const [validationError, setValidationError] = useState<string | null>(null);
+  const {
+    workspaceId,
+    idempotencyKey,
+    title,
+    objective,
+    context,
+    requirements,
+    constraints,
+    acceptanceCriteria,
+    decisions,
+    reviewRequired,
+    workItems,
+    workGraphCustomized,
+    showAdvancedWorkGraph,
+  } = taskCreationDraft;
   const [submitting, setSubmitting] = useState(false);
   const [creationPhase, setCreationPhase] = useState<CreationOperationPhase | null>(null);
   const submissionControllerRef = useRef<AbortController | null>(null);
@@ -134,13 +135,20 @@ export function NewTaskLanding() {
       newTaskWorkspaceId !== previousNewTaskWorkspaceId.current ||
       newTaskWorkspaceRequestId !== previousNewTaskWorkspaceRequestId.current;
     if (newTaskWorkspaceId && targetChanged && projectIds.has(newTaskWorkspaceId)) {
-      setWorkspaceId(newTaskWorkspaceId);
+      setTaskCreationDraft({ workspaceId: newTaskWorkspaceId });
     } else if (defaultWorkspaceId && !projectIds.has(workspaceId)) {
-      setWorkspaceId(defaultWorkspaceId);
+      setTaskCreationDraft({ workspaceId: defaultWorkspaceId });
     }
     previousNewTaskWorkspaceId.current = newTaskWorkspaceId;
     previousNewTaskWorkspaceRequestId.current = newTaskWorkspaceRequestId;
-  }, [defaultWorkspaceId, newTaskWorkspaceId, newTaskWorkspaceRequestId, projects, workspaceId]);
+  }, [
+    defaultWorkspaceId,
+    newTaskWorkspaceId,
+    newTaskWorkspaceRequestId,
+    projects,
+    setTaskCreationDraft,
+    workspaceId,
+  ]);
 
   useEffect(() => {
     if (workspaceId) void refreshTasks(workspaceId);
@@ -182,11 +190,12 @@ export function NewTaskLanding() {
     hasExpectedOutput &&
     !submitting;
 
-  const updateWorkItem = (id: string, patch: Partial<DraftWorkItem>) => {
-    setWorkGraphCustomized(true);
-    setWorkItems((current) =>
-      current.map((item) => (item.id === id ? { ...item, ...patch } : item)),
-    );
+  const updateWorkItem = (id: string, patch: Partial<TaskCreationDraftWorkItem>) => {
+    const currentWorkItems = useAppStore.getState().taskCreationDraft.workItems;
+    setTaskCreationDraft({
+      workGraphCustomized: true,
+      workItems: currentWorkItems.map((item) => (item.id === id ? { ...item, ...patch } : item)),
+    });
   };
 
   const submit = async (event: FormEvent<HTMLFormElement>) => {
@@ -228,10 +237,14 @@ export function NewTaskLanding() {
     };
     const parsed = taskCreationInputSchema.safeParse(task);
     if (!parsed.success) {
-      setValidationError(parsed.error.issues[0]?.message ?? "The task plan is incomplete.");
+      setTaskCreationError(
+        taskCreationDraft.revision,
+        parsed.error.issues[0]?.message ?? "The task plan is incomplete.",
+      );
       return;
     }
-    setValidationError(null);
+    const draftRevision = taskCreationDraft.revision;
+    setTaskCreationError(draftRevision, null);
     const operationIntent = beginCreationOperationIntent();
     const controller = new AbortController();
     submissionControllerRef.current = controller;
@@ -241,15 +254,19 @@ export function NewTaskLanding() {
       const created = await startTask({
         workspaceId,
         task: parsed.data,
+        draftRevision,
         intent: operationIntent,
         signal: controller.signal,
         onPhase: setCreationPhase,
       });
-      if (controller.signal.aborted) {
-        setValidationError(
-          created
-            ? "Task started in the background before cancellation completed. Your brief was preserved."
-            : "Task creation cancelled. Your brief was preserved.",
+      if (
+        created &&
+        !controller.signal.aborted &&
+        !isCreationNavigationIntentCurrent(operationIntent)
+      ) {
+        setTaskCreationError(
+          draftRevision,
+          "Task started in the background. Your brief was preserved.",
         );
       }
     } finally {
@@ -315,7 +332,10 @@ export function NewTaskLanding() {
                       id="new-task-project"
                       className="w-full"
                       value={workspaceId}
-                      onChange={(event) => setWorkspaceId(event.target.value)}
+                      disabled={submitting}
+                      onChange={(event) =>
+                        setTaskCreationDraft({ workspaceId: event.target.value })
+                      }
                     >
                       {projects.map((workspace) => (
                         <NativeSelectOption key={workspace.id} value={workspace.id}>
@@ -335,7 +355,8 @@ export function NewTaskLanding() {
                       maxLength={160}
                       placeholder="Ship task mode alongside standard chat"
                       value={title}
-                      onChange={(event) => setTitle(event.target.value)}
+                      disabled={submitting}
+                      onChange={(event) => setTaskCreationDraft({ title: event.target.value })}
                     />
                   </Field>
                   <Field>
@@ -345,7 +366,8 @@ export function NewTaskLanding() {
                       className="min-h-28 resize-y"
                       placeholder="State the concrete outcome to deliver."
                       value={objective}
-                      onChange={(event) => setObjective(event.target.value)}
+                      disabled={submitting}
+                      onChange={(event) => setTaskCreationDraft({ objective: event.target.value })}
                     />
                   </Field>
                   <Field>
@@ -358,7 +380,8 @@ export function NewTaskLanding() {
                       className="min-h-32 resize-y"
                       placeholder="Include relevant background, current state, audience, and boundaries."
                       value={context}
-                      onChange={(event) => setContext(event.target.value)}
+                      disabled={submitting}
+                      onChange={(event) => setTaskCreationDraft({ context: event.target.value })}
                     />
                     <FieldDescription>
                       Leave blank to start with a minimal handoff.
@@ -383,7 +406,10 @@ export function NewTaskLanding() {
                     variant="outline"
                     size="sm"
                     aria-expanded={showAdvancedWorkGraph}
-                    onClick={() => setShowAdvancedWorkGraph((open) => !open)}
+                    disabled={submitting}
+                    onClick={() =>
+                      setTaskCreationDraft({ showAdvancedWorkGraph: !showAdvancedWorkGraph })
+                    }
                   >
                     {showAdvancedWorkGraph ? "Hide advanced" : "Show advanced"}
                   </Button>
@@ -404,16 +430,19 @@ export function NewTaskLanding() {
                             size="icon-sm"
                             variant="ghost"
                             aria-label={`Remove step ${index + 1}`}
+                            disabled={submitting}
                             onClick={() => {
-                              setWorkGraphCustomized(true);
-                              setWorkItems((current) =>
-                                current
+                              const currentWorkItems =
+                                useAppStore.getState().taskCreationDraft.workItems;
+                              setTaskCreationDraft({
+                                workGraphCustomized: true,
+                                workItems: currentWorkItems
                                   .filter((entry) => entry.id !== item.id)
                                   .map((entry) => ({
                                     ...entry,
                                     dependencies: removeDependency(entry.dependencies, item.key),
                                   })),
-                              );
+                              });
                             }}
                           >
                             <Trash2Icon />
@@ -427,6 +456,7 @@ export function NewTaskLanding() {
                             id={`work-item-title-${item.id}`}
                             placeholder="Implement the coordinator"
                             value={item.title}
+                            disabled={submitting}
                             onChange={(event) =>
                               updateWorkItem(item.id, { title: event.target.value })
                             }
@@ -440,6 +470,7 @@ export function NewTaskLanding() {
                             id={`work-item-description-${item.id}`}
                             className="min-h-20 resize-y"
                             value={item.description}
+                            disabled={submitting}
                             onChange={(event) =>
                               updateWorkItem(item.id, { description: event.target.value })
                             }
@@ -454,6 +485,7 @@ export function NewTaskLanding() {
                               id={`work-item-dependencies-${item.id}`}
                               placeholder="step-1, step-2"
                               value={item.dependencies}
+                              disabled={submitting}
                               onChange={(event) =>
                                 updateWorkItem(item.id, { dependencies: event.target.value })
                               }
@@ -468,6 +500,7 @@ export function NewTaskLanding() {
                               className="min-h-20 resize-y"
                               placeholder="One output per line"
                               value={item.expectedOutputs}
+                              disabled={submitting}
                               onChange={(event) =>
                                 updateWorkItem(item.id, { expectedOutputs: event.target.value })
                               }
@@ -481,11 +514,18 @@ export function NewTaskLanding() {
                     type="button"
                     variant="outline"
                     className="self-start"
+                    disabled={submitting}
                     onClick={() => {
-                      const key = `step-${nextWorkItemNumber.current}`;
-                      nextWorkItemNumber.current += 1;
-                      setWorkGraphCustomized(true);
-                      setWorkItems((current) => [...current, newWorkItem(key)]);
+                      const currentWorkItems = useAppStore.getState().taskCreationDraft.workItems;
+                      const nextNumber =
+                        currentWorkItems.reduce((highest, item) => {
+                          const parsed = /^step-(\d+)$/.exec(item.key);
+                          return Math.max(highest, Number(parsed?.[1] ?? 0));
+                        }, 0) + 1;
+                      setTaskCreationDraft({
+                        workGraphCustomized: true,
+                        workItems: [...currentWorkItems, newWorkItem(`step-${nextNumber}`)],
+                      });
                     }}
                   >
                     <PlusIcon data-icon="inline-start" />
@@ -519,7 +559,10 @@ export function NewTaskLanding() {
                       className="min-h-24 resize-y"
                       placeholder="Required behavior or deliverable"
                       value={requirements}
-                      onChange={(event) => setRequirements(event.target.value)}
+                      disabled={submitting}
+                      onChange={(event) =>
+                        setTaskCreationDraft({ requirements: event.target.value })
+                      }
                     />
                   </Field>
                   <Field>
@@ -529,7 +572,10 @@ export function NewTaskLanding() {
                       className="min-h-24 resize-y"
                       placeholder="Compatibility, policy, timing, or scope boundary"
                       value={constraints}
-                      onChange={(event) => setConstraints(event.target.value)}
+                      disabled={submitting}
+                      onChange={(event) =>
+                        setTaskCreationDraft({ constraints: event.target.value })
+                      }
                     />
                   </Field>
                   <Field>
@@ -542,7 +588,10 @@ export function NewTaskLanding() {
                       className="min-h-28 resize-y"
                       placeholder="Observable evidence that the task is complete"
                       value={acceptanceCriteria}
-                      onChange={(event) => setAcceptanceCriteria(event.target.value)}
+                      disabled={submitting}
+                      onChange={(event) =>
+                        setTaskCreationDraft({ acceptanceCriteria: event.target.value })
+                      }
                     />
                     <FieldDescription>Defaults to the objective when empty.</FieldDescription>
                   </Field>
@@ -553,7 +602,8 @@ export function NewTaskLanding() {
                       className="min-h-24 resize-y"
                       placeholder="One accepted assumption or decision per line"
                       value={decisions}
-                      onChange={(event) => setDecisions(event.target.value)}
+                      disabled={submitting}
+                      onChange={(event) => setTaskCreationDraft({ decisions: event.target.value })}
                     />
                   </Field>
                   <Separator />
@@ -567,7 +617,10 @@ export function NewTaskLanding() {
                     <Switch
                       id="new-task-review"
                       checked={reviewRequired}
-                      onCheckedChange={setReviewRequired}
+                      disabled={submitting}
+                      onCheckedChange={(checked) =>
+                        setTaskCreationDraft({ reviewRequired: checked })
+                      }
                     />
                   </Field>
                   {validationError || taskError ? (

--- a/apps/desktop/test/app-jsonrpc-disposal.test.tsx
+++ b/apps/desktop/test/app-jsonrpc-disposal.test.tsx
@@ -120,7 +120,7 @@ const {
 const { __internal: jsonRpcSocketInternal } = await import(
   "../src/app/store.helpers/jsonRpcSocket"
 );
-const defaultStoreState = useAppStore.getState();
+const defaultStoreState = useAppStore.getInitialState();
 
 class MockJsonRpcSocket {
   static instances: MockJsonRpcSocket[] = [];
@@ -501,7 +501,7 @@ describe("App JSON-RPC shutdown disposal", () => {
         root?.render(createElement(StrictMode, null, createElement(App)));
       });
       await act(async () => {
-        await waitForCondition(() => bootstrapSelectThreadCalls === 1);
+        await useAppStore.getState().drainBootstrap();
       });
 
       expect(bootstrapLoadStateCalls).toBe(1);

--- a/apps/desktop/test/bootstrap-cache.test.ts
+++ b/apps/desktop/test/bootstrap-cache.test.ts
@@ -7,6 +7,7 @@ import {
   createComposerDraftAttachment,
   createEmptyComposerDraft,
 } from "../src/app/composerDrafts";
+import { createEmptyTaskCreationDraft } from "../src/app/creationDrafts";
 import { createDesktopCommandsMock } from "./helpers/mockDesktopCommands";
 
 const DESKTOP_STATE_CACHE_KEY = "cowork.desktop.state-cache.v2";
@@ -740,6 +741,89 @@ describe("desktop bootstrap cache", () => {
       reasoningEffort: "high",
     });
     expect(await seed?.composerDraftsByKey?.[key]?.attachments[0]?.file.text()).toBe("draft file");
+  });
+
+  test("buildCachedDesktopStateSeed restores revision-owned Research and Task creation state", () => {
+    const taskDraft = {
+      ...createEmptyTaskCreationDraft(9, "ws-cached"),
+      updatedAt: "2099-03-20T00:00:00.000Z",
+      idempotencyKey: "persisted-task-key",
+      title: "Persisted task",
+      objective: "Restore this exact brief.",
+    };
+    const seed = buildCachedDesktopStateSeed({
+      ...cachedState,
+      persistedState: {
+        ...cachedState.persistedState,
+        creationDrafts: {
+          research: {
+            revision: 7,
+            generation: 2,
+            updatedAt: "2099-03-20T00:00:00.000Z",
+            text: "Persisted research question",
+            attachments: [],
+            references: [],
+            provider: null,
+            model: null,
+            reasoningEffort: null,
+          },
+          researchError: { revision: 7, message: "Research failed after navigation" },
+          task: taskDraft,
+          taskError: { revision: 9, message: "Task failed after navigation" },
+        },
+      },
+    });
+
+    expect(seed?.researchCreationDraft).toMatchObject({
+      revision: 7,
+      generation: 2,
+      text: "Persisted research question",
+    });
+    expect(seed?.researchCreationError).toEqual({
+      revision: 7,
+      message: "Research failed after navigation",
+    });
+    expect(seed?.taskCreationDraft).toEqual(taskDraft);
+    expect(seed?.taskCreationError).toEqual({
+      revision: 9,
+      message: "Task failed after navigation",
+    });
+  });
+
+  test("desktop persistence serializes Research and Task creation drafts with matching errors", () => {
+    const researchDraft = {
+      ...createEmptyComposerDraft("2099-03-20T00:00:00.000Z"),
+      revision: 3,
+      text: "Persist this research",
+    };
+    const taskDraft = {
+      ...createEmptyTaskCreationDraft(4, "ws-cached"),
+      updatedAt: "2099-03-20T00:00:00.000Z",
+      title: "Persist this task",
+      objective: "Keep the brief and error together.",
+    };
+    useAppStore.setState({
+      researchCreationDraft: researchDraft,
+      researchCreationError: { revision: 3, message: "research error" },
+      taskCreationDraft: taskDraft,
+      taskCreationError: { revision: 4, message: "task error" },
+    });
+
+    const persisted = syncDesktopStateCacheNow(useAppStore.getState);
+
+    expect(persisted.creationDrafts).toMatchObject({
+      research: {
+        revision: 3,
+        text: "Persist this research",
+      },
+      researchError: { revision: 3, message: "research error" },
+      task: {
+        revision: 4,
+        title: "Persist this task",
+        objective: "Keep the brief and error together.",
+      },
+      taskError: { revision: 4, message: "task error" },
+    });
   });
 
   test("durable persistence includes attachment bytes while the fast cache omits them", async () => {

--- a/apps/desktop/test/control-socket.ensure.test.ts
+++ b/apps/desktop/test/control-socket.ensure.test.ts
@@ -19,6 +19,7 @@ import {
   persistCalls,
   RUNTIME,
   registerControlSocketLifecycleHooks,
+  requestJsonRpc,
   respondToJsonRpcRequest,
   setJsonRpcSocketOverride,
 } from "./control-socket.harness";
@@ -108,6 +109,103 @@ describe("control socket helpers over JSON-RPC", () => {
     expect(socket).toBeInstanceOf(MockJsonRpcSocket);
     expect((socket as MockJsonRpcSocket).opts.openTimeoutMs).toBe(5_000);
     expect((socket as MockJsonRpcSocket).opts.handshakeTimeoutMs).toBe(10_000);
+  });
+
+  test("waitForControlSession aborts before an unresolved socket becomes ready", async () => {
+    const workspaceId = "ws-abort-ready";
+    const { get, set } = createState(workspaceId);
+    const helpers = createControlSocketHelpers(deps);
+    const readyGate = Promise.withResolvers<void>();
+    const controller = new AbortController();
+    RUNTIME.jsonRpcSockets.set(workspaceId, {
+      readyPromise: readyGate.promise,
+      connect() {},
+      request: async () => ({}),
+      respond: () => true,
+      close() {},
+    } as never);
+
+    const pending = helpers.waitForControlSession(get as never, set as never, workspaceId, 10_000, {
+      signal: controller.signal,
+    });
+    controller.abort();
+
+    const outcome = await Promise.race([
+      pending.then(
+        () => "resolved" as const,
+        (error: unknown) => (error instanceof Error ? error.name : "unknown"),
+      ),
+      Bun.sleep(100).then(() => "timed-out" as const),
+    ]);
+    expect(outcome).toBe("AbortError");
+    expect(helpers.__internal.getPendingWaiterCounts().controlSessionWaiters).toBe(0);
+    readyGate.resolve();
+  });
+
+  test("requestJsonRpc aborts before an unresolved response arrives", async () => {
+    const workspaceId = "ws-abort-request";
+    const { get, set } = createState(workspaceId);
+    const requestGate = Promise.withResolvers<Record<string, unknown>>();
+    const controller = new AbortController();
+    RUNTIME.jsonRpcSockets.set(workspaceId, {
+      readyPromise: Promise.resolve(),
+      connect() {},
+      request: () => requestGate.promise,
+      respond: () => true,
+      close() {},
+    } as never);
+
+    const pending = requestJsonRpc(
+      get as never,
+      set as never,
+      workspaceId,
+      "research/start",
+      {},
+      { signal: controller.signal },
+    );
+    controller.abort();
+
+    const outcome = await Promise.race([
+      pending.then(
+        () => "resolved" as const,
+        (error: unknown) => (error instanceof Error ? error.name : "unknown"),
+      ),
+      Bun.sleep(100).then(() => "timed-out" as const),
+    ]);
+    expect(outcome).toBe("AbortError");
+    requestGate.resolve({});
+  });
+
+  test("requestJsonRpc does not send an already-cancelled request", async () => {
+    const workspaceId = "ws-pre-aborted-request";
+    const { get, set } = createState(workspaceId);
+    const controller = new AbortController();
+    let requestCount = 0;
+    controller.abort();
+    RUNTIME.jsonRpcSockets.set(workspaceId, {
+      readyPromise: Promise.resolve(),
+      connect() {},
+      request: async () => {
+        requestCount += 1;
+        return {};
+      },
+      respond: () => true,
+      close() {},
+    } as never);
+
+    await expect(
+      requestJsonRpc(
+        get as never,
+        set as never,
+        workspaceId,
+        "research/start",
+        {},
+        {
+          signal: controller.signal,
+        },
+      ),
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(requestCount).toBe(0);
   });
 
   test("stale socket close after a serverUrl swap does not clear the active control session", async () => {

--- a/apps/desktop/test/control-socket.harness.ts
+++ b/apps/desktop/test/control-socket.harness.ts
@@ -84,7 +84,7 @@ mock.module("../src/lib/agentSocket", () => ({
 }));
 
 const { createControlSocketHelpers } = await import("../src/app/store.helpers/controlSocket");
-const { ensureWorkspaceJsonRpcSocket, respondToJsonRpcRequest } = await import(
+const { ensureWorkspaceJsonRpcSocket, requestJsonRpc, respondToJsonRpcRequest } = await import(
   "../src/app/store.helpers/jsonRpcSocket"
 );
 const { RUNTIME, defaultWorkspaceRuntime } = await import("../src/app/store.helpers/runtimeState");
@@ -241,6 +241,7 @@ export {
   makeThreadListEntry,
   persistCalls,
   RUNTIME,
+  requestJsonRpc,
   respondToJsonRpcRequest,
   setJsonRpcSocketOverride,
 };

--- a/apps/desktop/test/research-actions.test.ts
+++ b/apps/desktop/test/research-actions.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { MAX_RESEARCH_UPLOAD_BYTES } from "../../../src/server/research/types";
+import {
+  __internalOperationIntent,
+  invalidateNavigationIntent,
+} from "../src/app/store.helpers/operationIntent";
 
 const { createResearchActions, __internalResearchActionBindings } = await import(
   "../src/app/store.actions/research"
@@ -47,6 +51,26 @@ function researchUploadFile(fileId: string) {
     mimeType: "text/plain",
     path: `/tmp/${fileId}.txt`,
     uploadedAt: "2026-04-21T00:00:00.000Z",
+  };
+}
+
+function completedResearch(id: string, title: string) {
+  return {
+    id,
+    title,
+    status: "completed" as const,
+    outputsMarkdown: "Done",
+    lastEventId: null,
+    updatedAt: "2026-04-21T00:00:00.000Z",
+    parentResearchId: null,
+    prompt: title,
+    interactionId: `interaction-${id}`,
+    inputs: { files: [] },
+    settings: { planApproval: false },
+    thoughtSummaries: [],
+    sources: [],
+    createdAt: "2026-04-21T00:00:00.000Z",
+    error: null,
   };
 }
 
@@ -118,6 +142,7 @@ describe("research actions", () => {
 
   beforeEach(() => {
     __internalResearchActionBindings.reset();
+    __internalOperationIntent.reset();
     requestJsonRpcMock.mockReset();
     requestJsonRpcMock.mockImplementation(async () => ({
       path: "/tmp/report.pdf",
@@ -125,6 +150,63 @@ describe("research actions", () => {
     }));
     saveExportedFileMock.mockReset();
     saveExportedFileMock.mockImplementation(async () => "/Users/test/Downloads/report.pdf");
+  });
+
+  test("a delayed research result is recorded without stealing newer navigation", async () => {
+    const harness = createHarness();
+    const actions = createResearchActions(harness.set as never, harness.get as never, deps);
+    const startGate = Promise.withResolvers<ReturnType<typeof completedResearch>>();
+    requestJsonRpcMock.mockImplementation(async (_get, _set, _workspaceId, method) => {
+      if (method === "research/start") {
+        return { research: await startGate.promise };
+      }
+      return {};
+    });
+
+    const pending = actions.startResearch({ input: "Investigate intent ownership." });
+    invalidateNavigationIntent();
+    harness.state.view = "settings";
+    harness.state.selectedResearchId = "research-1";
+    startGate.resolve(completedResearch("research-2", "Background result"));
+
+    await expect(pending).resolves.toMatchObject({ id: "research-2" });
+    expect(harness.state.view).toBe("settings");
+    expect(harness.state.selectedResearchId).toBe("research-1");
+    expect(harness.state.researchById["research-2"]?.title).toBe("Background result");
+  });
+
+  test("a delayed research subscription refresh preserves newer navigation", async () => {
+    const harness = createHarness();
+    const actions = createResearchActions(harness.set as never, harness.get as never, deps);
+    const subscriptionStarted = Promise.withResolvers<void>();
+    const subscriptionGate = Promise.withResolvers<ReturnType<typeof completedResearch>>();
+    const runningResearch = {
+      ...completedResearch("research-2", "Background result"),
+      status: "running" as const,
+      outputsMarkdown: "",
+    };
+    requestJsonRpcMock.mockImplementation(async (_get, _set, _workspaceId, method) => {
+      if (method === "research/start") {
+        return { research: runningResearch };
+      }
+      if (method === "research/subscribe") {
+        subscriptionStarted.resolve();
+        return { research: await subscriptionGate.promise };
+      }
+      return {};
+    });
+
+    const pending = actions.startResearch({ input: "Investigate subscription ownership." });
+    await subscriptionStarted.promise;
+    invalidateNavigationIntent();
+    harness.state.view = "settings";
+    harness.state.selectedResearchId = "research-1";
+    subscriptionGate.resolve(completedResearch("research-2", "Refreshed background result"));
+
+    await expect(pending).resolves.toMatchObject({ id: "research-2" });
+    expect(harness.state.view).toBe("settings");
+    expect(harness.state.selectedResearchId).toBe("research-1");
+    expect(harness.state.researchById["research-2"]?.title).toBe("Refreshed background result");
   });
 
   test("exportResearch saves with a sanitized title-derived filename and clears pending state", async () => {

--- a/apps/desktop/test/research-actions.test.ts
+++ b/apps/desktop/test/research-actions.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { MAX_RESEARCH_UPLOAD_BYTES } from "../../../src/server/research/types";
+import { type ComposerDraft, createEmptyComposerDraft } from "../src/app/composerDrafts";
+import type { CreationDraftError } from "../src/app/creationDrafts";
 import {
   __internalOperationIntent,
   invalidateNavigationIntent,
@@ -42,6 +44,8 @@ type TestState = {
   researchListError: string | null;
   researchSubscribedIds: string[];
   researchExportPendingIds: string[];
+  researchCreationDraft: ComposerDraft;
+  researchCreationError: CreationDraftError | null;
 };
 
 function researchUploadFile(fileId: string) {
@@ -110,6 +114,8 @@ function createHarness(overrides: Partial<TestState> = {}) {
     researchListError: null,
     researchSubscribedIds: [],
     researchExportPendingIds: [],
+    researchCreationDraft: createEmptyComposerDraft("2026-04-21T00:00:00.000Z"),
+    researchCreationError: null,
     ...overrides,
   };
 
@@ -138,6 +144,7 @@ describe("research actions", () => {
     ensureWorkspaceRuntime() {},
     syncDesktopStateCache() {},
     waitForControlSession: async () => true,
+    persist() {},
   };
 
   beforeEach(() => {
@@ -207,6 +214,130 @@ describe("research actions", () => {
     expect(harness.state.view).toBe("settings");
     expect(harness.state.selectedResearchId).toBe("research-1");
     expect(harness.state.researchById["research-2"]?.title).toBe("Refreshed background result");
+  });
+
+  test("overlapping research creation lets only the newest operation select its result", async () => {
+    const harness = createHarness();
+    const actions = createResearchActions(harness.set as never, harness.get as never, deps);
+    const firstGate = Promise.withResolvers<ReturnType<typeof completedResearch>>();
+    const secondGate = Promise.withResolvers<ReturnType<typeof completedResearch>>();
+    requestJsonRpcMock.mockImplementation(
+      async (_get, _set, _workspaceId, method, params: unknown) => {
+        if (method !== "research/start") return {};
+        const input =
+          typeof params === "object" && params !== null && "input" in params
+            ? (params as { input?: unknown }).input
+            : null;
+        return {
+          research: await (input === "First research" ? firstGate.promise : secondGate.promise),
+        };
+      },
+    );
+
+    const first = actions.startResearch({ input: "First research" });
+    const second = actions.startResearch({ input: "Second research" });
+    secondGate.resolve(completedResearch("research-3", "Second result"));
+    await expect(second).resolves.toMatchObject({ id: "research-3" });
+    firstGate.resolve(completedResearch("research-2", "First result"));
+    await expect(first).resolves.toMatchObject({ id: "research-2" });
+
+    expect(harness.state.selectedResearchId).toBe("research-3");
+    expect(harness.state.researchById["research-2"]?.title).toBe("First result");
+    expect(harness.state.researchById["research-3"]?.title).toBe("Second result");
+  });
+
+  test("delayed research failure retains the submitted draft after navigation", async () => {
+    const submittedDraft = {
+      ...createEmptyComposerDraft("2026-04-21T00:00:00.000Z"),
+      revision: 4,
+      text: "Preserve this research question",
+    };
+    const harness = createHarness({ researchCreationDraft: submittedDraft });
+    const actions = createResearchActions(harness.set as never, harness.get as never, deps);
+    const startGate = Promise.withResolvers<void>();
+    requestJsonRpcMock.mockImplementation(async (_get, _set, _workspaceId, method) => {
+      if (method === "research/start") {
+        await startGate.promise;
+        throw new Error("research service unavailable");
+      }
+      return {};
+    });
+
+    const pending = actions.startResearch({
+      input: submittedDraft.text,
+      draftRevision: submittedDraft.revision,
+    });
+    invalidateNavigationIntent();
+    harness.state.view = "settings";
+    startGate.resolve();
+
+    await expect(pending).resolves.toBeNull();
+    expect(harness.state.researchCreationDraft).toEqual(submittedDraft);
+    expect(harness.state.researchCreationError).toEqual({
+      revision: submittedDraft.revision,
+      message: "research service unavailable",
+    });
+    expect(harness.state.view).toBe("settings");
+  });
+
+  test("an older research failure cannot overwrite a newer draft revision", async () => {
+    const submittedDraft = {
+      ...createEmptyComposerDraft("2026-04-21T00:00:00.000Z"),
+      revision: 6,
+      text: "Old research question",
+    };
+    const harness = createHarness({ researchCreationDraft: submittedDraft });
+    const actions = createResearchActions(harness.set as never, harness.get as never, deps);
+    const startGate = Promise.withResolvers<void>();
+    requestJsonRpcMock.mockImplementation(async (_get, _set, _workspaceId, method) => {
+      if (method === "research/start") {
+        await startGate.promise;
+        throw new Error("stale failure");
+      }
+      return {};
+    });
+
+    const pending = actions.startResearch({
+      input: submittedDraft.text,
+      draftRevision: submittedDraft.revision,
+    });
+    actions.setResearchCreationInput("New research question");
+    startGate.resolve();
+
+    await expect(pending).resolves.toBeNull();
+    expect(harness.state.researchCreationDraft.text).toBe("New research question");
+    expect(harness.state.researchCreationDraft.revision).toBe(submittedDraft.revision + 1);
+    expect(harness.state.researchCreationError).toBeNull();
+  });
+
+  test("cancelling attachment reads stops waiting before the file read completes", async () => {
+    const harness = createHarness();
+    const actions = createResearchActions(harness.set as never, harness.get as never, deps);
+    const readGate = Promise.withResolvers<ArrayBuffer>();
+    const readStarted = Promise.withResolvers<void>();
+    const controller = new AbortController();
+    const file = {
+      name: "notes.txt",
+      type: "text/plain",
+      size: 5,
+      arrayBuffer: () => {
+        readStarted.resolve();
+        return readGate.promise;
+      },
+    } as unknown as File;
+
+    const pending = actions.startResearch({
+      input: "Analyze the notes.",
+      files: [file],
+      signal: controller.signal,
+    });
+    await readStarted.promise;
+    controller.abort();
+
+    const outcome = await Promise.race([pending, Bun.sleep(100).then(() => "timed-out" as const)]);
+    expect(outcome).toBeNull();
+    expect(requestJsonRpcMock.mock.calls.some((call) => call[3] === "research/start")).toBeFalse();
+    readGate.resolve(new ArrayBuffer(5));
   });
 
   test("exportResearch saves with a sanitized title-derived filename and clears pending state", async () => {

--- a/apps/desktop/test/task-actions.test.ts
+++ b/apps/desktop/test/task-actions.test.ts
@@ -11,6 +11,10 @@ import {
   createTaskActions,
   type TaskActionDependencies,
 } from "../src/app/store.actions/tasks";
+import {
+  __internalOperationIntent,
+  invalidateNavigationIntent,
+} from "../src/app/store.helpers/operationIntent";
 import type { ThreadRecord } from "../src/app/types";
 
 const NOW = "2026-06-18T12:00:00.000Z";
@@ -68,6 +72,32 @@ function taskRecord(overrides: Partial<TaskRecord> = {}): TaskRecord {
     activity: [],
     latestCheckpoint: null,
     ...overrides,
+  };
+}
+
+function taskCreationInput() {
+  return {
+    idempotencyKey: "manual-task-1",
+    title: "Implement task mode",
+    objective: "Add explicit task mode without changing standard chat.",
+    context: "The chat flow must remain available alongside managed tasks.",
+    requirements: [
+      {
+        kind: "acceptance_criterion" as const,
+        text: "A complete task opens in the work-first task view.",
+      },
+    ],
+    workItems: [
+      {
+        key: "implement",
+        title: "Implement task mode",
+        description: "Build and verify the managed task flow.",
+        dependsOn: [],
+        expectedOutputs: ["Working task mode"],
+      },
+    ],
+    decisions: [],
+    reviewRequired: true,
   };
 }
 
@@ -263,6 +293,7 @@ describe("desktop task actions", () => {
 
   beforeEach(() => {
     __internalTaskActions.reset();
+    __internalOperationIntent.reset();
     setRendererPlatform("win32");
     notificationRouter = null;
     requestJsonRpc.mockClear();
@@ -270,6 +301,34 @@ describe("desktop task actions", () => {
 
   afterEach(() => {
     setRendererPlatform(null);
+  });
+
+  test("a delayed task is recorded without stealing newer navigation", async () => {
+    const harness = createHarness();
+    const actions = createTaskActions(harness.set as never, harness.get as never, deps);
+    Object.assign(harness.state, actions);
+    const createGate = Promise.withResolvers<void>();
+    requestJsonRpc.mockImplementationOnce(async () => {
+      await createGate.promise;
+      return { task: taskRecord(), thread: { id: "task-session-1" } };
+    });
+
+    const pending = actions.startTask({
+      workspaceId: "ws-1",
+      task: taskCreationInput(),
+    });
+    invalidateNavigationIntent();
+    harness.state.view = "settings";
+    harness.state.selectedThreadId = "chat-1";
+    harness.state.selectedTaskId = null;
+    createGate.resolve();
+
+    await expect(pending).resolves.toMatchObject({ id: "task-1" });
+    expect(harness.state.view).toBe("settings");
+    expect(harness.state.selectedThreadId).toBe("chat-1");
+    expect(harness.state.selectedTaskId).toBeNull();
+    expect(harness.state.tasksById["task-1"]?.title).toBe("Implement task mode");
+    expect(harness.reconnectThread).not.toHaveBeenCalled();
   });
 
   test("creates an explicit task thread without replacing standard chat", async () => {

--- a/apps/desktop/test/task-actions.test.ts
+++ b/apps/desktop/test/task-actions.test.ts
@@ -7,6 +7,11 @@ import type {
   TaskRecord,
 } from "../../../src/shared/tasks";
 import {
+  type CreationDraftError,
+  createEmptyTaskCreationDraft,
+  type TaskCreationDraft,
+} from "../src/app/creationDrafts";
+import {
   __internalTaskActions,
   createTaskActions,
   type TaskActionDependencies,
@@ -14,6 +19,7 @@ import {
 import {
   __internalOperationIntent,
   invalidateNavigationIntent,
+  recordThreadNavigationIntent,
 } from "../src/app/store.helpers/operationIntent";
 import type { ThreadRecord } from "../src/app/types";
 
@@ -236,6 +242,8 @@ function createHarness(options: { workspacePath?: string } = {}) {
     taskListLoadingByWorkspaceId: {},
     taskLifecycleRequestByTaskId: {},
     taskError: null as string | null,
+    taskCreationDraft: createEmptyTaskCreationDraft(0, "ws-1") as TaskCreationDraft,
+    taskCreationError: null as CreationDraftError | null,
     desktopFeatureFlags: {
       menuBar: true,
       remoteAccess: false,
@@ -288,6 +296,7 @@ describe("desktop task actions", () => {
     },
     requestJsonRpc,
     syncDesktopStateCache: () => {},
+    persist: () => {},
     persistNow: async () => {},
   } as unknown as TaskActionDependencies;
 
@@ -296,7 +305,11 @@ describe("desktop task actions", () => {
     __internalOperationIntent.reset();
     setRendererPlatform("win32");
     notificationRouter = null;
-    requestJsonRpc.mockClear();
+    requestJsonRpc.mockReset();
+    requestJsonRpc.mockImplementation(async (_get, _set, _workspaceId, method) => {
+      if (method === "task/list") return { tasks: [] };
+      return { task: taskRecord(), thread: { id: "task-session-1" } };
+    });
   });
 
   afterEach(() => {
@@ -329,6 +342,123 @@ describe("desktop task actions", () => {
     expect(harness.state.selectedTaskId).toBeNull();
     expect(harness.state.tasksById["task-1"]?.title).toBe("Implement task mode");
     expect(harness.reconnectThread).not.toHaveBeenCalled();
+  });
+
+  test("overlapping task creation lets only the newest operation select its result", async () => {
+    const harness = createHarness();
+    const actions = createTaskActions(harness.set as never, harness.get as never, deps);
+    Object.assign(harness.state, actions);
+    const firstGate = Promise.withResolvers<void>();
+    const secondGate = Promise.withResolvers<void>();
+    const taskResult = (suffix: "first" | "second") => ({
+      task: taskRecord({
+        id: `task-${suffix}`,
+        title: `${suffix} task`,
+        threads: [
+          {
+            ...taskRecord().threads[0]!,
+            id: `task-thread-${suffix}`,
+            taskId: `task-${suffix}`,
+            sessionId: `task-session-${suffix}`,
+          },
+        ],
+      }),
+      thread: { id: `task-session-${suffix}` },
+    });
+    requestJsonRpc.mockImplementationOnce(async () => {
+      await firstGate.promise;
+      return taskResult("first");
+    });
+    requestJsonRpc.mockImplementationOnce(async () => {
+      await secondGate.promise;
+      return taskResult("second");
+    });
+
+    const first = actions.startTask({
+      workspaceId: "ws-1",
+      task: { ...taskCreationInput(), idempotencyKey: "first-task" },
+    });
+    const second = actions.startTask({
+      workspaceId: "ws-1",
+      task: { ...taskCreationInput(), idempotencyKey: "second-task" },
+    });
+    secondGate.resolve();
+    await expect(second).resolves.toMatchObject({ id: "task-second" });
+    firstGate.resolve();
+    await expect(first).resolves.toMatchObject({ id: "task-first" });
+
+    expect(harness.state.selectedTaskId).toBe("task-second");
+    expect(harness.state.selectedThreadId).toBe("task-session-second");
+    expect(harness.state.tasksById["task-first"]?.title).toBe("first task");
+    expect(harness.reconnectThread).toHaveBeenCalledTimes(1);
+    expect(harness.reconnectThread).toHaveBeenCalledWith("task-session-second", undefined, {
+      skipWorkspaceSelect: true,
+      refreshSnapshot: true,
+    });
+  });
+
+  test("delayed task failure retains the submitted brief after navigation", async () => {
+    const submittedDraft = {
+      ...createEmptyTaskCreationDraft(5, "ws-1"),
+      title: "Preserve this task",
+      objective: "Keep the exact submitted brief.",
+    };
+    const harness = createHarness();
+    harness.state.taskCreationDraft = submittedDraft;
+    const actions = createTaskActions(harness.set as never, harness.get as never, deps);
+    Object.assign(harness.state, actions);
+    const createGate = Promise.withResolvers<void>();
+    requestJsonRpc.mockImplementationOnce(async () => {
+      await createGate.promise;
+      throw new Error("task service unavailable");
+    });
+
+    const pending = actions.startTask({
+      workspaceId: "ws-1",
+      task: taskCreationInput(),
+      draftRevision: submittedDraft.revision,
+    });
+    invalidateNavigationIntent();
+    harness.state.view = "settings";
+    createGate.resolve();
+
+    await expect(pending).resolves.toBeNull();
+    expect(harness.state.taskCreationDraft).toEqual(submittedDraft);
+    expect(harness.state.taskCreationError).toEqual({
+      revision: submittedDraft.revision,
+      message: "task service unavailable",
+    });
+    expect(harness.state.view).toBe("settings");
+  });
+
+  test("an older task failure cannot overwrite a newer brief revision", async () => {
+    const submittedDraft = {
+      ...createEmptyTaskCreationDraft(8, "ws-1"),
+      title: "Old task",
+      objective: "Old objective",
+    };
+    const harness = createHarness();
+    harness.state.taskCreationDraft = submittedDraft;
+    const actions = createTaskActions(harness.set as never, harness.get as never, deps);
+    Object.assign(harness.state, actions);
+    const createGate = Promise.withResolvers<void>();
+    requestJsonRpc.mockImplementationOnce(async () => {
+      await createGate.promise;
+      throw new Error("stale failure");
+    });
+
+    const pending = actions.startTask({
+      workspaceId: "ws-1",
+      task: taskCreationInput(),
+      draftRevision: submittedDraft.revision,
+    });
+    actions.setTaskCreationDraft({ title: "New task" });
+    createGate.resolve();
+
+    await expect(pending).resolves.toBeNull();
+    expect(harness.state.taskCreationDraft.title).toBe("New task");
+    expect(harness.state.taskCreationDraft.revision).toBe(submittedDraft.revision + 1);
+    expect(harness.state.taskCreationError).toBeNull();
   });
 
   test("creates an explicit task thread without replacing standard chat", async () => {
@@ -408,12 +538,54 @@ describe("desktop task actions", () => {
       name: "Chat",
       workspaceKind: "oneOffChat",
     };
+    harness.state.threads[0] = {
+      ...harness.state.threads[0],
+      sessionId: "source-session-1",
+    };
     const actions = createTaskActions(harness.set as never, harness.get as never, deps);
     Object.assign(harness.state, actions);
     await actions.refreshTasks("ws-1");
+    recordThreadNavigationIntent("chat-1");
 
     const created = taskRecord({
       context: "Structured handoff",
+      sourceSessionId: "source-session-1",
+      creationOrigin: "chat_tool",
+    });
+    notificationRouter?.({
+      kind: "notification",
+      method: "task/created",
+      params: {
+        cwd: "c:/users/max/projects/demo",
+        task: created,
+        sourceSessionId: "source-session-1",
+        takeover: true,
+        workspaceDisposition: "promote_one_off",
+      },
+    });
+
+    expect(harness.state.workspaces[0]?.workspaceKind).toBe("project");
+    expect(harness.state.workspaces[0]?.name).toBe("Implement task mode");
+    expect(harness.state.view).toBe("task");
+    expect(harness.state.selectedTaskId).toBe("task-1");
+    expect(harness.state.selectedThreadId).toBe("task-session-1");
+  });
+
+  test("task/created production notification preserves an expired source-chat intent", async () => {
+    const harness = createHarness();
+    const actions = createTaskActions(harness.set as never, harness.get as never, deps);
+    Object.assign(harness.state, actions);
+    await actions.refreshTasks("ws-1");
+    recordThreadNavigationIntent("chat-1");
+
+    invalidateNavigationIntent();
+    harness.state.view = "settings";
+    harness.state.selectedThreadId = null;
+    invalidateNavigationIntent();
+    harness.state.view = "chat";
+    harness.state.selectedThreadId = "chat-1";
+
+    const created = taskRecord({
       sourceSessionId: "chat-1",
       creationOrigin: "chat_tool",
     });
@@ -425,15 +597,15 @@ describe("desktop task actions", () => {
         task: created,
         sourceSessionId: "chat-1",
         takeover: true,
-        workspaceDisposition: "promote_one_off",
+        workspaceDisposition: "existing_project",
       },
     });
 
-    expect(harness.state.workspaces[0]?.workspaceKind).toBe("project");
-    expect(harness.state.workspaces[0]?.name).toBe("Implement task mode");
-    expect(harness.state.view).toBe("task");
-    expect(harness.state.selectedTaskId).toBe("task-1");
-    expect(harness.state.selectedThreadId).toBe("task-session-1");
+    expect(harness.state.tasksById["task-1"]?.title).toBe("Implement task mode");
+    expect(harness.state.view).toBe("chat");
+    expect(harness.state.selectedThreadId).toBe("chat-1");
+    expect(harness.state.selectedTaskId).toBeNull();
+    expect(harness.reconnectThread).not.toHaveBeenCalled();
   });
 
   test("accepts canonical task notifications for the same Windows workspace", async () => {

--- a/apps/desktop/test/task-mode-ui.test.tsx
+++ b/apps/desktop/test/task-mode-ui.test.tsx
@@ -3,6 +3,7 @@ import { act, createElement, StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 
 import type { TaskArtifactDetail, TaskQuestion, TaskRecord } from "../../../src/shared/tasks";
+import { createEmptyTaskCreationDraft } from "../src/app/creationDrafts";
 import { createTaskActions, type TaskActionDependencies } from "../src/app/store.actions/tasks";
 import type { SandboxApprovalPrompt } from "../src/app/types";
 import { setupJsdom } from "./jsdomHarness";
@@ -429,6 +430,67 @@ describe("desktop task mode UI", () => {
       expect(container.querySelector("#new-task-objective")).not.toBeNull();
       expect(container.querySelector("#new-task-context")).not.toBeNull();
 
+      await act(async () => root.unmount());
+    } finally {
+      harness.restore();
+    }
+  });
+
+  test.serial("Cancel immediately unlocks a task composer waiting on startup", async () => {
+    const harness = setupJsdom();
+    const startTask = mock(
+      async ({ signal }: { signal?: AbortSignal }) =>
+        await new Promise<null>((resolve) => {
+          if (signal?.aborted) {
+            resolve(null);
+            return;
+          }
+          signal?.addEventListener("abort", () => resolve(null), { once: true });
+        }),
+    );
+    try {
+      const container = harness.dom.window.document.getElementById("root");
+      if (!container) throw new Error("missing root");
+      const { NewTaskLanding } = await import("../src/ui/tasks/NewTaskLanding");
+      const root = createRoot(container);
+      resetStore(null);
+      useAppStore.setState({
+        taskCreationDraft: {
+          ...createEmptyTaskCreationDraft(3, "ws-1"),
+          title: "Keep this task brief",
+          objective: "Cancel startup without losing the form.",
+        },
+        taskCreationError: null,
+        startTask,
+      } as never);
+
+      await act(async () => root.render(createElement(NewTaskLanding)));
+      await act(async () => {
+        submitForm(harness, container.querySelector("form"));
+        await Promise.resolve();
+      });
+
+      const cancelButton = Array.from(container.querySelectorAll("button")).find(
+        (button) => button.textContent?.trim() === "Cancel",
+      );
+      expect(cancelButton).toBeDefined();
+      expect(container.querySelector("#new-task-title")?.hasAttribute("disabled")).toBe(true);
+
+      await act(async () => {
+        cancelButton?.click();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(
+        Array.from(container.querySelectorAll("button")).some(
+          (button) => button.textContent?.trim() === "Cancel",
+        ),
+      ).toBe(false);
+      expect(container.querySelector("#new-task-title")?.hasAttribute("disabled")).toBe(false);
+      expect((container.querySelector("#new-task-title") as HTMLInputElement | null)?.value).toBe(
+        "Keep this task brief",
+      );
       await act(async () => root.unmount());
     } finally {
       harness.restore();

--- a/apps/desktop/test/task-mode-ui.test.tsx
+++ b/apps/desktop/test/task-mode-ui.test.tsx
@@ -552,19 +552,21 @@ describe("desktop task mode UI", () => {
           await Promise.resolve();
         });
 
-        expect(startTask).toHaveBeenCalledWith({
-          workspaceId: "ws-2",
-          task: expect.objectContaining({
-            title: "Ship dashboard hardening",
-            workItems: [
-              expect.objectContaining({
-                key: "step-1",
-                title: "Implement the invariant",
-                expectedOutputs: ["Passing regression tests"],
-              }),
-            ],
+        expect(startTask).toHaveBeenCalledWith(
+          expect.objectContaining({
+            workspaceId: "ws-2",
+            task: expect.objectContaining({
+              title: "Ship dashboard hardening",
+              workItems: [
+                expect.objectContaining({
+                  key: "step-1",
+                  title: "Implement the invariant",
+                  expectedOutputs: ["Passing regression tests"],
+                }),
+              ],
+            }),
           }),
-        });
+        );
 
         await act(async () => root.unmount());
       } finally {
@@ -657,15 +659,17 @@ describe("desktop task mode UI", () => {
           submitForm(harness, container.querySelector("form"));
           await Promise.resolve();
         });
-        expect(startTask).toHaveBeenCalledWith({
-          workspaceId: "ws-1",
-          task: expect.objectContaining({
-            workItems: [
-              expect.objectContaining({ key: "step-1", dependsOn: [] }),
-              expect.objectContaining({ key: "step-3", dependsOn: ["step-1"] }),
-            ],
+        expect(startTask).toHaveBeenCalledWith(
+          expect.objectContaining({
+            workspaceId: "ws-1",
+            task: expect.objectContaining({
+              workItems: [
+                expect.objectContaining({ key: "step-1", dependsOn: [] }),
+                expect.objectContaining({ key: "step-3", dependsOn: ["step-1"] }),
+              ],
+            }),
           }),
-        });
+        );
 
         await act(async () => root.unmount());
       } finally {

--- a/apps/desktop/test/workspace-startup.test.ts
+++ b/apps/desktop/test/workspace-startup.test.ts
@@ -1,4 +1,8 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  composerDraftKeyForNewChatTarget,
+  createEmptyComposerDraft,
+} from "../src/app/composerDrafts";
 import type { SessionSnapshot } from "../src/app/types";
 import type { WorkspaceServerStatus } from "../src/lib/desktopApi";
 import { clearJsonRpcSocketOverride, setJsonRpcSocketOverride } from "./helpers/jsonRpcSocketMock";
@@ -187,6 +191,7 @@ const { useAppStore } = await import("../src/app/store");
 const { isSandboxApprovalThreadVisible } = await import("../src/app/sandboxApprovalVisibility");
 const { RUNTIME } = await import("../src/app/store.helpers");
 const { hydrateThreadSelection } = await import("../src/app/store.actions/thread");
+const { __internalOperationIntent } = await import("../src/app/store.helpers/operationIntent");
 
 const defaultProviderActions = {
   requestProviderCatalog: useAppStore.getState().requestProviderCatalog,
@@ -252,6 +257,20 @@ function seedCachedSnapshot(sessionId: string, text: string) {
   return snapshot;
 }
 
+function projectWorkspace(id: string) {
+  return {
+    id,
+    name: id,
+    path: `/tmp/${id}`,
+    workspaceKind: "project" as const,
+    createdAt: "2026-03-08T00:00:00.000Z",
+    lastOpenedAt: "2026-03-08T00:00:00.000Z",
+    defaultEnableMcp: true,
+    defaultBackupsEnabled: false,
+    yolo: false,
+  };
+}
+
 describe("workspace startup flow", () => {
   beforeEach(() => {
     setJsonRpcSocketOverride(MockJsonRpcSocket);
@@ -276,6 +295,7 @@ describe("workspace startup flow", () => {
     RUNTIME.modelStreamByThread.clear();
     RUNTIME.jsonRpcSockets.clear();
     RUNTIME.sessionSnapshots.clear();
+    __internalOperationIntent.reset();
     MockJsonRpcSocket.autoOpen = true;
 
     useAppStore.setState({
@@ -2066,6 +2086,265 @@ describe("workspace startup flow", () => {
     expect(state.view).toBe("chat");
     expect(state.selectedThreadId).toBe("draft-ws-1");
     expect(state.selectedTaskId).toBeNull();
+  });
+
+  test("a delayed chat finishes without leaving a newer Settings navigation", async () => {
+    const workspace = projectWorkspace("ws-create");
+    const target = { kind: "project" as const, workspaceId: workspace.id };
+    const draftKey = composerDraftKeyForNewChatTarget(target);
+    const draft = {
+      ...createEmptyComposerDraft("2026-03-08T09:00:00.000Z"),
+      revision: 1,
+      text: "Keep working in the background",
+    };
+    useAppStore.setState({
+      view: "chat",
+      lastNonSettingsView: "chat",
+      workspaces: [workspace],
+      threads: [],
+      selectedWorkspaceId: workspace.id,
+      selectedThreadId: null,
+      selectedTaskId: null,
+      workspaceRuntimeById: {},
+      threadRuntimeById: {},
+      newChatLandingTarget: target,
+      composerDraftsByKey: { [draftKey]: draft },
+      composerDraftRevisionFloorByKey: {},
+    });
+
+    const creation = useAppStore.getState().newThread({
+      scope: "project",
+      workspaceId: workspace.id,
+      mode: "session",
+      firstMessage: draft.text,
+      draftSubmission: { key: draftKey, revision: draft.revision },
+    });
+    await waitForCondition(() => startCalls.length === 1);
+
+    useAppStore.getState().openSettings("models");
+    startDeferreds[0]?.resolve({ url: "ws://create" });
+
+    await expect(creation).resolves.toBe(true);
+    const state = useAppStore.getState();
+    expect(state.view).toBe("settings");
+    expect(state.selectedThreadId).toBeNull();
+    expect(state.threads).toHaveLength(1);
+    expect(state.threads[0]?.title).toBe("New chat");
+  });
+
+  test("the newest overlapping chat creation alone owns navigation", async () => {
+    const firstWorkspace = projectWorkspace("ws-first");
+    const secondWorkspace = projectWorkspace("ws-second");
+    useAppStore.setState({
+      view: "chat",
+      lastNonSettingsView: "chat",
+      workspaces: [firstWorkspace, secondWorkspace],
+      threads: [],
+      selectedWorkspaceId: firstWorkspace.id,
+      selectedThreadId: null,
+      selectedTaskId: null,
+      workspaceRuntimeById: {},
+      threadRuntimeById: {},
+    });
+
+    const first = useAppStore.getState().newThread({
+      scope: "project",
+      workspaceId: firstWorkspace.id,
+      mode: "session",
+      titleHint: "First delayed chat",
+      firstMessage: "first",
+    });
+    await waitForCondition(() => startCalls.length === 1);
+    const second = useAppStore.getState().newThread({
+      scope: "project",
+      workspaceId: secondWorkspace.id,
+      mode: "session",
+      titleHint: "Second delayed chat",
+      firstMessage: "second",
+    });
+    await waitForCondition(() => startCalls.length === 2);
+
+    startDeferreds[1]?.resolve({ url: "ws://second" });
+    await expect(second).resolves.toBe(true);
+    const secondThreadId = useAppStore.getState().selectedThreadId;
+    expect(
+      useAppStore.getState().threads.find((thread) => thread.id === secondThreadId)?.title,
+    ).toBe("Second delayed chat");
+
+    startDeferreds[0]?.resolve({ url: "ws://first" });
+    await expect(first).resolves.toBe(true);
+    expect(useAppStore.getState().selectedThreadId).toBe(secondThreadId);
+    expect(
+      useAppStore
+        .getState()
+        .threads.map((thread) => thread.title)
+        .toSorted(),
+    ).toEqual(["First delayed chat", "Second delayed chat"]);
+  });
+
+  test("a successful chat creation still opens while its intent remains current", async () => {
+    const workspace = projectWorkspace("ws-current");
+    useAppStore.setState({
+      view: "chat",
+      workspaces: [workspace],
+      threads: [],
+      selectedWorkspaceId: workspace.id,
+      selectedThreadId: null,
+      selectedTaskId: null,
+      workspaceRuntimeById: {},
+      threadRuntimeById: {},
+    });
+
+    const creation = useAppStore.getState().newThread({
+      scope: "project",
+      workspaceId: workspace.id,
+      mode: "session",
+      firstMessage: "stay here",
+    });
+    await waitForCondition(() => startCalls.length === 1);
+    startDeferreds[0]?.resolve({ url: "ws://current" });
+
+    await expect(creation).resolves.toBe(true);
+    const state = useAppStore.getState();
+    expect(state.view).toBe("chat");
+    expect(state.selectedWorkspaceId).toBe(workspace.id);
+    expect(state.selectedThreadId).toBe(state.threads[0]?.id);
+  });
+
+  test("cancelling delayed startup preserves the exact submitted draft", async () => {
+    const workspace = projectWorkspace("ws-cancel-start");
+    const target = { kind: "project" as const, workspaceId: workspace.id };
+    const draftKey = composerDraftKeyForNewChatTarget(target);
+    const draft = {
+      ...createEmptyComposerDraft("2026-03-08T09:00:00.000Z"),
+      revision: 7,
+      text: "Do not lose this draft",
+    };
+    const controller = new AbortController();
+    useAppStore.setState({
+      view: "chat",
+      workspaces: [workspace],
+      threads: [],
+      selectedWorkspaceId: workspace.id,
+      selectedThreadId: null,
+      workspaceRuntimeById: {},
+      threadRuntimeById: {},
+      newChatLandingTarget: target,
+      composerDraftsByKey: { [draftKey]: draft },
+    });
+
+    const creation = useAppStore.getState().newThread({
+      scope: "project",
+      workspaceId: workspace.id,
+      mode: "session",
+      firstMessage: draft.text,
+      draftSubmission: { key: draftKey, revision: draft.revision },
+      signal: controller.signal,
+    });
+    await waitForCondition(() => startCalls.length === 1);
+    controller.abort();
+    startDeferreds[0]?.resolve({ url: "ws://cancelled" });
+
+    await expect(creation).resolves.toBe(false);
+    const state = useAppStore.getState();
+    expect(state.threads).toEqual([]);
+    expect(state.composerDraftsByKey[draftKey]).toEqual(draft);
+  });
+
+  test("cancelling attachment processing preserves the exact submitted draft", async () => {
+    const workspace = projectWorkspace("ws-cancel-attachment");
+    const target = { kind: "project" as const, workspaceId: workspace.id };
+    const draftKey = composerDraftKeyForNewChatTarget(target);
+    const draft = {
+      ...createEmptyComposerDraft("2026-03-08T09:00:00.000Z"),
+      revision: 9,
+      text: "Keep the attachment draft",
+    };
+    const attachmentRead = createDeferred<ArrayBuffer>();
+    let attachmentReadStarted = false;
+    const file = {
+      name: "notes.txt",
+      type: "text/plain",
+      size: 5,
+      lastModified: 1,
+      arrayBuffer: async () => {
+        attachmentReadStarted = true;
+        return await attachmentRead.promise;
+      },
+    } as File;
+    const controller = new AbortController();
+    useAppStore.setState({
+      view: "chat",
+      workspaces: [workspace],
+      threads: [],
+      selectedWorkspaceId: workspace.id,
+      selectedThreadId: null,
+      workspaceRuntimeById: {
+        [workspace.id]: {
+          serverUrl: "ws://ready",
+          error: null,
+          starting: false,
+        },
+      },
+      threadRuntimeById: {},
+      newChatLandingTarget: target,
+      composerDraftsByKey: { [draftKey]: draft },
+    } as never);
+
+    const creation = useAppStore.getState().newThread({
+      scope: "project",
+      workspaceId: workspace.id,
+      mode: "session",
+      firstMessage: draft.text,
+      attachmentFiles: [file],
+      draftSubmission: { key: draftKey, revision: draft.revision },
+      signal: controller.signal,
+    });
+    await waitForCondition(() => attachmentReadStarted);
+    controller.abort();
+    attachmentRead.resolve(new ArrayBuffer(5));
+
+    await expect(creation).resolves.toBe(false);
+    const state = useAppStore.getState();
+    expect(state.threads).toEqual([]);
+    expect(state.composerDraftsByKey[draftKey]).toEqual(draft);
+  });
+
+  test("startup failure preserves the exact submitted draft", async () => {
+    const workspace = projectWorkspace("ws-failure");
+    const target = { kind: "project" as const, workspaceId: workspace.id };
+    const draftKey = composerDraftKeyForNewChatTarget(target);
+    const draft = {
+      ...createEmptyComposerDraft("2026-03-08T09:00:00.000Z"),
+      revision: 11,
+      text: "Retry this exact request",
+    };
+    useAppStore.setState({
+      view: "chat",
+      workspaces: [workspace],
+      threads: [],
+      selectedWorkspaceId: workspace.id,
+      selectedThreadId: null,
+      workspaceRuntimeById: {},
+      threadRuntimeById: {},
+      newChatLandingTarget: target,
+      composerDraftsByKey: { [draftKey]: draft },
+    });
+
+    const creation = useAppStore.getState().newThread({
+      scope: "project",
+      workspaceId: workspace.id,
+      mode: "session",
+      firstMessage: draft.text,
+      draftSubmission: { key: draftKey, revision: draft.revision },
+    });
+    await waitForCondition(() => startCalls.length === 1);
+    startDeferreds[0]?.reject(new Error("server failed"));
+
+    await expect(creation).resolves.toBe(false);
+    const state = useAppStore.getState();
+    expect(state.threads).toEqual([]);
+    expect(state.composerDraftsByKey[draftKey]).toEqual(draft);
   });
 
   test("provider auth method refresh stays quiet while the control socket is still handshaking", async () => {

--- a/apps/desktop/test/workspace-startup.test.ts
+++ b/apps/desktop/test/workspace-startup.test.ts
@@ -2243,12 +2243,16 @@ describe("workspace startup flow", () => {
     });
     await waitForCondition(() => startCalls.length === 1);
     controller.abort();
-    startDeferreds[0]?.resolve({ url: "ws://cancelled" });
 
-    await expect(creation).resolves.toBe(false);
-    const state = useAppStore.getState();
-    expect(state.threads).toEqual([]);
-    expect(state.composerDraftsByKey[draftKey]).toEqual(draft);
+    const outcome = await Promise.race([creation, Bun.sleep(100).then(() => "timed-out" as const)]);
+    expect(outcome).toBe(false);
+    expect(useAppStore.getState().threads).toEqual([]);
+    expect(useAppStore.getState().composerDraftsByKey[draftKey]).toEqual(draft);
+
+    startDeferreds[0]?.resolve({ url: "ws://cancelled" });
+    await flushAsyncWork();
+    expect(useAppStore.getState().threads).toEqual([]);
+    expect(useAppStore.getState().composerDraftsByKey[draftKey]).toEqual(draft);
   });
 
   test("cancelling attachment processing preserves the exact submitted draft", async () => {
@@ -2302,12 +2306,16 @@ describe("workspace startup flow", () => {
     });
     await waitForCondition(() => attachmentReadStarted);
     controller.abort();
-    attachmentRead.resolve(new ArrayBuffer(5));
 
-    await expect(creation).resolves.toBe(false);
-    const state = useAppStore.getState();
-    expect(state.threads).toEqual([]);
-    expect(state.composerDraftsByKey[draftKey]).toEqual(draft);
+    const outcome = await Promise.race([creation, Bun.sleep(100).then(() => "timed-out" as const)]);
+    expect(outcome).toBe(false);
+    expect(useAppStore.getState().threads).toEqual([]);
+    expect(useAppStore.getState().composerDraftsByKey[draftKey]).toEqual(draft);
+
+    attachmentRead.resolve(new ArrayBuffer(5));
+    await flushAsyncWork();
+    expect(useAppStore.getState().threads).toEqual([]);
+    expect(useAppStore.getState().composerDraftsByKey[draftKey]).toEqual(draft);
   });
 
   test("startup failure preserves the exact submitted draft", async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #214.

Adds navigation-intent ownership and failure-safe creation across Chat, Research, and Task.

[navigation_intent_race_walkthrough.mp4](https://cursor.com/agents/bc-2fe1a13d-c977-4764-9f33-e0042e2eeb81/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnavigation_intent_race_walkthrough.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2fe1a13d-c977-4764-9f33-e0042e2eeb81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2fe1a13d-c977-4764-9f33-e0042e2eeb81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

