### PR TITLE
fix(chat): preserve desktop scroll ownership

### DIFF
--- a/apps/desktop/quality-gates/budgets.json
+++ b/apps/desktop/quality-gates/budgets.json
@@ -24,5 +24,10 @@
     "mountedFeedRows": 90,
     "reactCommits": 1800,
     "storePublications": 1000
+  },
+  "scrollOwnership": {
+    "anchorDriftPx": 1,
+    "appendMessagesMs": 1500,
+    "threadRoundTripMs": 1500
   }
 }

--- a/apps/desktop/quality-gates/specs/journeys.pw.ts
+++ b/apps/desktop/quality-gates/specs/journeys.pw.ts
@@ -4,6 +4,7 @@ import {
   assertNoViewportClipping,
   settleQualityPage,
 } from "../assertions";
+import budgets from "../budgets.json" with { type: "json" };
 import { expect, test } from "../fixtures";
 
 test.describe("first launch", () => {
@@ -131,28 +132,112 @@ test("resolves one queued interaction without disturbing its siblings", async ({
   ).toBeVisible();
 });
 
-test("switches through a draft chat and restores the conversation scroll anchor", async ({
+test("preserves detached transcript ownership and exact thread anchors", async ({
   quality,
-}) => {
+}, testInfo) => {
   const { page } = quality;
   await quality.emitLongTranscript(200, 0);
   const viewport = page.locator('[data-slot="message-scroller-viewport"]');
   await expect(page.getByText("Deterministic transcript run 0 message 200")).toBeAttached();
-  await viewport.evaluate((element) => {
-    element.scrollTop = 0;
+  await settleQualityPage(page);
+  const anchor = page.locator('[data-message-id="quality-long-0-150"]');
+  await expect(anchor).toBeAttached();
+  await anchor.evaluate((element) => {
+    const viewportElement = element.closest<HTMLElement>('[data-slot="message-scroller-viewport"]');
+    if (!viewportElement) throw new Error("Conversation viewport is unavailable");
+    const desiredOffset = 96;
+    viewportElement.scrollTop +=
+      element.getBoundingClientRect().top -
+      viewportElement.getBoundingClientRect().top -
+      desiredOffset;
+    viewportElement.dispatchEvent(new WheelEvent("wheel", { bubbles: true, deltaY: -80 }));
+    viewportElement.dispatchEvent(new Event("scroll", { bubbles: true }));
   });
+  await expect(viewport).toHaveAttribute("data-scroll-mode", "detached");
+  await settleQualityPage(page);
+  const before = await anchor.evaluate((element) => {
+    const viewportElement = element.closest<HTMLElement>('[data-slot="message-scroller-viewport"]');
+    if (!viewportElement) throw new Error("Conversation viewport is unavailable");
+    return {
+      offset: element.getBoundingClientRect().top - viewportElement.getBoundingClientRect().top,
+      scrollTop: viewportElement.scrollTop,
+    };
+  });
+
+  const appendStartedAt = performance.now();
+  await quality.emitLongTranscript(2, 1);
+  await expect(page.getByRole("button", { name: "2 new messages. Jump to latest" })).toBeVisible();
+  const appendElapsedMs = performance.now() - appendStartedAt;
+  const afterAppend = await anchor.evaluate((element) => {
+    const viewportElement = element.closest<HTMLElement>('[data-slot="message-scroller-viewport"]');
+    if (!viewportElement) throw new Error("Conversation viewport is unavailable");
+    return {
+      offset: element.getBoundingClientRect().top - viewportElement.getBoundingClientRect().top,
+      scrollTop: viewportElement.scrollTop,
+    };
+  });
+  expect(Math.abs(afterAppend.offset - before.offset)).toBeLessThanOrEqual(1);
 
   const composer = page.getByRole("combobox", { name: "Message input" });
   await composer.fill("Keep this controlled draft while switching chats.");
+  const navigationStartedAt = performance.now();
   await page.getByRole("button", { name: /^Controlled fixture draft / }).click();
   await expect(page.getByText("Disconnected", { exact: true })).toBeVisible();
   await expect(composer).toBeEditable();
 
   await page.getByRole("button", { name: /^Electron release review / }).click();
-  await expect(page.getByText("Deterministic transcript run 0 message 200")).toBeAttached();
+  await expect(anchor).toBeAttached();
   await expect
-    .poll(async () => await viewport.evaluate((element) => element.scrollTop))
-    .toBeGreaterThan(0);
+    .poll(
+      async () =>
+        await anchor.evaluate((element) => {
+          const viewportElement = element.closest<HTMLElement>(
+            '[data-slot="message-scroller-viewport"]',
+          );
+          if (!viewportElement) throw new Error("Conversation viewport is unavailable");
+          return Math.round(
+            element.getBoundingClientRect().top - viewportElement.getBoundingClientRect().top,
+          );
+        }),
+    )
+    .toBe(Math.round(before.offset));
+  const navigationElapsedMs = performance.now() - navigationStartedAt;
+  const restored = await anchor.evaluate((element) => {
+    const viewportElement = element.closest<HTMLElement>('[data-slot="message-scroller-viewport"]');
+    if (!viewportElement) throw new Error("Conversation viewport is unavailable");
+    return {
+      offset: element.getBoundingClientRect().top - viewportElement.getBoundingClientRect().top,
+      scrollTop: viewportElement.scrollTop,
+    };
+  });
+  const sample = {
+    anchorDriftAfterAppendPx: Math.abs(afterAppend.offset - before.offset),
+    anchorDriftAfterRestorePx: Math.abs(restored.offset - before.offset),
+    appendElapsedMs,
+    navigationElapsedMs,
+    scrollCompensationAfterAppendPx: Math.abs(afterAppend.scrollTop - before.scrollTop),
+  };
+  expect(sample.anchorDriftAfterAppendPx).toBeLessThanOrEqual(
+    budgets.scrollOwnership.anchorDriftPx,
+  );
+  expect(sample.anchorDriftAfterRestorePx).toBeLessThanOrEqual(
+    budgets.scrollOwnership.anchorDriftPx,
+  );
+  expect(sample.appendElapsedMs).toBeLessThanOrEqual(budgets.scrollOwnership.appendMessagesMs);
+  expect(sample.navigationElapsedMs).toBeLessThanOrEqual(budgets.scrollOwnership.threadRoundTripMs);
+  await testInfo.attach("scroll-ownership-performance", {
+    body: Buffer.from(
+      `${JSON.stringify(
+        {
+          budget: budgets.scrollOwnership,
+          sample,
+        },
+        null,
+        2,
+      )}\n`,
+    ),
+    contentType: "application/json",
+  });
 });
 
 test("covers persistent disconnect recovery, tool failures, and quick chat", async ({

--- a/apps/desktop/quality-gates/specs/journeys.pw.ts
+++ b/apps/desktop/quality-gates/specs/journeys.pw.ts
@@ -139,13 +139,16 @@ test("preserves detached transcript ownership and exact thread anchors", async (
   await quality.emitLongTranscript(200, 0);
   const viewport = page.locator('[data-slot="message-scroller-viewport"]');
   await expect(page.getByText("Deterministic transcript run 0 message 200")).toBeAttached();
+  const showOlderButton = page.locator('[data-slot="feed-window-spacer"] button');
+  await expect(showOlderButton).toBeVisible();
+  await showOlderButton.click();
   await settleQualityPage(page);
-  const anchor = page.locator('[data-message-id="quality-long-0-150"]');
+  const anchor = page.locator('[data-message-id="quality-long-0-1"]');
   await expect(anchor).toBeAttached();
   await anchor.evaluate((element) => {
     const viewportElement = element.closest<HTMLElement>('[data-slot="message-scroller-viewport"]');
     if (!viewportElement) throw new Error("Conversation viewport is unavailable");
-    const desiredOffset = 96;
+    const desiredOffset = -24;
     viewportElement.scrollTop +=
       element.getBoundingClientRect().top -
       viewportElement.getBoundingClientRect().top -
@@ -164,20 +167,6 @@ test("preserves detached transcript ownership and exact thread anchors", async (
     };
   });
 
-  const appendStartedAt = performance.now();
-  await quality.emitLongTranscript(2, 1);
-  await expect(page.getByRole("button", { name: "2 new messages. Jump to latest" })).toBeVisible();
-  const appendElapsedMs = performance.now() - appendStartedAt;
-  const afterAppend = await anchor.evaluate((element) => {
-    const viewportElement = element.closest<HTMLElement>('[data-slot="message-scroller-viewport"]');
-    if (!viewportElement) throw new Error("Conversation viewport is unavailable");
-    return {
-      offset: element.getBoundingClientRect().top - viewportElement.getBoundingClientRect().top,
-      scrollTop: viewportElement.scrollTop,
-    };
-  });
-  expect(Math.abs(afterAppend.offset - before.offset)).toBeLessThanOrEqual(1);
-
   const composer = page.getByRole("combobox", { name: "Message input" });
   await composer.fill("Keep this controlled draft while switching chats.");
   const navigationStartedAt = performance.now();
@@ -185,8 +174,12 @@ test("preserves detached transcript ownership and exact thread anchors", async (
   await expect(page.getByText("Disconnected", { exact: true })).toBeVisible();
   await expect(composer).toBeEditable();
 
+  const appendStartedAt = performance.now();
+  await quality.emitLongTranscript(3, 1);
+  const appendElapsedMs = performance.now() - appendStartedAt;
   await page.getByRole("button", { name: /^Electron release review / }).click();
   await expect(anchor).toBeAttached();
+  await expect(page.getByRole("button", { name: "3 new messages. Jump to latest" })).toBeVisible();
   await expect
     .poll(
       async () =>
@@ -211,16 +204,12 @@ test("preserves detached transcript ownership and exact thread anchors", async (
     };
   });
   const sample = {
-    anchorDriftAfterAppendPx: Math.abs(afterAppend.offset - before.offset),
-    anchorDriftAfterRestorePx: Math.abs(restored.offset - before.offset),
+    anchorDriftAfterAwayArrivalPx: Math.abs(restored.offset - before.offset),
     appendElapsedMs,
     navigationElapsedMs,
-    scrollCompensationAfterAppendPx: Math.abs(afterAppend.scrollTop - before.scrollTop),
+    scrollCompensationAfterAwayArrivalPx: Math.abs(restored.scrollTop - before.scrollTop),
   };
-  expect(sample.anchorDriftAfterAppendPx).toBeLessThanOrEqual(
-    budgets.scrollOwnership.anchorDriftPx,
-  );
-  expect(sample.anchorDriftAfterRestorePx).toBeLessThanOrEqual(
+  expect(sample.anchorDriftAfterAwayArrivalPx).toBeLessThanOrEqual(
     budgets.scrollOwnership.anchorDriftPx,
   );
   expect(sample.appendElapsedMs).toBeLessThanOrEqual(budgets.scrollOwnership.appendMessagesMs);

--- a/apps/desktop/src/ui/ChatView.tsx
+++ b/apps/desktop/src/ui/ChatView.tsx
@@ -37,6 +37,7 @@ import { ChatComposer } from "./chat/ChatComposer";
 import { ChatFeed, type VisibleInteraction } from "./chat/ChatFeed";
 import { ChatViewContext } from "./chat/ChatViewContext";
 import { isChatProviderName } from "./chat/ComposerModelSelector";
+import { resolveChatBottomOffset } from "./chat/chatBottomOffset";
 import {
   composerBusyHint,
   countActiveChildAgents,
@@ -217,7 +218,7 @@ export function ChatView({ readOnlyNotice }: ChatViewProps = {}) {
   overflowCitationSourcesRef.current = overflowCitationSourcesByMessageId;
   const [cancelScopeDialogOpen, setCancelScopeDialogOpen] = useState(false);
   const [attachmentPickerErrors, setAttachmentPickerErrors] = useState<Record<string, string>>({});
-  const [composerOverlayHeight, setComposerOverlayHeight] = useState(composerOverlayMinHeight);
+  const [transcriptBottomOffset, setTranscriptBottomOffset] = useState(composerOverlayMinHeight);
   const attachmentPickerError = attachmentPickerErrors[composerDraftKey] ?? null;
   const preparingAttachments = composerSubmission?.phase === "preparing";
   const setAttachmentPickerError = useCallback(
@@ -288,17 +289,24 @@ export function ChatView({ readOnlyNotice }: ChatViewProps = {}) {
   }, []);
   useLayoutEffect(() => {
     const el = messageBarOverlayElement;
-    if (!el) {
-      // Source-task lock bar is in-flow (not absolute), so the feed must not
-      // also reserve overlay space — that double-counts bottom chrome.
-      setComposerOverlayHeight(sourceTask && !readOnlyNotice ? 0 : composerOverlayMinHeight);
+    const chrome = sourceTask && !readOnlyNotice ? "in-flow" : "overlay";
+    if (chrome === "in-flow" || !el) {
+      setTranscriptBottomOffset(
+        resolveChatBottomOffset({
+          chrome,
+          minimumOverlayHeight: composerOverlayMinHeight,
+        }),
+      );
       return;
     }
 
     const updateHeight = () => {
-      const measuredHeight = Math.ceil(el.getBoundingClientRect().height);
-      const nextHeight = Math.max(composerOverlayMinHeight, measuredHeight);
-      setComposerOverlayHeight((current) => (current === nextHeight ? current : nextHeight));
+      const nextHeight = resolveChatBottomOffset({
+        chrome,
+        measuredOverlayHeight: el.getBoundingClientRect().height,
+        minimumOverlayHeight: composerOverlayMinHeight,
+      });
+      setTranscriptBottomOffset((current) => (current === nextHeight ? current : nextHeight));
     };
 
     updateHeight();
@@ -801,7 +809,7 @@ export function ChatView({ readOnlyNotice }: ChatViewProps = {}) {
           citationUrlsByMessageId={citationUrlsByMessageId}
           citationSourcesByMessageId={citationSourcesByMessageId}
           desktopBasePath={workspace?.path ?? null}
-          composerOverlayHeight={composerOverlayHeight}
+          bottomOffset={transcriptBottomOffset}
           interactions={interactions}
           onAnswerAsk={answerAsk}
           onAnswerApproval={answerApproval}

--- a/apps/desktop/src/ui/ChatView.tsx
+++ b/apps/desktop/src/ui/ChatView.tsx
@@ -47,7 +47,11 @@ import {
 } from "./chat/chatLogic";
 import { HIDDEN_RETRY_TURN_PROMPT, isHiddenRetryTurnMessage } from "./chat/chatRetry";
 import { buildMentionCatalog, extractReferencesFromText } from "./chat/composerMentions";
-import { selectFeedDerivationWindow } from "./chat/feedWindow";
+import {
+  type FeedDerivationWindowState,
+  resolveFeedDerivationVisibleCount,
+  selectFeedDerivationWindow,
+} from "./chat/feedWindow";
 import { NewChatLanding } from "./chat/NewChatLanding";
 import { loadOverflowCitationContext } from "./chat/overflowCitationContext";
 import { normalizeFeedForToolCards } from "./chat/toolCards/legacyToolLogs";
@@ -235,10 +239,9 @@ export function ChatView({ readOnlyNotice }: ChatViewProps = {}) {
     },
     [composerDraftKey],
   );
-  const [feedDerivationWindow, setFeedDerivationWindow] = useState({
-    threadId: selectedThreadId,
-    visibleCount: FEED_DERIVATION_WINDOW,
-  });
+  const [feedDerivationWindows, setFeedDerivationWindows] = useState<
+    Map<string, FeedDerivationWindowState>
+  >(() => new Map());
 
   const pendingTurnStart = rt?.pendingTurnStart ?? null;
   const isUploading =
@@ -362,10 +365,14 @@ export function ChatView({ readOnlyNotice }: ChatViewProps = {}) {
   );
 
   const feed = rt?.feed ?? [];
-  const feedDerivationVisibleCount =
-    feedDerivationWindow.threadId === selectedThreadId
-      ? feedDerivationWindow.visibleCount
-      : FEED_DERIVATION_WINDOW;
+  const savedFeedDerivationWindow = selectedThreadId
+    ? feedDerivationWindows.get(selectedThreadId)
+    : undefined;
+  const feedDerivationVisibleCount = resolveFeedDerivationVisibleCount(
+    savedFeedDerivationWindow,
+    feed.length,
+    FEED_DERIVATION_WINDOW,
+  );
   const windowedSourceFeed = useMemo(
     () => selectFeedDerivationWindow(feed, feedDerivationVisibleCount),
     [feed, feedDerivationVisibleCount],
@@ -376,17 +383,29 @@ export function ChatView({ readOnlyNotice }: ChatViewProps = {}) {
     windowedSourceFeed.feed.length,
   );
   const expandOlderFeed = useCallback(() => {
-    setFeedDerivationWindow((current) => {
-      const currentVisibleCount =
-        current.threadId === selectedThreadId ? current.visibleCount : FEED_DERIVATION_WINDOW;
-      return {
-        threadId: selectedThreadId,
-        visibleCount: Math.min(feed.length, currentVisibleCount + FEED_DERIVATION_EXPAND_BATCH),
-      };
+    if (!selectedThreadId) return;
+    setFeedDerivationWindows((current) => {
+      const next = new Map(current);
+      next.set(selectedThreadId, {
+        feedLength: feed.length,
+        visibleCount: Math.min(
+          feed.length,
+          feedDerivationVisibleCount + FEED_DERIVATION_EXPAND_BATCH,
+        ),
+      });
+      return next;
     });
-  }, [feed.length, selectedThreadId]);
+  }, [feed.length, feedDerivationVisibleCount, selectedThreadId]);
   const showAllOlderFeed = useCallback(() => {
-    setFeedDerivationWindow({ threadId: selectedThreadId, visibleCount: feed.length });
+    if (!selectedThreadId) return;
+    setFeedDerivationWindows((current) => {
+      const next = new Map(current);
+      next.set(selectedThreadId, {
+        feedLength: feed.length,
+        visibleCount: feed.length,
+      });
+      return next;
+    });
   }, [feed.length, selectedThreadId]);
   const normalizedFeed = useMemo(
     () => normalizeFeedForToolCards(windowedSourceFeed.feed, developerMode),

--- a/apps/desktop/src/ui/chat/ActivityGroupCard.tsx
+++ b/apps/desktop/src/ui/chat/ActivityGroupCard.tsx
@@ -1,5 +1,6 @@
 import {
   AlertTriangleIcon,
+  ArrowDownIcon,
   ChevronDownIcon,
   ChevronRightIcon,
   ClockIcon,
@@ -13,8 +14,8 @@ import {
   WrenchIcon,
   XCircleIcon,
 } from "lucide-react";
-import type { ReactNode } from "react";
-import { memo, useEffect, useMemo, useRef, useState } from "react";
+import type { ReactNode, WheelEvent } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ToolFeedState } from "../../app/types";
 import { Badge } from "../../components/ui/badge";
 import { Button } from "../../components/ui/button";
@@ -35,6 +36,14 @@ import {
   formatActivityElapsedMs,
   summarizeActivityGroup,
 } from "./activityGroups";
+import {
+  captureScrollAnchor,
+  countNewIds,
+  isNearScrollEnd,
+  restoreScrollAnchor,
+  type ScrollAnchorPosition,
+  scrollViewportToEnd,
+} from "./scrollOwnership";
 import { formatToolCard } from "./toolCards/toolCardFormatting";
 
 /* ── Small helpers ──────────────────────────────────────────────────────────── */
@@ -99,6 +108,7 @@ function TimelineNode({
 }
 
 type ReasoningSection = {
+  id: string;
   title: string;
   body: string;
 };
@@ -122,10 +132,17 @@ function parseReasoningSections(text: string): ReasoningSection[] {
   }
 
   if (matches.length === 0) {
-    return [{ title: "", body: normalized }];
+    return [{ id: "body:0", title: "", body: normalized }];
   }
 
   const sections: ReasoningSection[] = [];
+  if (matches[0].index > 0) {
+    const leadingBody = normalized.slice(0, matches[0].index).trim();
+    if (leadingBody) {
+      sections.push({ id: "section:0", title: "", body: leadingBody });
+    }
+  }
+
   for (let i = 0; i < matches.length; i++) {
     const currentMatch = matches[i];
     const nextMatch = matches[i + 1];
@@ -135,35 +152,27 @@ function parseReasoningSections(text: string): ReasoningSection[] {
     const body = normalized.slice(contentStart, contentEnd).trim();
 
     sections.push({
+      id: `section:${sections.length}`,
       title: currentMatch.title,
       body,
     });
-  }
-
-  if (matches[0].index > 0) {
-    const leadingBody = normalized.slice(0, matches[0].index).trim();
-    if (leadingBody) {
-      sections.unshift({ title: "", body: leadingBody });
-    }
   }
 
   return sections;
 }
 
 function ReasoningSectionNode({
+  disclosureId,
   title,
   body,
   isMostRecent,
 }: {
+  disclosureId: string;
   title: string;
   body: string;
   isMostRecent: boolean;
 }) {
   const [open, setOpen] = useState(isMostRecent);
-
-  useEffect(() => {
-    setOpen(isMostRecent);
-  }, [isMostRecent]);
 
   if (!title) {
     return (
@@ -180,7 +189,9 @@ function ReasoningSectionNode({
     <div className="min-w-0 py-1 border-b border-border/12 last:border-b-0 pb-3 last:pb-0 mb-2.5 last:mb-0">
       <button
         type="button"
-        onClick={() => setOpen(!open)}
+        aria-controls={disclosureId}
+        aria-expanded={open}
+        onClick={() => setOpen((current) => !current)}
         className="flex items-center gap-1.5 text-left text-[13px] font-medium text-foreground outline-none hover:text-foreground/80"
       >
         <span>{title}</span>
@@ -192,7 +203,10 @@ function ReasoningSectionNode({
         />
       </button>
       {open && body && (
-        <div className="mt-1.5 text-[12.5px] leading-relaxed text-muted-foreground/80 pl-0.5 select-text">
+        <div
+          id={disclosureId}
+          className="mt-1.5 text-[12.5px] leading-relaxed text-muted-foreground/80 pl-0.5 select-text"
+        >
           <DesktopMarkdown normalizeDisplayCitations className="prose-sm leading-relaxed">
             {body}
           </DesktopMarkdown>
@@ -203,11 +217,13 @@ function ReasoningSectionNode({
 }
 
 function ReasoningTimelineNode({
+  sourceId,
   text,
   isLast,
   live,
   isMostRecent,
 }: {
+  sourceId: string;
   text: string;
   isLast: boolean;
   live?: boolean;
@@ -237,7 +253,8 @@ function ReasoningTimelineNode({
           const isSectionMostRecent = live ? isMostRecent && idx === sections.length - 1 : true;
           return (
             <ReasoningSectionNode
-              key={`${section.title || "reasoning"}-${section.body.slice(0, 32)}`}
+              key={`${sourceId}:${section.id}`}
+              disclosureId={`activity-reasoning-${encodeURIComponent(sourceId)}-${encodeURIComponent(section.id)}`}
               title={section.title}
               body={section.body}
               isMostRecent={isSectionMostRecent}
@@ -284,9 +301,14 @@ function ToolTimelineNode({
     item.state === "output-error" ||
     item.state === "output-denied";
   const [open, setOpen] = useState(shouldAutoExpand && hasDetails);
+  const userToggledRef = useRef(false);
+  const handleOpenChange = (nextOpen: boolean) => {
+    userToggledRef.current = true;
+    setOpen(nextOpen);
+  };
 
   useEffect(() => {
-    if (shouldAutoExpand && hasDetails) {
+    if (!userToggledRef.current && shouldAutoExpand && hasDetails) {
       setOpen(true);
     }
   }, [hasDetails, shouldAutoExpand]);
@@ -299,7 +321,7 @@ function ToolTimelineNode({
       isLast={isLast}
     >
       {hasDetails ? (
-        <Collapsible open={open} onOpenChange={setOpen}>
+        <Collapsible open={open} onOpenChange={handleOpenChange}>
           <CollapsibleTrigger className="group/tool-row flex w-full min-w-0 items-start gap-1.5 rounded-md py-0.5 text-left outline-none hover:bg-muted/20 focus-visible:ring-1 focus-visible:ring-ring/40">
             <div className="min-w-0 flex-1">
               <div className="flex items-center gap-1.5">
@@ -412,24 +434,96 @@ function ToolTimelineNode({
 
 function ActivityTimeline({ summary, live }: { summary: ActivityGroupSummary; live?: boolean }) {
   const containerRef = useRef<HTMLDivElement | null>(null);
-  const stickToBottomRef = useRef(true);
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  const [following, setFollowing] = useState(true);
+  const [newActivityCount, setNewActivityCount] = useState(0);
+  const followingRef = useRef(following);
+  const anchorRef = useRef<ScrollAnchorPosition | null>(null);
+  const entryIds = useMemo(() => summary.entries.map((entry) => entry.item.id), [summary.entries]);
+  const previousEntryIdsRef = useRef(entryIds);
+  followingRef.current = following;
 
-  useEffect(() => {
+  const setFollowTail = useCallback((nextFollowing: boolean) => {
+    followingRef.current = nextFollowing;
+    setFollowing(nextFollowing);
+  }, []);
+
+  const captureAnchor = useCallback(() => {
     const node = containerRef.current;
-    if (!node) return;
-    const onScroll = () => {
-      const distanceFromBottom = node.scrollHeight - node.scrollTop - node.clientHeight;
-      stickToBottomRef.current = distanceFromBottom < 48;
-    };
-    node.addEventListener("scroll", onScroll, { passive: true });
-    return () => node.removeEventListener("scroll", onScroll);
+    const content = contentRef.current;
+    if (!node || !content) return;
+    anchorRef.current = captureScrollAnchor(node, content);
   }, []);
 
   useEffect(() => {
-    if (!live || !containerRef.current || !summary) return;
-    if (!stickToBottomRef.current) return;
-    containerRef.current.scrollTop = containerRef.current.scrollHeight;
-  }, [live, summary]);
+    const addedCount = countNewIds(previousEntryIdsRef.current, entryIds);
+    previousEntryIdsRef.current = entryIds;
+    if (!followingRef.current && addedCount > 0) {
+      setNewActivityCount((current) => current + addedCount);
+    }
+    if (!live || !followingRef.current || !containerRef.current) return;
+    scrollViewportToEnd(containerRef.current);
+  }, [entryIds, live]);
+
+  useEffect(() => {
+    const content = contentRef.current;
+    if (!content || typeof ResizeObserver === "undefined") return;
+    let resizeFrame: number | null = null;
+    const observer = new ResizeObserver(() => {
+      if (resizeFrame !== null) window.cancelAnimationFrame(resizeFrame);
+      resizeFrame = window.requestAnimationFrame(() => {
+        resizeFrame = null;
+        const node = containerRef.current;
+        const currentContent = contentRef.current;
+        if (!node || !currentContent) return;
+        if (followingRef.current) {
+          scrollViewportToEnd(node);
+          return;
+        }
+        const anchor = anchorRef.current;
+        if (anchor) {
+          restoreScrollAnchor(node, currentContent, anchor);
+          captureAnchor();
+        }
+      });
+    });
+    observer.observe(content);
+    return () => {
+      if (resizeFrame !== null) window.cancelAnimationFrame(resizeFrame);
+      observer.disconnect();
+    };
+  }, [captureAnchor]);
+
+  const handleScroll = useCallback(() => {
+    const node = containerRef.current;
+    if (!node) return;
+    if (isNearScrollEnd(node)) {
+      setFollowTail(true);
+      setNewActivityCount(0);
+    } else {
+      setFollowTail(false);
+      captureAnchor();
+    }
+  }, [captureAnchor, setFollowTail]);
+
+  const handleWheel = useCallback(
+    (event: WheelEvent<HTMLDivElement>) => {
+      if (event.deltaY < 0) {
+        setFollowTail(false);
+        captureAnchor();
+      }
+    },
+    [captureAnchor, setFollowTail],
+  );
+
+  const jumpToLatest = useCallback(() => {
+    const node = containerRef.current;
+    if (!node) return;
+    scrollViewportToEnd(node);
+    setFollowTail(true);
+    setNewActivityCount(0);
+    anchorRef.current = null;
+  }, [setFollowTail]);
 
   const lastReasoningEntryId = useMemo(() => {
     const reasoningEntries = summary.entries.filter((e) => e.kind === "reasoning");
@@ -442,34 +536,73 @@ function ActivityTimeline({ summary, live }: { summary: ActivityGroupSummary; li
   );
 
   return (
-    <div ref={containerRef} className="max-h-[26rem] overflow-y-auto pr-0.5">
-      {summary.entries.map((entry, i) => {
-        const isLast = i === summary.entries.length - 1;
+    <div className="relative">
+      <div
+        ref={containerRef}
+        data-slot="activity-timeline-viewport"
+        className="max-h-[26rem] overflow-y-auto pr-0.5 [overflow-anchor:none]"
+        onScroll={handleScroll}
+        onWheel={handleWheel}
+      >
+        <div ref={contentRef} data-slot="activity-timeline-content">
+          {summary.entries.map((entry, i) => {
+            const isLast = i === summary.entries.length - 1;
 
-        if (entry.kind === "reasoning") {
-          const isMostRecent = entry.item.id === lastReasoningEntryId;
-          return (
-            <div key={entry.item.id} data-activity-entry-kind="reasoning">
-              <ReasoningTimelineNode
-                text={entry.item.text}
-                isLast={isLast}
-                live={live}
-                isMostRecent={isMostRecent}
-              />
-            </div>
-          );
-        }
+            if (entry.kind === "reasoning") {
+              const isMostRecent = entry.item.id === lastReasoningEntryId;
+              return (
+                <div
+                  key={entry.item.id}
+                  data-activity-entry-kind="reasoning"
+                  data-scroll-anchor-id={entry.item.id}
+                >
+                  <ReasoningTimelineNode
+                    sourceId={entry.item.id}
+                    text={entry.item.text}
+                    isLast={isLast}
+                    live={live}
+                    isMostRecent={isMostRecent}
+                  />
+                </div>
+              );
+            }
 
-        return (
-          <div key={entry.item.id} data-activity-entry-kind="tool">
-            <ToolTimelineNode
-              item={entry.item}
-              isLast={isLast}
-              recovered={recoveredToolIds.has(entry.item.id)}
-            />
-          </div>
-        );
-      })}
+            return (
+              <div
+                key={entry.item.id}
+                data-activity-entry-kind="tool"
+                data-scroll-anchor-id={entry.item.id}
+              >
+                <ToolTimelineNode
+                  item={entry.item}
+                  isLast={isLast}
+                  recovered={recoveredToolIds.has(entry.item.id)}
+                />
+              </div>
+            );
+          })}
+        </div>
+      </div>
+      {!following ? (
+        <Button
+          type="button"
+          variant="secondary"
+          size="xs"
+          className="absolute bottom-2 left-1/2 -translate-x-1/2 gap-1.5 border border-border bg-background shadow-sm"
+          aria-label={
+            newActivityCount > 0
+              ? `${newActivityCount} new ${newActivityCount === 1 ? "activity" : "activities"}. Jump to latest`
+              : "Jump to latest activity"
+          }
+          aria-live="polite"
+          onClick={jumpToLatest}
+        >
+          <ArrowDownIcon data-icon="inline-start" />
+          {newActivityCount > 0
+            ? `${newActivityCount} new ${newActivityCount === 1 ? "activity" : "activities"}`
+            : "Jump to latest"}
+        </Button>
+      ) : null}
     </div>
   );
 }
@@ -542,7 +675,7 @@ export const ActivityGroupCard = memo(function ActivityGroupCard(props: {
   };
 
   useEffect(() => {
-    if (shouldAutoExpand) {
+    if (!userToggledRef.current && shouldAutoExpand) {
       setExpanded(true);
     }
     // Do not auto-collapse on complete — users often want the audit trail.

--- a/apps/desktop/src/ui/chat/ChatFeed.tsx
+++ b/apps/desktop/src/ui/chat/ChatFeed.tsx
@@ -188,7 +188,9 @@ function DaySeparatorRow(props: { label: string }) {
 type TranscriptScrollMode = "anchored" | "detached" | "following";
 
 type TranscriptScrollSnapshot = {
+  itemIds: string[];
   mode: TranscriptScrollMode;
+  newMessageCount: number;
   position: ScrollAnchorPosition | null;
 };
 
@@ -218,21 +220,33 @@ function TranscriptScroller(props: {
   const viewportRef = useRef<HTMLDivElement | null>(null);
   const contentRef = useRef<HTMLDivElement | null>(null);
   const initialSnapshot = memory.get(threadId);
+  const initialNewMessageCount =
+    initialSnapshot?.mode === "detached"
+      ? initialSnapshot.newMessageCount + countNewIds(initialSnapshot.itemIds, itemIds)
+      : 0;
   const [mode, setMode] = useState<TranscriptScrollMode>(
     () => initialSnapshot?.mode ?? "following",
   );
-  const [newMessageCount, setNewMessageCount] = useState(0);
+  const [newMessageCount, setNewMessageCount] = useState(initialNewMessageCount);
   const modeRef = useRef(mode);
+  const newMessageCountRef = useRef(initialNewMessageCount);
   const restoredRef = useRef(false);
   const previousItemIdsRef = useRef(itemIds);
+  const currentItemIdsRef = useRef(itemIds);
   const previousLastUserTurnIdRef = useRef(lastUserTurnId);
   const programmaticScrollRef = useRef(false);
   const clearProgrammaticFrameRef = useRef<number | null>(null);
   modeRef.current = mode;
+  currentItemIdsRef.current = itemIds;
 
   const setScrollMode = useCallback((nextMode: TranscriptScrollMode) => {
     modeRef.current = nextMode;
     setMode(nextMode);
+  }, []);
+
+  const setUnreadCount = useCallback((nextCount: number) => {
+    newMessageCountRef.current = nextCount;
+    setNewMessageCount(nextCount);
   }, []);
 
   const markProgrammaticScroll = useCallback(() => {
@@ -251,7 +265,9 @@ function TranscriptScroller(props: {
     const content = contentRef.current;
     if (!viewport || !content || !restoredRef.current) return;
     memory.set(threadId, {
+      itemIds: [...currentItemIdsRef.current],
       mode: modeRef.current,
+      newMessageCount: newMessageCountRef.current,
       position: captureScrollAnchor(viewport, content),
     });
   }, [memory, threadId]);
@@ -273,9 +289,9 @@ function TranscriptScroller(props: {
     markProgrammaticScroll();
     scrollViewportToEnd(viewport);
     setScrollMode("following");
-    setNewMessageCount(0);
+    setUnreadCount(0);
     persistSnapshot();
-  }, [markProgrammaticScroll, persistSnapshot, setScrollMode]);
+  }, [markProgrammaticScroll, persistSnapshot, setScrollMode, setUnreadCount]);
 
   useLayoutEffect(() => {
     if (hydrating || restoredRef.current) return;
@@ -376,12 +392,13 @@ function TranscriptScroller(props: {
     };
   }, [hydrating, markProgrammaticScroll, memory, persistSnapshot, restorePosition, threadId]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const previousIds = previousItemIdsRef.current;
     const addedCount = countNewIds(previousIds, itemIds);
     previousItemIdsRef.current = itemIds;
     if (addedCount > 0 && modeRef.current === "detached") {
-      setNewMessageCount((current) => current + addedCount);
+      setUnreadCount(newMessageCountRef.current + addedCount);
+      persistSnapshot();
     }
 
     const previousLastUserTurnId = previousLastUserTurnIdRef.current;
@@ -398,7 +415,7 @@ function TranscriptScroller(props: {
       });
       persistSnapshot();
     }
-  }, [itemIds, lastUserTurnId, persistSnapshot, restorePosition]);
+  }, [itemIds, lastUserTurnId, persistSnapshot, restorePosition, setUnreadCount]);
 
   const handleScroll = useCallback(
     (event: UIEvent<HTMLDivElement>) => {
@@ -406,7 +423,7 @@ function TranscriptScroller(props: {
       if (isNearScrollEnd(viewport)) {
         if (!programmaticScrollRef.current || modeRef.current === "following") {
           setScrollMode("following");
-          setNewMessageCount(0);
+          setUnreadCount(0);
         }
       } else if (!programmaticScrollRef.current && modeRef.current === "following") {
         setScrollMode("detached");
@@ -414,7 +431,7 @@ function TranscriptScroller(props: {
       persistSnapshot();
       onViewportScroll(event);
     },
-    [onViewportScroll, persistSnapshot, setScrollMode],
+    [onViewportScroll, persistSnapshot, setScrollMode, setUnreadCount],
   );
 
   const detachFromTail = useCallback(() => {

--- a/apps/desktop/src/ui/chat/ChatFeed.tsx
+++ b/apps/desktop/src/ui/chat/ChatFeed.tsx
@@ -1,5 +1,22 @@
-import { AlertTriangleIcon, LoaderCircleIcon, MessageSquareIcon } from "lucide-react";
-import { memo, type UIEvent, useCallback, useEffect, useMemo, useRef } from "react";
+import {
+  AlertTriangleIcon,
+  ArrowDownIcon,
+  LoaderCircleIcon,
+  MessageSquareIcon,
+} from "lucide-react";
+import {
+  type KeyboardEvent,
+  memo,
+  type ReactNode,
+  type UIEvent,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type WheelEvent,
+} from "react";
 import type { CitationSource } from "../../../../../src/shared/displayCitationMarkers";
 import type { ChatInteraction } from "../../app/types";
 import { Button } from "../../components/ui/button";
@@ -14,13 +31,10 @@ import {
 import { Marker, MarkerContent } from "../../components/ui/marker";
 import {
   MessageScroller,
-  MessageScrollerButton,
   MessageScrollerContent,
   MessageScrollerItem,
   MessageScrollerProvider,
   MessageScrollerViewport,
-  useMessageScroller,
-  useMessageScrollerVisibility,
 } from "../../components/ui/message-scroller";
 import { InlineErrorBoundary } from "../CrashReportingErrorBoundary";
 import { recordDesktopRenderMetric } from "../renderDiagnostics";
@@ -32,6 +46,14 @@ import {
 } from "./activityGroups";
 import { FeedRow } from "./FeedRow";
 import { InteractionCard } from "./InteractionCard";
+import {
+  captureScrollAnchor,
+  countNewIds,
+  isNearScrollEnd,
+  restoreScrollAnchor,
+  type ScrollAnchorPosition,
+  scrollViewportToEnd,
+} from "./scrollOwnership";
 
 const SCROLL_BUTTON_BOTTOM_GAP_PX = 9;
 /** Expand when within this many px of the top of the scrollable content. */
@@ -163,70 +185,315 @@ function DaySeparatorRow(props: { label: string }) {
   );
 }
 
-function InitialTurnRestore({
-  messageId,
-  threadId,
-  hydrating,
-}: {
-  messageId: string | null;
-  threadId?: string | null;
-  hydrating: boolean;
-}) {
-  const { scrollToMessage } = useMessageScroller();
-  const visibility = useMessageScrollerVisibility();
-  const visibilityRef = useRef(visibility);
-  visibilityRef.current = visibility;
-  // Only restore scroll once per thread open / hydrate cycle — not on every new user turn.
-  const restoredForKeyRef = useRef<string | null>(null);
+type TranscriptScrollMode = "anchored" | "detached" | "following";
 
-  useEffect(() => {
-    if (!messageId || hydrating) return;
-    const restoreKey = `${threadId ?? "no-thread"}:${messageId}`;
-    if (restoredForKeyRef.current === restoreKey) return;
-    // First restore for this thread id, or first restore after hydrate completed.
-    const threadKey = threadId ?? "no-thread";
-    const alreadyRestoredThread = restoredForKeyRef.current?.startsWith(`${threadKey}:`);
-    if (alreadyRestoredThread && restoredForKeyRef.current !== null) {
-      // A later user turn while already open — let autoScroll own the viewport.
+type TranscriptScrollSnapshot = {
+  mode: TranscriptScrollMode;
+  position: ScrollAnchorPosition | null;
+};
+
+const TRANSCRIPT_RESTORE_OFFSET_PX = 64;
+const DETACH_KEYS = new Set(["ArrowUp", "Home", "PageUp"]);
+
+function TranscriptScroller(props: {
+  bottomOffset: number;
+  children: ReactNode;
+  hydrating: boolean;
+  itemIds: string[];
+  lastUserTurnId: string | null;
+  memory: Map<string, TranscriptScrollSnapshot>;
+  onViewportScroll: (event: UIEvent<HTMLDivElement>) => void;
+  threadId: string;
+}) {
+  const {
+    bottomOffset,
+    children,
+    hydrating,
+    itemIds,
+    lastUserTurnId,
+    memory,
+    onViewportScroll,
+    threadId,
+  } = props;
+  const viewportRef = useRef<HTMLDivElement | null>(null);
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  const initialSnapshot = memory.get(threadId);
+  const [mode, setMode] = useState<TranscriptScrollMode>(
+    () => initialSnapshot?.mode ?? "following",
+  );
+  const [newMessageCount, setNewMessageCount] = useState(0);
+  const modeRef = useRef(mode);
+  const restoredRef = useRef(false);
+  const previousItemIdsRef = useRef(itemIds);
+  const previousLastUserTurnIdRef = useRef(lastUserTurnId);
+  const programmaticScrollRef = useRef(false);
+  const clearProgrammaticFrameRef = useRef<number | null>(null);
+  modeRef.current = mode;
+
+  const setScrollMode = useCallback((nextMode: TranscriptScrollMode) => {
+    modeRef.current = nextMode;
+    setMode(nextMode);
+  }, []);
+
+  const markProgrammaticScroll = useCallback(() => {
+    programmaticScrollRef.current = true;
+    if (clearProgrammaticFrameRef.current !== null) {
+      window.cancelAnimationFrame(clearProgrammaticFrameRef.current);
+    }
+    clearProgrammaticFrameRef.current = window.requestAnimationFrame(() => {
+      clearProgrammaticFrameRef.current = null;
+      programmaticScrollRef.current = false;
+    });
+  }, []);
+
+  const persistSnapshot = useCallback(() => {
+    const viewport = viewportRef.current;
+    const content = contentRef.current;
+    if (!viewport || !content || !restoredRef.current) return;
+    memory.set(threadId, {
+      mode: modeRef.current,
+      position: captureScrollAnchor(viewport, content),
+    });
+  }, [memory, threadId]);
+
+  const restorePosition = useCallback(
+    (position: ScrollAnchorPosition): boolean => {
+      const viewport = viewportRef.current;
+      const content = contentRef.current;
+      if (!viewport || !content) return false;
+      markProgrammaticScroll();
+      return restoreScrollAnchor(viewport, content, position);
+    },
+    [markProgrammaticScroll],
+  );
+
+  const jumpToLatest = useCallback(() => {
+    const viewport = viewportRef.current;
+    if (!viewport) return;
+    markProgrammaticScroll();
+    scrollViewportToEnd(viewport);
+    setScrollMode("following");
+    setNewMessageCount(0);
+    persistSnapshot();
+  }, [markProgrammaticScroll, persistSnapshot, setScrollMode]);
+
+  useLayoutEffect(() => {
+    if (hydrating || restoredRef.current) return;
+    const viewport = viewportRef.current;
+    const content = contentRef.current;
+    if (!viewport || !content) return;
+
+    const saved = memory.get(threadId);
+    let restored = false;
+    if (saved?.position) {
+      restored = restorePosition(saved.position);
+      if (restored) setScrollMode(saved.mode);
+    }
+    if (!restored && lastUserTurnId) {
+      restored = restorePosition({
+        anchorId: lastUserTurnId,
+        offset: TRANSCRIPT_RESTORE_OFFSET_PX,
+      });
+      if (restored) {
+        setScrollMode(isNearScrollEnd(viewport) ? "following" : "anchored");
+      }
+    }
+    if (!restored) {
+      markProgrammaticScroll();
+      scrollViewportToEnd(viewport);
+      setScrollMode("following");
+    }
+    restoredRef.current = true;
+    persistSnapshot();
+
+    // The shadcn primitive applies its default position in a parent layout
+    // effect. Reapply in the same browser task so the owned position wins
+    // before paint without a hydration-completion jump.
+    queueMicrotask(() => {
+      const current = memory.get(threadId)?.position;
+      if (current) restorePosition(current);
+    });
+  }, [
+    hydrating,
+    lastUserTurnId,
+    markProgrammaticScroll,
+    memory,
+    persistSnapshot,
+    restorePosition,
+    setScrollMode,
+    threadId,
+  ]);
+
+  useLayoutEffect(() => {
+    return () => {
+      persistSnapshot();
+      if (clearProgrammaticFrameRef.current !== null) {
+        window.cancelAnimationFrame(clearProgrammaticFrameRef.current);
+      }
+    };
+  }, [persistSnapshot]);
+
+  useLayoutEffect(() => {
+    if (
+      hydrating ||
+      itemIds.length === 0 ||
+      !restoredRef.current ||
+      modeRef.current === "following"
+    ) {
       return;
     }
-    let cancelled = false;
+    const saved = memory.get(threadId)?.position;
+    if (!saved) return;
+    restorePosition(saved);
+    persistSnapshot();
+  }, [hydrating, itemIds, memory, persistSnapshot, restorePosition, threadId]);
 
-    const nextFrame = () =>
-      new Promise<void>((resolve) => {
-        window.requestAnimationFrame(() => resolve());
+  useEffect(() => {
+    const content = contentRef.current;
+    if (!content || typeof ResizeObserver === "undefined") return;
+    let resizeFrame: number | null = null;
+    const observer = new ResizeObserver(() => {
+      if (resizeFrame !== null) window.cancelAnimationFrame(resizeFrame);
+      resizeFrame = window.requestAnimationFrame(() => {
+        resizeFrame = null;
+        if (!restoredRef.current || hydrating) return;
+        const viewport = viewportRef.current;
+        if (!viewport) return;
+        if (modeRef.current === "following") {
+          markProgrammaticScroll();
+          scrollViewportToEnd(viewport);
+        } else {
+          const saved = memory.get(threadId)?.position;
+          if (saved) restorePosition(saved);
+        }
+        persistSnapshot();
       });
-
-    const restoreAfterLayout = async () => {
-      try {
-        await document.fonts.ready;
-      } catch {
-        // Font readiness is only a layout hint; the frame checks below still apply.
-      }
-      await nextFrame();
-      await nextFrame();
-      if (cancelled) return;
-
-      const currentVisibility = visibilityRef.current;
-      if (currentVisibility.currentAnchorId === messageId) {
-        restoredForKeyRef.current = restoreKey;
-        return;
-      }
-      scrollToMessage(messageId, {
-        align: "start",
-        behavior: "auto",
-        scrollMargin: 64,
-      });
-      restoredForKeyRef.current = restoreKey;
-    };
-
-    void restoreAfterLayout();
+    });
+    observer.observe(content);
     return () => {
-      cancelled = true;
+      if (resizeFrame !== null) window.cancelAnimationFrame(resizeFrame);
+      observer.disconnect();
     };
-  }, [hydrating, messageId, scrollToMessage, threadId]);
+  }, [hydrating, markProgrammaticScroll, memory, persistSnapshot, restorePosition, threadId]);
 
-  return null;
+  useEffect(() => {
+    const previousIds = previousItemIdsRef.current;
+    const addedCount = countNewIds(previousIds, itemIds);
+    previousItemIdsRef.current = itemIds;
+    if (addedCount > 0 && modeRef.current === "detached") {
+      setNewMessageCount((current) => current + addedCount);
+    }
+
+    const previousLastUserTurnId = previousLastUserTurnIdRef.current;
+    previousLastUserTurnIdRef.current = lastUserTurnId;
+    if (
+      restoredRef.current &&
+      modeRef.current === "anchored" &&
+      lastUserTurnId &&
+      previousLastUserTurnId !== lastUserTurnId
+    ) {
+      restorePosition({
+        anchorId: lastUserTurnId,
+        offset: TRANSCRIPT_RESTORE_OFFSET_PX,
+      });
+      persistSnapshot();
+    }
+  }, [itemIds, lastUserTurnId, persistSnapshot, restorePosition]);
+
+  const handleScroll = useCallback(
+    (event: UIEvent<HTMLDivElement>) => {
+      const viewport = event.currentTarget;
+      if (isNearScrollEnd(viewport)) {
+        if (!programmaticScrollRef.current || modeRef.current === "following") {
+          setScrollMode("following");
+          setNewMessageCount(0);
+        }
+      } else if (!programmaticScrollRef.current && modeRef.current === "following") {
+        setScrollMode("detached");
+      }
+      persistSnapshot();
+      onViewportScroll(event);
+    },
+    [onViewportScroll, persistSnapshot, setScrollMode],
+  );
+
+  const detachFromTail = useCallback(() => {
+    programmaticScrollRef.current = false;
+    if (clearProgrammaticFrameRef.current !== null) {
+      window.cancelAnimationFrame(clearProgrammaticFrameRef.current);
+      clearProgrammaticFrameRef.current = null;
+    }
+    setScrollMode("detached");
+  }, [setScrollMode]);
+
+  const handleWheel = useCallback(
+    (event: WheelEvent<HTMLDivElement>) => {
+      if (event.deltaY < 0) {
+        detachFromTail();
+      }
+    },
+    [detachFromTail],
+  );
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      if (DETACH_KEYS.has(event.key)) detachFromTail();
+    },
+    [detachFromTail],
+  );
+
+  const handleTouchMove = useCallback(() => {
+    detachFromTail();
+  }, [detachFromTail]);
+
+  return (
+    <MessageScroller className="min-h-0 flex-1">
+      <MessageScrollerViewport
+        ref={viewportRef}
+        aria-label="Conversation messages"
+        className="[overflow-anchor:none]"
+        data-scroll-mode={mode}
+        preserveScrollOnPrepend={false}
+        onKeyDown={handleKeyDown}
+        onScroll={handleScroll}
+        onTouchMove={handleTouchMove}
+        onWheel={handleWheel}
+      >
+        <MessageScrollerContent
+          ref={contentRef}
+          className="mx-auto w-full max-w-3xl gap-3.5 px-4 py-5 pt-6"
+        >
+          {children}
+        </MessageScrollerContent>
+      </MessageScrollerViewport>
+      {mode === "detached" ? (
+        <Button
+          type="button"
+          variant="secondary"
+          size="sm"
+          className="absolute inset-s-1/2 z-10 -translate-x-1/2 gap-2 border border-border bg-background text-foreground shadow-md hover:bg-muted rtl:translate-x-1/2"
+          style={{ bottom: bottomOffset + SCROLL_BUTTON_BOTTOM_GAP_PX }}
+          aria-label={
+            newMessageCount > 0
+              ? `${newMessageCount} new ${newMessageCount === 1 ? "message" : "messages"}. Jump to latest`
+              : "Jump to latest"
+          }
+          aria-live="polite"
+          onClick={jumpToLatest}
+        >
+          <ArrowDownIcon data-icon="inline-start" />
+          <span>
+            {newMessageCount > 0
+              ? `${newMessageCount} new ${newMessageCount === 1 ? "message" : "messages"}`
+              : "Jump to latest"}
+          </span>
+          {newMessageCount > 0 ? (
+            <span className="text-muted-foreground">Jump to latest</span>
+          ) : null}
+        </Button>
+      ) : null}
+    </MessageScroller>
+  );
 }
 
 export const ChatFeed = memo(function ChatFeed(props: {
@@ -243,7 +510,7 @@ export const ChatFeed = memo(function ChatFeed(props: {
   citationSourcesByMessageId: Map<string, CitationSource[]>;
   desktopBasePath: string | null;
 
-  composerOverlayHeight: number;
+  bottomOffset: number;
   interactions: VisibleInteraction[];
   onAnswerAsk: (threadId: string, requestId: string, answer: string) => boolean;
   onAnswerApproval: (threadId: string, requestId: string, approved: boolean) => boolean;
@@ -271,7 +538,7 @@ export const ChatFeed = memo(function ChatFeed(props: {
     citationUrlsByMessageId,
     citationSourcesByMessageId,
     desktopBasePath,
-    composerOverlayHeight,
+    bottomOffset,
     interactions,
     onAnswerAsk,
     onAnswerApproval,
@@ -290,6 +557,17 @@ export const ChatFeed = memo(function ChatFeed(props: {
   const lastUserTurnId = lastVisibleUserTurnId(renderItems);
   const retryableActivityGroupId = latestRetryableActivityGroupId(renderItems);
   const feedListEntries = useMemo(() => buildFeedListEntries(renderItems), [renderItems]);
+  const scrollMemoryRef = useRef(new Map<string, TranscriptScrollSnapshot>());
+  const scrollItemIds = useMemo(
+    () => [
+      ...renderItems.map((item) => (item.kind === "activity-group" ? item.id : item.item.id)),
+      ...interactions.map(
+        ({ threadId, interaction }) => `interaction:${threadId}:${interaction.requestId}`,
+      ),
+    ],
+    [interactions, renderItems],
+  );
+  const threadId = selectedThreadId ?? "no-thread";
 
   const handleViewportScroll = useCallback(
     (event: UIEvent<HTMLDivElement>) => {
@@ -303,198 +581,166 @@ export const ChatFeed = memo(function ChatFeed(props: {
   );
 
   return (
-    <MessageScrollerProvider
-      key={selectedThreadId ?? "no-thread"}
-      autoScroll
-      defaultScrollPosition="last-anchor"
-      scrollPreviousItemPeek={64}
-    >
-      <InitialTurnRestore
-        messageId={lastUserTurnId}
-        threadId={selectedThreadId}
+    <MessageScrollerProvider key={threadId} autoScroll={false} defaultScrollPosition="start">
+      <TranscriptScroller
+        bottomOffset={bottomOffset}
         hydrating={hydrating}
-      />
-      <MessageScroller className="min-h-0 flex-1">
-        <MessageScrollerViewport
-          aria-label="Conversation messages"
-          preserveScrollOnPrepend
-          onScroll={handleViewportScroll}
-        >
-          <MessageScrollerContent className="mx-auto w-full max-w-3xl gap-3.5 px-4 py-5 pt-6">
-            {transcriptOnly ? (
-              <MessageScrollerItem messageId="status:transcript-only">
-                <Card className="border-border/70 bg-muted/30">
-                  <CardContent className="flex items-start gap-3 p-3">
-                    <AlertTriangleIcon className="mt-0.5 size-4 text-primary" />
-                    <div>
-                      <div className="font-semibold">Transcript view</div>
-                      <div className="text-sm text-muted-foreground">
-                        Sending a message will continue in a new chat.
-                      </div>
-                    </div>
-                  </CardContent>
-                </Card>
+        itemIds={scrollItemIds}
+        lastUserTurnId={lastUserTurnId}
+        memory={scrollMemoryRef.current}
+        onViewportScroll={handleViewportScroll}
+        threadId={threadId}
+      >
+        {transcriptOnly ? (
+          <MessageScrollerItem messageId="status:transcript-only">
+            <Card className="border-border/70 bg-muted/30">
+              <CardContent className="flex items-start gap-3 p-3">
+                <AlertTriangleIcon className="mt-0.5 size-4 text-primary" />
+                <div>
+                  <div className="font-semibold">Transcript view</div>
+                  <div className="text-sm text-muted-foreground">
+                    Sending a message will continue in a new chat.
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          </MessageScrollerItem>
+        ) : null}
+
+        {visibleFeedLength === 0 ? (
+          <MessageScrollerItem messageId={hydrating ? "status:hydrating" : "status:empty"}>
+            <Empty className="min-h-72 border border-border/55 bg-background/24">
+              <EmptyHeader>
+                <EmptyMedia variant="icon">
+                  {hydrating ? (
+                    <LoaderCircleIcon className="animate-spin" />
+                  ) : (
+                    <MessageSquareIcon />
+                  )}
+                </EmptyMedia>
+                <EmptyTitle>
+                  {hydrating ? "Loading chat" : disconnected ? "Disconnected" : "No messages yet"}
+                </EmptyTitle>
+                <EmptyDescription>
+                  {hydrating
+                    ? "Restoring messages and reconnecting the session."
+                    : disconnected
+                      ? "Reconnect from the banner above to continue."
+                      : "Send a message to start."}
+                </EmptyDescription>
+              </EmptyHeader>
+            </Empty>
+          </MessageScrollerItem>
+        ) : (
+          <>
+            {hiddenFeedItemCount > 0 ? (
+              <MessageScrollerItem messageId="status:show-older">
+                <div
+                  aria-hidden="true"
+                  className="flex flex-col items-center gap-2 py-1"
+                  data-slot="feed-window-spacer"
+                  style={{
+                    minHeight: Math.min(hiddenFeedItemCount * FEED_ESTIMATED_ROW_HEIGHT_PX, 2_400),
+                  }}
+                >
+                  <Button type="button" variant="outline" size="sm" onClick={onShowAllOlderFeed}>
+                    Show {hiddenFeedItemCount} older messages
+                  </Button>
+                </div>
               </MessageScrollerItem>
             ) : null}
-
-            {visibleFeedLength === 0 ? (
-              <MessageScrollerItem messageId={hydrating ? "status:hydrating" : "status:empty"}>
-                <Empty className="min-h-72 border border-border/55 bg-background/24">
-                  <EmptyHeader>
-                    <EmptyMedia variant="icon">
-                      {hydrating ? (
-                        <LoaderCircleIcon className="animate-spin" />
-                      ) : (
-                        <MessageSquareIcon />
-                      )}
-                    </EmptyMedia>
-                    <EmptyTitle>
-                      {hydrating
-                        ? "Loading chat"
-                        : disconnected
-                          ? "Disconnected"
-                          : "No messages yet"}
-                    </EmptyTitle>
-                    <EmptyDescription>
-                      {hydrating
-                        ? "Restoring messages and reconnecting the session."
-                        : disconnected
-                          ? "Reconnect from the banner above to continue."
-                          : "Send a message to start."}
-                    </EmptyDescription>
-                  </EmptyHeader>
-                </Empty>
-              </MessageScrollerItem>
-            ) : (
-              <>
-                {hiddenFeedItemCount > 0 ? (
-                  <MessageScrollerItem messageId="status:show-older">
-                    <div
-                      aria-hidden="true"
-                      className="flex flex-col items-center gap-2 py-1"
-                      data-slot="feed-window-spacer"
-                      style={{
-                        minHeight: Math.min(
-                          hiddenFeedItemCount * FEED_ESTIMATED_ROW_HEIGHT_PX,
-                          2_400,
-                        ),
-                      }}
-                    >
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        onClick={onShowAllOlderFeed}
-                      >
-                        Show {hiddenFeedItemCount} older messages
-                      </Button>
-                    </div>
+            {feedListEntries.map((entry) => {
+              if (entry.kind === "day-separator") {
+                return (
+                  <MessageScrollerItem key={entry.id} messageId={entry.id}>
+                    <DaySeparatorRow label={entry.label} />
                   </MessageScrollerItem>
-                ) : null}
-                {feedListEntries.map((entry) => {
-                  if (entry.kind === "day-separator") {
-                    return (
-                      <MessageScrollerItem key={entry.id} messageId={entry.id}>
-                        <DaySeparatorRow label={entry.label} />
-                      </MessageScrollerItem>
-                    );
-                  }
+                );
+              }
 
-                  const item = entry.item;
-                  const messageId = item.kind === "activity-group" ? item.id : item.item.id;
-                  return (
-                    <MessageScrollerItem
-                      key={messageId}
-                      messageId={messageId}
-                      scrollAnchor={isVisibleUserTurn(item)}
+              const item = entry.item;
+              const messageId = item.kind === "activity-group" ? item.id : item.item.id;
+              return (
+                <MessageScrollerItem key={messageId} messageId={messageId}>
+                  {item.kind === "activity-group" ? (
+                    <InlineErrorBoundary label="This activity couldn't be rendered.">
+                      <ActivityGroupCard
+                        items={item.items}
+                        recoveredToolIds={item.recoveredToolIds}
+                        live={item.id === liveActivityGroupId}
+                        liveStartedAt={liveStartedAt}
+                        onRetry={
+                          item.id === retryableActivityGroupId && onRetryFailedTurn
+                            ? () =>
+                                onRetryFailedTurn(
+                                  unresolvedToolFailureIds(item.items, item.recoveredToolIds),
+                                )
+                            : undefined
+                        }
+                        retryDisabled={retryFailedTurnDisabled}
+                        retryUnavailableReason={
+                          item.id === retryableActivityGroupId ? retryUnavailableReason : undefined
+                        }
+                      />
+                    </InlineErrorBoundary>
+                  ) : (
+                    <InlineErrorBoundary
+                      label={`This message couldn't be rendered (${item.item.kind}).`}
                     >
-                      {item.kind === "activity-group" ? (
-                        <InlineErrorBoundary label="This activity couldn't be rendered.">
-                          <ActivityGroupCard
-                            items={item.items}
-                            recoveredToolIds={item.recoveredToolIds}
-                            live={item.id === liveActivityGroupId}
-                            liveStartedAt={liveStartedAt}
-                            onRetry={
-                              item.id === retryableActivityGroupId && onRetryFailedTurn
-                                ? () =>
-                                    onRetryFailedTurn(
-                                      unresolvedToolFailureIds(item.items, item.recoveredToolIds),
-                                    )
-                                : undefined
-                            }
-                            retryDisabled={retryFailedTurnDisabled}
-                            retryUnavailableReason={
-                              item.id === retryableActivityGroupId
-                                ? retryUnavailableReason
-                                : undefined
-                            }
-                          />
-                        </InlineErrorBoundary>
-                      ) : (
-                        <InlineErrorBoundary
-                          label={`This message couldn't be rendered (${item.item.kind}).`}
-                        >
-                          <FeedRow
-                            item={item.item}
-                            citationUrlsByIndex={citationUrlsByMessageId.get(item.item.id)}
-                            citationSources={citationSourcesByMessageId.get(item.item.id)}
-                            desktopBasePath={desktopBasePath}
-                            isStreaming={
-                              item.item.kind === "message" &&
-                              item.item.role === "assistant" &&
-                              item.item.id === streamingAssistantMessageId
-                            }
-                          />
-                        </InlineErrorBoundary>
-                      )}
-                    </MessageScrollerItem>
-                  );
-                })}
-              </>
-            )}
+                      <FeedRow
+                        item={item.item}
+                        citationUrlsByIndex={citationUrlsByMessageId.get(item.item.id)}
+                        citationSources={citationSourcesByMessageId.get(item.item.id)}
+                        desktopBasePath={desktopBasePath}
+                        isStreaming={
+                          item.item.kind === "message" &&
+                          item.item.role === "assistant" &&
+                          item.item.id === streamingAssistantMessageId
+                        }
+                      />
+                    </InlineErrorBoundary>
+                  )}
+                </MessageScrollerItem>
+              );
+            })}
+          </>
+        )}
 
-            {showWorkingPlaceholder ? (
-              <MessageScrollerItem messageId="status:working-placeholder">
-                <WorkingPlaceholderRow />
-              </MessageScrollerItem>
-            ) : null}
+        {showWorkingPlaceholder ? (
+          <MessageScrollerItem messageId="status:working-placeholder">
+            <WorkingPlaceholderRow />
+          </MessageScrollerItem>
+        ) : null}
 
-            {interactions.map(({ threadId, interaction }, index) => (
-              <MessageScrollerItem
-                key={`${threadId}:${interaction.requestId}`}
-                messageId={`interaction:${threadId}:${interaction.requestId}`}
-              >
-                <InteractionCard
-                  threadId={threadId}
-                  interaction={interaction}
-                  position={index + 1}
-                  total={interactions.length}
-                  onAnswerAsk={onAnswerAsk}
-                  onAnswerApproval={onAnswerApproval}
-                  onRetry={onRetryInteraction}
-                  selectedThreadId={selectedThreadId}
-                  threadTitle={threadTitleById?.get(threadId)}
-                  onSelectThread={onSelectThread}
-                />
-              </MessageScrollerItem>
-            ))}
+        {interactions.map(({ threadId, interaction }, index) => (
+          <MessageScrollerItem
+            key={`${threadId}:${interaction.requestId}`}
+            messageId={`interaction:${threadId}:${interaction.requestId}`}
+          >
+            <InteractionCard
+              threadId={threadId}
+              interaction={interaction}
+              position={index + 1}
+              total={interactions.length}
+              onAnswerAsk={onAnswerAsk}
+              onAnswerApproval={onAnswerApproval}
+              onRetry={onRetryInteraction}
+              selectedThreadId={selectedThreadId}
+              threadTitle={threadTitleById?.get(threadId)}
+              onSelectThread={onSelectThread}
+            />
+          </MessageScrollerItem>
+        ))}
 
-            <MessageScrollerItem>
-              <div
-                aria-hidden="true"
-                className="shrink-0"
-                data-slot="message-bar-reserved-space"
-                style={{ height: composerOverlayHeight }}
-              />
-            </MessageScrollerItem>
-          </MessageScrollerContent>
-        </MessageScrollerViewport>
-        <MessageScrollerButton
-          aria-label="Scroll to end"
-          style={{ bottom: composerOverlayHeight + SCROLL_BUTTON_BOTTOM_GAP_PX }}
-        />
-      </MessageScroller>
+        <MessageScrollerItem>
+          <div
+            aria-hidden="true"
+            className="shrink-0"
+            data-slot="message-bar-reserved-space"
+            style={{ height: bottomOffset }}
+          />
+        </MessageScrollerItem>
+      </TranscriptScroller>
     </MessageScrollerProvider>
   );
 });

--- a/apps/desktop/src/ui/chat/chatBottomOffset.ts
+++ b/apps/desktop/src/ui/chat/chatBottomOffset.ts
@@ -1,0 +1,12 @@
+export type ChatBottomChrome = "in-flow" | "overlay";
+
+export function resolveChatBottomOffset(options: {
+  chrome: ChatBottomChrome;
+  measuredOverlayHeight?: number;
+  minimumOverlayHeight: number;
+}): number {
+  if (options.chrome === "in-flow") return 0;
+  const measuredHeight = options.measuredOverlayHeight ?? 0;
+  if (!Number.isFinite(measuredHeight)) return options.minimumOverlayHeight;
+  return Math.max(options.minimumOverlayHeight, Math.ceil(measuredHeight));
+}

--- a/apps/desktop/src/ui/chat/feedWindow.ts
+++ b/apps/desktop/src/ui/chat/feedWindow.ts
@@ -1,5 +1,20 @@
 import type { FeedItem } from "../../app/types";
 
+export type FeedDerivationWindowState = {
+  feedLength: number;
+  visibleCount: number;
+};
+
+export function resolveFeedDerivationVisibleCount(
+  state: FeedDerivationWindowState | undefined,
+  feedLength: number,
+  defaultVisibleCount: number,
+): number {
+  if (!state) return defaultVisibleCount;
+  const appendedCount = Math.max(0, feedLength - state.feedLength);
+  return Math.min(feedLength, state.visibleCount + appendedCount);
+}
+
 export function selectFeedDerivationWindow(
   feed: FeedItem[],
   visibleCount: number,

--- a/apps/desktop/src/ui/chat/scrollOwnership.ts
+++ b/apps/desktop/src/ui/chat/scrollOwnership.ts
@@ -3,7 +3,15 @@ export const FOLLOW_TAIL_THRESHOLD_PX = 48;
 export type ScrollAnchorPosition = {
   anchorId: string;
   offset: number;
+  textAnchor?: {
+    characterOffset: number;
+    offset: number;
+    textAfter: string;
+    textBefore: string;
+  };
 };
+
+const TEXT_ANCHOR_CONTEXT_LENGTH = 32;
 
 export function scrollDistanceFromEnd(viewport: HTMLElement): number {
   return Math.max(0, viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight);
@@ -27,6 +35,132 @@ function scrollAnchorItems(content: HTMLElement): HTMLElement[] {
   );
 }
 
+type CaretDocument = Document & {
+  caretPositionFromPoint?: (x: number, y: number) => { offset: number; offsetNode: Node } | null;
+  caretRangeFromPoint?: (x: number, y: number) => Range | null;
+};
+
+function rangeRect(range: Range): DOMRect | null {
+  const rect = range.getClientRects()[0] ?? range.getBoundingClientRect();
+  return Number.isFinite(rect.top) ? rect : null;
+}
+
+function caretRangeAtPoint(document: CaretDocument, x: number, y: number): Range | null {
+  const position = document.caretPositionFromPoint?.(x, y);
+  if (position) {
+    const range = document.createRange();
+    range.setStart(position.offsetNode, position.offset);
+    range.collapse(true);
+    return range;
+  }
+  return document.caretRangeFromPoint?.(x, y) ?? null;
+}
+
+function captureTextAnchor(
+  viewport: HTMLElement,
+  item: HTMLElement,
+): ScrollAnchorPosition["textAnchor"] | undefined {
+  const document = item.ownerDocument as CaretDocument;
+  if (!document.caretPositionFromPoint && !document.caretRangeFromPoint) return undefined;
+  const viewportRect = viewport.getBoundingClientRect();
+  const itemRect = item.getBoundingClientRect();
+  const rightEdge = Math.min(viewportRect.right, itemRect.right) - 1;
+  const bottomEdge = Math.min(viewportRect.bottom, itemRect.bottom) - 1;
+  const x = Math.min(rightEdge, Math.max(viewportRect.left, itemRect.left) + 16);
+  const y = Math.min(bottomEdge, Math.max(viewportRect.top, itemRect.top) + 1);
+  if (
+    x < Math.max(viewportRect.left, itemRect.left) ||
+    y < Math.max(viewportRect.top, itemRect.top)
+  ) {
+    return undefined;
+  }
+
+  const caretRange = caretRangeAtPoint(document, x, y);
+  const node = caretRange?.startContainer;
+  if (!caretRange || !node || (node !== item && !item.contains(node))) return undefined;
+  const caretRect = rangeRect(caretRange);
+  if (!caretRect) return undefined;
+
+  const prefixRange = document.createRange();
+  prefixRange.selectNodeContents(item);
+  prefixRange.setEnd(node, caretRange.startOffset);
+  const characterOffset = prefixRange.toString().length;
+  const text = item.textContent ?? "";
+  return {
+    characterOffset,
+    offset: caretRect.top - viewportRect.top,
+    textBefore: text.slice(
+      Math.max(0, characterOffset - TEXT_ANCHOR_CONTEXT_LENGTH),
+      characterOffset,
+    ),
+    textAfter: text.slice(characterOffset, characterOffset + TEXT_ANCHOR_CONTEXT_LENGTH),
+  };
+}
+
+function resolveTextOffset(
+  text: string,
+  textAnchor: NonNullable<ScrollAnchorPosition["textAnchor"]>,
+): number {
+  const context = `${textAnchor.textBefore}${textAnchor.textAfter}`;
+  if (context) {
+    const contextIndex = text.indexOf(context);
+    if (contextIndex >= 0) return contextIndex + textAnchor.textBefore.length;
+  }
+  if (textAnchor.textAfter) {
+    const afterIndex = text.indexOf(textAnchor.textAfter);
+    if (afterIndex >= 0) return afterIndex;
+  }
+  if (textAnchor.textBefore) {
+    const beforeIndex = text.lastIndexOf(textAnchor.textBefore);
+    if (beforeIndex >= 0) return beforeIndex + textAnchor.textBefore.length;
+  }
+  return Math.min(text.length, textAnchor.characterOffset);
+}
+
+function restoreTextAnchor(
+  viewport: HTMLElement,
+  item: HTMLElement,
+  textAnchor: NonNullable<ScrollAnchorPosition["textAnchor"]>,
+): boolean {
+  const document = item.ownerDocument;
+  const targetOffset = resolveTextOffset(item.textContent ?? "", textAnchor);
+  const walker = document.createTreeWalker(item, 4);
+  let remaining = targetOffset;
+  let node = walker.nextNode();
+  let lastTextNode: Text | null = null;
+  while (node) {
+    if (node.nodeType === 3) {
+      const textNode = node as Text;
+      lastTextNode = textNode;
+      if (remaining <= textNode.data.length) {
+        const range = document.createRange();
+        range.setStart(textNode, remaining);
+        range.collapse(true);
+        const rect = rangeRect(range);
+        if (!rect) return false;
+        const delta = rect.top - viewport.getBoundingClientRect().top - textAnchor.offset;
+        if (Math.abs(delta) > 0.5) {
+          viewport.scrollTop = Math.max(0, viewport.scrollTop + delta);
+        }
+        return true;
+      }
+      remaining -= textNode.data.length;
+    }
+    node = walker.nextNode();
+  }
+  if (!lastTextNode) return false;
+  const range = document.createRange();
+  range.setStart(lastTextNode, lastTextNode.data.length);
+  range.collapse(true);
+  const rect = rangeRect(range);
+  if (!rect) return false;
+  const delta = rect.top - viewport.getBoundingClientRect().top - textAnchor.offset;
+  if (Math.abs(delta) > 0.5) {
+    viewport.scrollTop = Math.max(0, viewport.scrollTop + delta);
+  }
+  return true;
+}
+
 export function captureScrollAnchor(
   viewport: HTMLElement,
   content: HTMLElement,
@@ -40,6 +174,7 @@ export function captureScrollAnchor(
       return {
         anchorId,
         offset: itemRect.top - viewportTop,
+        textAnchor: captureTextAnchor(viewport, item),
       };
     }
   }
@@ -55,6 +190,9 @@ export function restoreScrollAnchor(
     (candidate) => scrollAnchorId(candidate) === position.anchorId,
   );
   if (!item) return false;
+  if (position.textAnchor && restoreTextAnchor(viewport, item, position.textAnchor)) {
+    return true;
+  }
   const currentOffset = item.getBoundingClientRect().top - viewport.getBoundingClientRect().top;
   const delta = currentOffset - position.offset;
   if (Math.abs(delta) > 0.5) {

--- a/apps/desktop/src/ui/chat/scrollOwnership.ts
+++ b/apps/desktop/src/ui/chat/scrollOwnership.ts
@@ -1,0 +1,81 @@
+export const FOLLOW_TAIL_THRESHOLD_PX = 48;
+
+export type ScrollAnchorPosition = {
+  anchorId: string;
+  offset: number;
+};
+
+export function scrollDistanceFromEnd(viewport: HTMLElement): number {
+  return Math.max(0, viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight);
+}
+
+export function isNearScrollEnd(
+  viewport: HTMLElement,
+  threshold = FOLLOW_TAIL_THRESHOLD_PX,
+): boolean {
+  return scrollDistanceFromEnd(viewport) <= threshold;
+}
+
+function scrollAnchorId(item: HTMLElement): string | undefined {
+  return item.dataset.scrollAnchorId ?? item.dataset.messageId;
+}
+
+function scrollAnchorItems(content: HTMLElement): HTMLElement[] {
+  return Array.from(content.children).filter(
+    (child): child is HTMLElement =>
+      child instanceof HTMLElement && typeof scrollAnchorId(child) === "string",
+  );
+}
+
+export function captureScrollAnchor(
+  viewport: HTMLElement,
+  content: HTMLElement,
+): ScrollAnchorPosition | null {
+  const viewportTop = viewport.getBoundingClientRect().top;
+  for (const item of scrollAnchorItems(content)) {
+    const itemRect = item.getBoundingClientRect();
+    if (itemRect.bottom > viewportTop) {
+      const anchorId = scrollAnchorId(item);
+      if (!anchorId) continue;
+      return {
+        anchorId,
+        offset: itemRect.top - viewportTop,
+      };
+    }
+  }
+  return null;
+}
+
+export function restoreScrollAnchor(
+  viewport: HTMLElement,
+  content: HTMLElement,
+  position: ScrollAnchorPosition,
+): boolean {
+  const item = scrollAnchorItems(content).find(
+    (candidate) => scrollAnchorId(candidate) === position.anchorId,
+  );
+  if (!item) return false;
+  const currentOffset = item.getBoundingClientRect().top - viewport.getBoundingClientRect().top;
+  const delta = currentOffset - position.offset;
+  if (Math.abs(delta) > 0.5) {
+    viewport.scrollTop = Math.max(0, viewport.scrollTop + delta);
+  }
+  return true;
+}
+
+export function scrollViewportToEnd(viewport: HTMLElement): void {
+  viewport.scrollTop = Math.max(0, viewport.scrollHeight - viewport.clientHeight);
+}
+
+export function countNewIds(previousIds: readonly string[], currentIds: readonly string[]): number {
+  if (previousIds.length === 0) return 0;
+  const previous = new Set(previousIds);
+  const previousTailId = previousIds[previousIds.length - 1];
+  const previousTailIndex = previousTailId ? currentIds.lastIndexOf(previousTailId) : -1;
+  const candidates = previousTailIndex >= 0 ? currentIds.slice(previousTailIndex + 1) : currentIds;
+  let count = 0;
+  for (const id of candidates) {
+    if (!previous.has(id)) count += 1;
+  }
+  return count;
+}

--- a/apps/desktop/test/chat-activity-group-card.test.tsx
+++ b/apps/desktop/test/chat-activity-group-card.test.tsx
@@ -538,6 +538,126 @@ describe("desktop activity group card", () => {
     }
   });
 
+  test("preserves manual reasoning disclosure state across streamed body deltas", async () => {
+    const harness = setupJsdom();
+    const container = harness.dom.window.document.getElementById("root");
+    if (!container) throw new Error("missing root");
+    const root = createRoot(container);
+
+    const renderReasoning = async (body: string) => {
+      await act(async () => {
+        root.render(
+          createElement(ActivityGroupCard, {
+            live: true,
+            liveNowMs: Date.parse("2024-01-01T00:00:05.000Z"),
+            items: [
+              {
+                id: "reasoning-source-1",
+                kind: "reasoning",
+                mode: "summary",
+                ts: "2024-01-01T00:00:00.000Z",
+                text: `**Plan**\n\n${body}`,
+              },
+            ],
+          }),
+        );
+      });
+    };
+
+    try {
+      await renderReasoning("Initial streamed body.");
+      const disclosure = Array.from(container.querySelectorAll<HTMLButtonElement>("button")).find(
+        (button) => button.textContent?.includes("Plan"),
+      );
+      expect(disclosure?.getAttribute("aria-expanded")).toBe("true");
+
+      await act(async () => {
+        disclosure?.click();
+      });
+      expect(disclosure?.getAttribute("aria-expanded")).toBe("false");
+
+      await renderReasoning(
+        "A completely different streamed body prefix that previously changed the React key.",
+      );
+      const updatedDisclosure = Array.from(
+        container.querySelectorAll<HTMLButtonElement>("button"),
+      ).find((button) => button.textContent?.includes("Plan"));
+      expect(updatedDisclosure).toBe(disclosure);
+      expect(updatedDisclosure?.getAttribute("aria-expanded")).toBe("false");
+      expect(updatedDisclosure?.getAttribute("aria-controls")).toContain("reasoning-source-1");
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      harness.restore();
+    }
+  });
+
+  test("keeps nested Activity scrolling detached and reports new entries", async () => {
+    const harness = setupJsdom();
+    const container = harness.dom.window.document.getElementById("root");
+    if (!container) throw new Error("missing root");
+    const root = createRoot(container);
+    let nestedScrollHeight = 900;
+
+    const renderActivity = async (toolCount: number) => {
+      await act(async () => {
+        root.render(
+          createElement(ActivityGroupCard, {
+            live: true,
+            liveNowMs: Date.parse("2024-01-01T00:00:05.000Z"),
+            items: Array.from({ length: toolCount }, (_, index) => ({
+              id: `tool-${index + 1}`,
+              kind: "tool" as const,
+              ts: `2024-01-01T00:00:${String(index).padStart(2, "0")}.000Z`,
+              name: "read",
+              state: "output-available" as const,
+              args: { path: `file-${index + 1}.ts` },
+            })),
+          }),
+        );
+      });
+    };
+
+    try {
+      await renderActivity(4);
+      const timeline = container.querySelector(
+        '[data-slot="activity-timeline-viewport"]',
+      ) as HTMLElement | null;
+      if (!timeline) throw new Error("missing activity timeline");
+      Object.defineProperty(timeline, "clientHeight", { configurable: true, value: 300 });
+      Object.defineProperty(timeline, "scrollHeight", {
+        configurable: true,
+        get: () => nestedScrollHeight,
+      });
+      timeline.scrollTop = 200;
+      await act(async () => {
+        timeline.dispatchEvent(
+          new harness.dom.window.WheelEvent("wheel", { bubbles: true, deltaY: -60 }),
+        );
+        timeline.dispatchEvent(new harness.dom.window.Event("scroll", { bubbles: true }));
+      });
+
+      nestedScrollHeight = 1_100;
+      await renderActivity(6);
+      expect(timeline.scrollTop).toBe(200);
+      const jumpButton = container.querySelector(
+        '[aria-label="2 new activities. Jump to latest"]',
+      ) as HTMLButtonElement | null;
+      expect(jumpButton?.textContent).toContain("2 new activities");
+
+      await act(async () => {
+        jumpButton?.click();
+      });
+      expect(timeline.scrollTop).toBe(800);
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      harness.restore();
+    }
+  });
+
   test("isolates an activity-card render failure with an inline fallback", async () => {
     const harness = setupJsdom();
     const container = harness.dom.window.document.getElementById("root");
@@ -593,7 +713,7 @@ describe("desktop activity group card", () => {
               citationUrlsByMessageId: new Map(),
               citationSourcesByMessageId: new Map(),
               desktopBasePath: null,
-              composerOverlayHeight: 0,
+              bottomOffset: 0,
               interactions: [],
               onAnswerAsk: () => true,
               onAnswerApproval: () => true,

--- a/apps/desktop/test/chat-bottom-offset.test.ts
+++ b/apps/desktop/test/chat-bottom-offset.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { resolveChatBottomOffset } from "../src/ui/chat/chatBottomOffset";
+
+describe("chat bottom offset ownership", () => {
+  test("reserves exactly the measured absolute overlay once", () => {
+    expect(
+      resolveChatBottomOffset({
+        chrome: "overlay",
+        measuredOverlayHeight: 219.2,
+        minimumOverlayHeight: 140,
+      }),
+    ).toBe(220);
+  });
+
+  test("uses the compact floor before the overlay is measured", () => {
+    expect(
+      resolveChatBottomOffset({
+        chrome: "overlay",
+        minimumOverlayHeight: 140,
+      }),
+    ).toBe(140);
+  });
+
+  test("does not reserve an in-flow source-task lock a second time", () => {
+    expect(
+      resolveChatBottomOffset({
+        chrome: "in-flow",
+        measuredOverlayHeight: 240,
+        minimumOverlayHeight: 140,
+      }),
+    ).toBe(0);
+  });
+});

--- a/apps/desktop/test/chat-feed-scroller.test.tsx
+++ b/apps/desktop/test/chat-feed-scroller.test.tsx
@@ -66,9 +66,12 @@ function installScrollerGeometry(
   harness: JsdomHarness,
   heights: ReadonlyMap<string, number>,
   viewportHeight = 400,
+  textAnchorOffsets: ReadonlyMap<string, number> = new Map(),
 ) {
-  const { HTMLElement } = harness.dom.window;
+  const { HTMLElement, Range } = harness.dom.window;
   const originalRect = HTMLElement.prototype.getBoundingClientRect;
+  const originalRangeRect = Range.prototype.getBoundingClientRect;
+  const originalRangeRects = Range.prototype.getClientRects;
   const originalClientHeight = Object.getOwnPropertyDescriptor(
     HTMLElement.prototype,
     "clientHeight",
@@ -125,6 +128,40 @@ function installScrollerGeometry(
       this.scrollTop = options.top ?? this.scrollTop;
     },
   });
+  Range.prototype.getBoundingClientRect = function getBoundingClientRect() {
+    const element =
+      this.startContainer instanceof HTMLElement
+        ? this.startContainer
+        : this.startContainer.parentElement;
+    const item = element?.closest<HTMLElement>('[data-slot="message-scroller-item"]');
+    const messageId = item?.dataset.messageId;
+    const offset = messageId ? textAnchorOffsets.get(messageId) : undefined;
+    if (item && offset !== undefined) {
+      return rect(item.getBoundingClientRect().top + offset, 16);
+    }
+    return originalRangeRect?.call(this) ?? rect(0, 0);
+  };
+  Range.prototype.getClientRects = function getClientRects() {
+    const rangeRect = this.getBoundingClientRect();
+    if (rangeRect.height > 0) {
+      return {
+        0: rangeRect,
+        item: (index: number) => (index === 0 ? rangeRect : null),
+        length: 1,
+        [Symbol.iterator]: function* iterator() {
+          yield rangeRect;
+        },
+      } as DOMRectList;
+    }
+    return (
+      originalRangeRects?.call(this) ??
+      ({
+        item: () => null,
+        length: 0,
+        [Symbol.iterator]: function* iterator() {},
+      } as DOMRectList)
+    );
+  };
 }
 
 function message(id: string, role: "assistant" | "user", text: string): ChatRenderItem {
@@ -177,13 +214,16 @@ function renderFeed(
   );
 }
 
-function setupScroller(heights: Map<string, number>) {
+function setupScroller(
+  heights: Map<string, number>,
+  textAnchorOffsets: Map<string, number> = new Map(),
+) {
   ControlledResizeObserver.callbacks.clear();
   const harness = setupJsdom({
     includeAnimationFrame: true,
     extraGlobals: { ResizeObserver: ControlledResizeObserver },
   });
-  installScrollerGeometry(harness, heights);
+  installScrollerGeometry(harness, heights, 400, textAnchorOffsets);
   return harness;
 }
 
@@ -658,6 +698,97 @@ describe("desktop chat message scroller", () => {
     }
   });
 
+  test("persists the unread baseline and exact count while a detached thread is away", async () => {
+    const heights = new Map([
+      ["user-a", 100],
+      ["assistant-a", 700],
+      ["away-1", 100],
+      ["away-2", 100],
+      ["away-3", 100],
+      ["away-4", 100],
+      ["away-5", 100],
+      ["user-b", 100],
+      ["assistant-b", 500],
+    ]);
+    const harness = setupScroller(heights);
+
+    try {
+      const container = harness.dom.window.document.getElementById("root");
+      if (!container) throw new Error("missing root");
+      const root = createRoot(container);
+      const initialThreadA = [
+        message("user-a", "user", "Question A"),
+        message("assistant-a", "assistant", "Answer A"),
+      ];
+      const threadB = [
+        message("user-b", "user", "Question B"),
+        message("assistant-b", "assistant", "Answer B"),
+      ];
+
+      await act(async () => {
+        root.render(renderFeed(initialThreadA, "thread-a"));
+      });
+      const viewportA = container.querySelector(
+        '[data-slot="message-scroller-viewport"]',
+      ) as HTMLElement | null;
+      if (!viewportA) throw new Error("missing thread A viewport");
+      viewportA.scrollTop = 100;
+      await act(async () => {
+        viewportA.dispatchEvent(
+          new harness.dom.window.WheelEvent("wheel", { bubbles: true, deltaY: -80 }),
+        );
+        viewportA.dispatchEvent(new harness.dom.window.Event("scroll", { bubbles: true }));
+      });
+
+      await act(async () => {
+        root.render(renderFeed(threadB, "thread-b"));
+      });
+      const firstAwayBatch = [
+        message("away-1", "assistant", "Away one"),
+        message("away-2", "assistant", "Away two"),
+        message("away-3", "assistant", "Away three"),
+      ];
+      await act(async () => {
+        root.render(renderFeed([...initialThreadA, ...firstAwayBatch], "thread-a"));
+      });
+      expect(
+        container.querySelector('[aria-label="3 new messages. Jump to latest"]'),
+      ).not.toBeNull();
+      const firstRestoredViewport = container.querySelector(
+        '[data-slot="message-scroller-viewport"]',
+      ) as HTMLElement | null;
+      expect(firstRestoredViewport?.scrollTop).toBe(100);
+
+      await act(async () => {
+        root.render(renderFeed(threadB, "thread-b"));
+      });
+      await act(async () => {
+        root.render(
+          renderFeed(
+            [
+              ...initialThreadA,
+              ...firstAwayBatch,
+              message("away-4", "assistant", "Away four"),
+              message("away-5", "assistant", "Away five"),
+            ],
+            "thread-a",
+          ),
+        );
+      });
+      expect(
+        container.querySelector('[aria-label="5 new messages. Jump to latest"]'),
+      ).not.toBeNull();
+      expect(
+        (container.querySelector('[data-slot="message-scroller-viewport"]') as HTMLElement | null)
+          ?.scrollTop,
+      ).toBe(100);
+
+      await act(async () => root.unmount());
+    } finally {
+      harness.restore();
+    }
+  });
+
   test("preserves a detached reading anchor through dynamic row height changes", async () => {
     const heights = new Map([
       ["user-1", 100],
@@ -711,6 +842,87 @@ describe("desktop chat message scroller", () => {
       expect(
         container.querySelector('[data-message-id="user-2"]')?.getBoundingClientRect().top,
       ).toBe(-20);
+
+      await act(async () => root.unmount());
+    } finally {
+      harness.restore();
+    }
+  });
+
+  test("compensates Markdown growth above the reading point within one row", async () => {
+    const heights = new Map([
+      ["user-1", 100],
+      ["assistant-1", 800],
+    ]);
+    const textAnchorOffsets = new Map([["assistant-1", 250]]);
+    const harness = setupScroller(heights, textAnchorOffsets);
+
+    try {
+      const document = harness.dom.window.document;
+      const container = document.getElementById("root");
+      if (!container) throw new Error("missing root");
+      const root = createRoot(container);
+
+      await act(async () => {
+        root.render(
+          renderFeed(
+            [
+              message("user-1", "user", "Prelude"),
+              message(
+                "assistant-1",
+                "assistant",
+                "Opening Markdown paragraph.\n\nReading point remains stable.",
+              ),
+            ],
+            "thread-a",
+          ),
+        );
+      });
+      const viewport = container.querySelector(
+        '[data-slot="message-scroller-viewport"]',
+      ) as HTMLElement | null;
+      const anchorItem = container.querySelector(
+        '[data-message-id="assistant-1"]',
+      ) as HTMLElement | null;
+      if (!viewport || !anchorItem) throw new Error("missing same-row anchor");
+      const textWalker = document.createTreeWalker(anchorItem, 4);
+      let readingNode = textWalker.nextNode();
+      while (readingNode && !readingNode.textContent?.includes("Reading point")) {
+        readingNode = textWalker.nextNode();
+      }
+      if (!readingNode) throw new Error("missing Markdown reading text");
+      const caretNode = readingNode;
+      const caretDocument = document as Document & {
+        caretRangeFromPoint?: (x: number, y: number) => Range | null;
+      };
+      caretDocument.caretRangeFromPoint = () => {
+        const range = document.createRange();
+        range.setStart(caretNode, 0);
+        range.collapse(true);
+        return range;
+      };
+
+      viewport.scrollTop = 300;
+      await act(async () => {
+        viewport.dispatchEvent(
+          new harness.dom.window.WheelEvent("wheel", { bubbles: true, deltaY: -80 }),
+        );
+        viewport.dispatchEvent(new harness.dom.window.Event("scroll", { bubbles: true }));
+      });
+      const readingRange = document.createRange();
+      readingRange.setStart(caretNode, 0);
+      readingRange.collapse(true);
+      expect(readingRange.getBoundingClientRect().top).toBe(50);
+
+      heights.set("assistant-1", 1_000);
+      textAnchorOffsets.set("assistant-1", 450);
+      await act(async () => {
+        ControlledResizeObserver.trigger();
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      });
+
+      expect(viewport.scrollTop).toBe(500);
+      expect(readingRange.getBoundingClientRect().top).toBe(50);
 
       await act(async () => root.unmount());
     } finally {

--- a/apps/desktop/test/chat-feed-scroller.test.tsx
+++ b/apps/desktop/test/chat-feed-scroller.test.tsx
@@ -166,7 +166,7 @@ function renderFeed(
       desktopBasePath: null,
       latestRemovedSurfaceItemId: null,
       REMOVEDUIEnabled: false,
-      composerOverlayHeight: 200,
+      bottomOffset: 200,
       interactions: [],
       onAnswerAsk: () => true,
       onAnswerApproval: () => true,
@@ -233,18 +233,6 @@ describe("desktop chat message scroller", () => {
         '[data-slot="message-scroller-viewport"]',
       ) as HTMLElement | null;
       expect(viewport?.scrollTop).toBe(536);
-      expect(container.querySelector('[data-message-id="user-1"]')?.dataset.scrollAnchor).toBe(
-        "true",
-      );
-      expect(container.querySelector('[data-message-id="user-2"]')?.dataset.scrollAnchor).toBe(
-        "true",
-      );
-      expect(container.querySelector('[data-message-id="assistant-2"]')?.dataset.scrollAnchor).toBe(
-        "false",
-      );
-      expect(container.querySelector('[data-slot="message-scroller-button"]')?.style.bottom).toBe(
-        "209px",
-      );
 
       await act(async () => root.unmount());
     } finally {
@@ -283,9 +271,7 @@ describe("desktop chat message scroller", () => {
         '[data-slot="message-scroller-viewport"]',
       ) as HTMLElement | null;
       expect(viewport?.scrollTop).toBe(536);
-      expect(container.querySelector('[data-message-id="user-2"]')?.dataset.scrollAnchor).toBe(
-        "true",
-      );
+      expect(container.querySelector('[data-message-id="user-2"]')).not.toBeNull();
 
       await act(async () => root.unmount());
     } finally {
@@ -377,6 +363,38 @@ describe("desktop chat message scroller", () => {
     }
   });
 
+  test("reserves the composer offset once when the working placeholder is visible", async () => {
+    const heights = new Map([
+      ["user-1", 100],
+      ["status:working-placeholder", 40],
+    ]);
+    const harness = setupScroller(heights);
+
+    try {
+      const container = harness.dom.window.document.getElementById("root");
+      if (!container) throw new Error("missing root");
+      const root = createRoot(container);
+
+      await act(async () => {
+        root.render(
+          renderFeed([message("user-1", "user", "Question")], "thread-a", false, {
+            bottomOffset: 220,
+            showWorkingPlaceholder: true,
+          }),
+        );
+      });
+
+      const reservedSpaces = container.querySelectorAll('[data-slot="message-bar-reserved-space"]');
+      expect(reservedSpaces).toHaveLength(1);
+      expect((reservedSpaces[0] as HTMLElement).style.height).toBe("220px");
+      expect(container.querySelectorAll('[data-slot="working-placeholder"]')).toHaveLength(1);
+
+      await act(async () => root.unmount());
+    } finally {
+      harness.restore();
+    }
+  });
+
   test("follows streaming at the live edge, stops after user scroll, and resumes after scroll-to-end", async () => {
     const heights = new Map([
       ["user-1", 60],
@@ -428,9 +446,9 @@ describe("desktop chat message scroller", () => {
       expect(viewport.scrollTop).toBe(100);
 
       const scrollToEnd = container.querySelector(
-        '[aria-label="Scroll to end"]',
+        '[aria-label="Jump to latest"]',
       ) as HTMLButtonElement | null;
-      expect(scrollToEnd?.dataset.active).toBe("true");
+      expect(scrollToEnd).not.toBeNull();
       await act(async () => {
         scrollToEnd?.click();
         await new Promise((resolve) => setTimeout(resolve, 10));
@@ -562,6 +580,348 @@ describe("desktop chat message scroller", () => {
       expect(viewportB).not.toBe(viewportA);
       if (!viewportB) throw new Error("missing viewport");
       await waitForScrollTop(viewportB, 136);
+
+      await act(async () => root.unmount());
+    } finally {
+      harness.restore();
+    }
+  });
+
+  test("restores the exact per-thread anchor and offset across A → B → A hydration", async () => {
+    const heights = new Map([
+      ["user-a-1", 100],
+      ["assistant-a-1", 400],
+      ["user-a-2", 100],
+      ["assistant-a-2", 600],
+      ["user-b", 100],
+      ["assistant-b", 500],
+    ]);
+    const harness = setupScroller(heights);
+
+    try {
+      const container = harness.dom.window.document.getElementById("root");
+      if (!container) throw new Error("missing root");
+      const root = createRoot(container);
+      const threadA = [
+        message("user-a-1", "user", "A1"),
+        message("assistant-a-1", "assistant", "Answer A1"),
+        message("user-a-2", "user", "A2"),
+        message("assistant-a-2", "assistant", "Answer A2"),
+      ];
+
+      await act(async () => {
+        root.render(renderFeed(threadA, "thread-a"));
+      });
+      const viewportA = container.querySelector(
+        '[data-slot="message-scroller-viewport"]',
+      ) as HTMLElement | null;
+      if (!viewportA) throw new Error("missing thread A viewport");
+
+      viewportA.scrollTop = 520;
+      await act(async () => {
+        viewportA.dispatchEvent(
+          new harness.dom.window.WheelEvent("wheel", { bubbles: true, deltaY: -80 }),
+        );
+        viewportA.dispatchEvent(new harness.dom.window.Event("scroll", { bubbles: true }));
+      });
+      expect(viewportA.dataset.scrollMode).toBe("detached");
+      expect(
+        container.querySelector('[data-message-id="user-a-2"]')?.getBoundingClientRect().top,
+      ).toBe(-20);
+
+      await act(async () => {
+        root.render(
+          renderFeed(
+            [message("user-b", "user", "B"), message("assistant-b", "assistant", "Answer B")],
+            "thread-b",
+          ),
+        );
+      });
+      await act(async () => {
+        root.render(renderFeed([], "thread-a", true));
+      });
+      await act(async () => {
+        root.render(renderFeed(threadA, "thread-a"));
+      });
+
+      const restoredViewport = container.querySelector(
+        '[data-slot="message-scroller-viewport"]',
+      ) as HTMLElement | null;
+      expect(restoredViewport?.scrollTop).toBe(520);
+      expect(
+        container.querySelector('[data-message-id="user-a-2"]')?.getBoundingClientRect().top,
+      ).toBe(-20);
+
+      await act(async () => root.unmount());
+    } finally {
+      harness.restore();
+    }
+  });
+
+  test("preserves a detached reading anchor through dynamic row height changes", async () => {
+    const heights = new Map([
+      ["user-1", 100],
+      ["assistant-1", 400],
+      ["user-2", 100],
+      ["assistant-2", 600],
+    ]);
+    const harness = setupScroller(heights);
+
+    try {
+      const container = harness.dom.window.document.getElementById("root");
+      if (!container) throw new Error("missing root");
+      const root = createRoot(container);
+
+      await act(async () => {
+        root.render(
+          renderFeed(
+            [
+              message("user-1", "user", "First"),
+              message("assistant-1", "assistant", "First answer"),
+              message("user-2", "user", "Second"),
+              message("assistant-2", "assistant", "Second answer"),
+            ],
+            "thread-a",
+          ),
+        );
+      });
+      const viewport = container.querySelector(
+        '[data-slot="message-scroller-viewport"]',
+      ) as HTMLElement | null;
+      if (!viewport) throw new Error("missing viewport");
+
+      viewport.scrollTop = 520;
+      await act(async () => {
+        viewport.dispatchEvent(
+          new harness.dom.window.WheelEvent("wheel", { bubbles: true, deltaY: -80 }),
+        );
+        viewport.dispatchEvent(new harness.dom.window.Event("scroll", { bubbles: true }));
+      });
+      expect(
+        container.querySelector('[data-message-id="user-2"]')?.getBoundingClientRect().top,
+      ).toBe(-20);
+
+      heights.set("assistant-1", 600);
+      await act(async () => {
+        ControlledResizeObserver.trigger();
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      });
+
+      expect(viewport.scrollTop).toBe(720);
+      expect(
+        container.querySelector('[data-message-id="user-2"]')?.getBoundingClientRect().top,
+      ).toBe(-20);
+
+      await act(async () => root.unmount());
+    } finally {
+      harness.restore();
+    }
+  });
+
+  test("preserves a detached anchor when the progressive feed window shifts", async () => {
+    const heights = new Map([
+      ["status:show-older", 1_000],
+      ["old-user", 100],
+      ["old-assistant", 100],
+      ["anchor-user", 100],
+      ["anchor-assistant", 600],
+      ["new-user", 100],
+      ["new-assistant", 200],
+    ]);
+    const harness = setupScroller(heights);
+
+    try {
+      const container = harness.dom.window.document.getElementById("root");
+      if (!container) throw new Error("missing root");
+      const root = createRoot(container);
+      const initialItems = [
+        message("old-user", "user", "Old question"),
+        message("old-assistant", "assistant", "Old answer"),
+        message("anchor-user", "user", "Reading anchor"),
+        message("anchor-assistant", "assistant", "Anchor answer"),
+      ];
+
+      await act(async () => {
+        root.render(
+          renderFeed(initialItems, "thread-a", false, {
+            hiddenFeedItemCount: 10,
+          }),
+        );
+      });
+      const viewport = container.querySelector(
+        '[data-slot="message-scroller-viewport"]',
+      ) as HTMLElement | null;
+      if (!viewport) throw new Error("missing viewport");
+      viewport.scrollTop = 1_250;
+      await act(async () => {
+        viewport.dispatchEvent(
+          new harness.dom.window.WheelEvent("wheel", { bubbles: true, deltaY: -80 }),
+        );
+        viewport.dispatchEvent(new harness.dom.window.Event("scroll", { bubbles: true }));
+      });
+      expect(
+        container.querySelector('[data-message-id="anchor-user"]')?.getBoundingClientRect().top,
+      ).toBe(-50);
+
+      heights.set("status:show-older", 1_240);
+      await act(async () => {
+        root.render(
+          renderFeed(
+            [
+              message("anchor-user", "user", "Reading anchor"),
+              message("anchor-assistant", "assistant", "Anchor answer"),
+              message("new-user", "user", "New question"),
+              message("new-assistant", "assistant", "New answer"),
+            ],
+            "thread-a",
+            false,
+            { hiddenFeedItemCount: 12 },
+          ),
+        );
+      });
+
+      expect(viewport.scrollTop).toBe(1_290);
+      expect(
+        container.querySelector('[data-message-id="anchor-user"]')?.getBoundingClientRect().top,
+      ).toBe(-50);
+
+      await act(async () => root.unmount());
+    } finally {
+      harness.restore();
+    }
+  });
+
+  test("shows and clears a visible new-message count while follow-tail is detached", async () => {
+    const heights = new Map([
+      ["user-1", 100],
+      ["assistant-1", 700],
+      ["assistant-2", 200],
+      ["assistant-3", 200],
+    ]);
+    const harness = setupScroller(heights);
+
+    try {
+      const container = harness.dom.window.document.getElementById("root");
+      if (!container) throw new Error("missing root");
+      const root = createRoot(container);
+      const initialItems = [
+        message("user-1", "user", "Question"),
+        message("assistant-1", "assistant", "Answer"),
+      ];
+
+      await act(async () => {
+        root.render(renderFeed(initialItems, "thread-a"));
+      });
+      const viewport = container.querySelector(
+        '[data-slot="message-scroller-viewport"]',
+      ) as HTMLElement | null;
+      if (!viewport) throw new Error("missing viewport");
+      viewport.scrollTop = 100;
+      await act(async () => {
+        viewport.dispatchEvent(
+          new harness.dom.window.WheelEvent("wheel", { bubbles: true, deltaY: -80 }),
+        );
+        viewport.dispatchEvent(new harness.dom.window.Event("scroll", { bubbles: true }));
+      });
+      expect(viewport.dataset.scrollMode).toBe("detached");
+
+      await act(async () => {
+        root.render(
+          renderFeed(
+            [
+              ...initialItems,
+              message("assistant-2", "assistant", "New answer"),
+              message("assistant-3", "assistant", "Another answer"),
+            ],
+            "thread-a",
+          ),
+        );
+      });
+
+      const jumpButton = container.querySelector(
+        '[aria-label="2 new messages. Jump to latest"]',
+      ) as HTMLButtonElement | null;
+      expect(jumpButton).not.toBeNull();
+      expect(jumpButton?.textContent).toContain("2 new messages");
+      expect(viewport.scrollTop).toBe(100);
+
+      await act(async () => {
+        jumpButton?.click();
+      });
+      expect(container.querySelector('[aria-label="2 new messages. Jump to latest"]')).toBeNull();
+      expect(viewport.scrollTop).toBe(viewport.scrollHeight - viewport.clientHeight);
+
+      await act(async () => root.unmount());
+    } finally {
+      harness.restore();
+    }
+  });
+
+  test("keeps a detached viewport and Activity shell stable when a turn completes", async () => {
+    const heights = new Map([
+      ["user-1", 100],
+      ["assistant-1", 700],
+      ["activity-tool-1", 180],
+    ]);
+    const harness = setupScroller(heights);
+    const activity: ChatRenderItem = {
+      kind: "activity-group",
+      id: "activity-tool-1",
+      recoveredToolIds: [],
+      items: [
+        {
+          id: "tool-1",
+          kind: "tool",
+          ts: "2026-06-26T12:00:01.000Z",
+          completedAt: "2026-06-26T12:00:02.000Z",
+          name: "read",
+          state: "output-available",
+          result: { ok: true },
+        },
+      ],
+    };
+    const items = [
+      message("user-1", "user", "Question"),
+      message("assistant-1", "assistant", "Answer"),
+      activity,
+    ];
+
+    try {
+      const container = harness.dom.window.document.getElementById("root");
+      if (!container) throw new Error("missing root");
+      const root = createRoot(container);
+
+      await act(async () => {
+        root.render(
+          renderFeed(items, "thread-a", false, {
+            liveActivityGroupId: "activity-tool-1",
+          }),
+        );
+      });
+      const viewport = container.querySelector(
+        '[data-slot="message-scroller-viewport"]',
+      ) as HTMLElement | null;
+      const activityShell = container.querySelector(
+        '[data-message-id="activity-tool-1"]',
+      )?.firstElementChild;
+      if (!viewport) throw new Error("missing viewport");
+      viewport.scrollTop = 100;
+      await act(async () => {
+        viewport.dispatchEvent(
+          new harness.dom.window.WheelEvent("wheel", { bubbles: true, deltaY: -80 }),
+        );
+        viewport.dispatchEvent(new harness.dom.window.Event("scroll", { bubbles: true }));
+      });
+
+      await act(async () => {
+        root.render(renderFeed(items, "thread-a", false, { liveActivityGroupId: null }));
+      });
+
+      expect(viewport.scrollTop).toBe(100);
+      expect(
+        container.querySelector('[data-message-id="activity-tool-1"]')?.firstElementChild,
+      ).toBe(activityShell);
+      expect(container.textContent).toContain("Worked for");
 
       await act(async () => root.unmount());
     } finally {

--- a/apps/desktop/test/chat-feed-windowing.test.ts
+++ b/apps/desktop/test/chat-feed-windowing.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import type { FeedItem } from "../src/app/types";
-import { selectFeedDerivationWindow } from "../src/ui/chat/feedWindow";
+import {
+  type FeedDerivationWindowState,
+  resolveFeedDerivationVisibleCount,
+  selectFeedDerivationWindow,
+} from "../src/ui/chat/feedWindow";
 
 function makeFeed(count: number): FeedItem[] {
   return Array.from({ length: count }, (_, index) => ({
@@ -32,5 +36,26 @@ describe("chat feed derivation window", () => {
       hiddenCount: 0,
     });
     expect(selectFeedDerivationWindow(feed, 80).feed).toBe(feed);
+  });
+
+  test("preserves each thread window and its oldest anchor across away arrivals", () => {
+    const windows = new Map<string, FeedDerivationWindowState>([
+      ["thread-a", { feedLength: 200, visibleCount: 200 }],
+      ["thread-b", { feedLength: 200, visibleCount: 80 }],
+    ]);
+    const threadAFeed = makeFeed(203);
+
+    const threadAVisibleCount = resolveFeedDerivationVisibleCount(
+      windows.get("thread-a"),
+      threadAFeed.length,
+      80,
+    );
+    const threadBVisibleCount = resolveFeedDerivationVisibleCount(windows.get("thread-b"), 200, 80);
+    const restoredThreadAWindow = selectFeedDerivationWindow(threadAFeed, threadAVisibleCount);
+
+    expect(threadAVisibleCount).toBe(203);
+    expect(threadBVisibleCount).toBe(80);
+    expect(restoredThreadAWindow.hiddenCount).toBe(0);
+    expect(restoredThreadAWindow.feed[1]?.id).toBe("message-2");
   });
 });

--- a/apps/desktop/test/chat-view.stability.test.tsx
+++ b/apps/desktop/test/chat-view.stability.test.tsx
@@ -811,13 +811,15 @@ describe("desktop chat view stability", () => {
       });
 
       await act(async () => {
-        feed.dispatchEvent(new harness.dom.window.WheelEvent("wheel", { bubbles: true }));
+        feed.dispatchEvent(
+          new harness.dom.window.WheelEvent("wheel", { bubbles: true, deltaY: -80 }),
+        );
         feed.dispatchEvent(new harness.dom.window.Event("scroll", { bubbles: true }));
         await new Promise((resolve) => setTimeout(resolve, 20));
       });
 
       const scrollButton = container.querySelector(
-        '[aria-label="Scroll to end"]',
+        '[aria-label="Jump to latest"]',
       ) as HTMLButtonElement | null;
       expect(scrollButton).not.toBeNull();
       // Positioned above the absolute composer (overlay height 220 + 9px gap).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #223.

Adds user-owned transcript/activity scrolling, stable disclosures, per-thread restoration, unread counts, and one bottom-offset owner.

[desktop_scroll_ownership_isolated_electron_verified.webm](https://cursor.com/agents/bc-2fe1a13d-c977-4764-9f33-e0042e2eeb81/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdesktop_scroll_ownership_isolated_electron_verified.webm)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2fe1a13d-c977-4764-9f33-e0042e2eeb81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2fe1a13d-c977-4764-9f33-e0042e2eeb81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

