### PR TITLE
fix(desktop): address accessibility review feedback

### DIFF
--- a/apps/desktop/src/ui/ChatView.tsx
+++ b/apps/desktop/src/ui/ChatView.tsx
@@ -332,7 +332,7 @@ export function ChatView({ readOnlyNotice }: ChatViewProps = {}) {
 
   const ingestAttachmentFiles = useCallback(
     async (selectedFiles: File[]) => {
-      if (selectedFiles.length === 0) return;
+      if (selectedFiles.length === 0) return false;
 
       const validationMessage = getComposerDraftAttachmentValidationMessage(
         useAppStore.getState().composerDraftsByKey,
@@ -341,14 +341,16 @@ export function ChatView({ readOnlyNotice }: ChatViewProps = {}) {
       );
       if (validationMessage) {
         setAttachmentPickerError(validationMessage);
-        return;
+        return false;
       }
 
       setAttachmentPickerError(null);
       try {
         await addComposerAttachments(selectedFiles);
+        return true;
       } catch (error) {
         setAttachmentPickerError(error instanceof Error ? error.message : String(error));
+        return false;
       }
     },
     [addComposerAttachments, composerDraftKey, setAttachmentPickerError],
@@ -827,6 +829,7 @@ export function ChatView({ readOnlyNotice }: ChatViewProps = {}) {
     <ChatViewContext.Provider value={contextValue}>
       <div className="relative flex h-full min-h-0 flex-col bg-panel">
         <ChatFeed
+          busy={busy}
           transcriptOnly={transcriptOnly}
           disconnected={disconnected}
           visibleFeedLength={visibleFeed.length}

--- a/apps/desktop/src/ui/UniverSpreadsheetCanvas.tsx
+++ b/apps/desktop/src/ui/UniverSpreadsheetCanvas.tsx
@@ -50,7 +50,6 @@ import { useAppStore } from "../app/store";
 import { Button } from "../components/ui/button";
 import { Input } from "../components/ui/input";
 import { openExternalUrl } from "../lib/desktopCommands";
-import { isImeComposing } from "../lib/keyboard";
 import { reportSpreadsheetBackgroundSaveFailure } from "../lib/spreadsheetSaveNotifications";
 import { buildUniverSheetsFooterConfig } from "../lib/univerCanvasConfig";
 import {
@@ -744,11 +743,6 @@ export function UniverSpreadsheetCanvas({ path, compact = false }: UniverSpreads
             className="h-8 border-border bg-[var(--surface-spreadsheet)] text-sm shadow-none"
             value={promptText}
             onChange={(event) => setPromptText(event.currentTarget.value)}
-            onKeyDown={(event) => {
-              if (event.key === "Enter" && isImeComposing(event.nativeEvent)) {
-                event.preventDefault();
-              }
-            }}
             aria-label="Spreadsheet prompt"
             placeholder="Ask agent about this selection..."
           />

--- a/apps/desktop/src/ui/chat/ChatComposer.tsx
+++ b/apps/desktop/src/ui/chat/ChatComposer.tsx
@@ -41,7 +41,7 @@ export function ChatComposer(props: {
   messageBarHeight: number;
   inputDisabled: boolean;
   transcriptOnly: boolean;
-  ingestAttachmentFiles: (files: File[]) => void;
+  ingestAttachmentFiles: (files: File[]) => Promise<boolean>;
   isUploading: boolean;
   pendingAttachments: ComposerAttachmentFile[];
   removeAttachment: (index: number) => void;
@@ -129,9 +129,7 @@ export function ChatComposer(props: {
           className="w-full max-w-full rounded-[28px] border border-border/55 bg-background/95 app-shadow-overlay backdrop-blur-md"
           style={{ "--composer-cap": `${messageBarHeight}px` } as CSSProperties}
           fileDrop={
-            inputDisabled || transcriptOnly
-              ? undefined
-              : { onFiles: (files) => void ingestAttachmentFiles(files) }
+            inputDisabled || transcriptOnly ? undefined : { onFiles: ingestAttachmentFiles }
           }
         >
           {isUploading && !attachmentPickerError && (

--- a/apps/desktop/src/ui/chat/ChatFeed.tsx
+++ b/apps/desktop/src/ui/chat/ChatFeed.tsx
@@ -65,18 +65,23 @@ const COMPLETION_ANNOUNCEMENT_LIFETIME_MS = 4_000;
 const FEED_NEAR_TOP_PX = 160;
 
 const ResponseCompletionAnnouncement = memo(function ResponseCompletionAnnouncement({
+  busy,
   streamingAssistantMessageId,
 }: {
+  busy: boolean;
   streamingAssistantMessageId: string | null | undefined;
 }) {
-  const previousStreamingAssistantMessageIdRef = useRef(streamingAssistantMessageId);
+  const pendingStreamingAssistantMessageIdRef = useRef(streamingAssistantMessageId);
   const announcementSequenceRef = useRef(0);
   const [announcement, setAnnouncement] = useState<{ id: number; message: string } | null>(null);
 
   useEffect(() => {
-    const previousId = previousStreamingAssistantMessageIdRef.current;
-    previousStreamingAssistantMessageIdRef.current = streamingAssistantMessageId;
-    if (!previousId || previousId === streamingAssistantMessageId) return;
+    if (streamingAssistantMessageId) {
+      pendingStreamingAssistantMessageIdRef.current = streamingAssistantMessageId;
+      return;
+    }
+    if (busy || !pendingStreamingAssistantMessageIdRef.current) return;
+    pendingStreamingAssistantMessageIdRef.current = null;
 
     const timeout = window.setTimeout(() => {
       announcementSequenceRef.current += 1;
@@ -86,7 +91,7 @@ const ResponseCompletionAnnouncement = memo(function ResponseCompletionAnnouncem
       });
     }, COMPLETION_ANNOUNCEMENT_DELAY_MS);
     return () => window.clearTimeout(timeout);
-  }, [streamingAssistantMessageId]);
+  }, [busy, streamingAssistantMessageId]);
 
   useEffect(() => {
     if (!announcement) return;
@@ -573,6 +578,7 @@ function TranscriptScroller(props: {
 }
 
 export const ChatFeed = memo(function ChatFeed(props: {
+  busy: boolean;
   transcriptOnly: boolean;
   disconnected: boolean;
   visibleFeedLength: number;
@@ -602,6 +608,7 @@ export const ChatFeed = memo(function ChatFeed(props: {
   onShowAllOlderFeed?: () => void;
 }) {
   const {
+    busy,
     transcriptOnly,
     disconnected,
     visibleFeedLength,
@@ -658,7 +665,10 @@ export const ChatFeed = memo(function ChatFeed(props: {
 
   return (
     <MessageScrollerProvider key={threadId} autoScroll={false} defaultScrollPosition="start">
-      <ResponseCompletionAnnouncement streamingAssistantMessageId={streamingAssistantMessageId} />
+      <ResponseCompletionAnnouncement
+        busy={busy}
+        streamingAssistantMessageId={streamingAssistantMessageId}
+      />
       <TranscriptScroller
         bottomOffset={bottomOffset}
         hydrating={hydrating}

--- a/apps/desktop/src/ui/chat/NewChatLanding.tsx
+++ b/apps/desktop/src/ui/chat/NewChatLanding.tsx
@@ -237,7 +237,7 @@ export function NewChatLanding() {
 
   const ingestAttachmentFiles = useCallback(
     async (selectedFiles: File[]) => {
-      if (selectedFiles.length === 0 || composerLocked) return;
+      if (selectedFiles.length === 0 || composerLocked) return false;
 
       const validationMessage = getComposerDraftAttachmentValidationMessage(
         useAppStore.getState().composerDraftsByKey,
@@ -246,14 +246,16 @@ export function NewChatLanding() {
       );
       if (validationMessage) {
         setAttachmentPickerError(validationMessage);
-        return;
+        return false;
       }
 
       setAttachmentPickerError(null);
       try {
         await addComposerAttachments(selectedFiles);
+        return true;
       } catch (error) {
         setAttachmentPickerError(error instanceof Error ? error.message : String(error));
+        return false;
       }
     },
     [addComposerAttachments, composerDraftKey, composerLocked, setAttachmentPickerError],

--- a/apps/desktop/src/ui/composer/MessageComposer.tsx
+++ b/apps/desktop/src/ui/composer/MessageComposer.tsx
@@ -30,7 +30,7 @@ type MessageComposerSubmissionStatus = "ready" | "pending";
 type MessageComposerMode = "send" | "steer-ready" | "steer-pending";
 
 type MessageComposerFileDropOptions = {
-  onFiles: (files: File[]) => void | Promise<void>;
+  onFiles: (files: File[]) => boolean | Promise<boolean>;
   disabled?: boolean;
 };
 
@@ -115,10 +115,12 @@ export function MessageComposerRoot({
       });
       void Promise.resolve()
         .then(() => fileDrop.onFiles(files))
-        .then(() => {
+        .then((attached) => {
           setDropAnnouncement({
             kind: "status",
-            message: `${files.length} ${fileLabel} attached.`,
+            message: attached
+              ? `${files.length} ${fileLabel} attached.`
+              : `No ${fileLabel} attached.`,
           });
         })
         .catch((error: unknown) => {

--- a/apps/desktop/src/ui/markdown/DesktopMarkdown.tsx
+++ b/apps/desktop/src/ui/markdown/DesktopMarkdown.tsx
@@ -427,7 +427,16 @@ function DesktopCitationChip({
             className="app-surface-card app-shadow-surface-elevated w-[min(23rem,calc(100vw-2rem))] overflow-hidden rounded-lg border-border/32 p-0 text-card-foreground"
             onMouseEnter={handleHoverEnter}
             onMouseLeave={handleHoverLeave}
-            onOpenAutoFocus={(event) => event.preventDefault()}
+            onKeyDown={(event) => {
+              if (sources.length <= 1) return;
+              if (event.key === "ArrowLeft") {
+                event.preventDefault();
+                setActiveIndex((index) => (index - 1 + sources.length) % sources.length);
+              } else if (event.key === "ArrowRight") {
+                event.preventDefault();
+                setActiveIndex((index) => (index + 1) % sources.length);
+              }
+            }}
           >
             <div className="flex items-center gap-0 border-b border-border/32 bg-muted/20 px-1.5 py-0.5">
               <AccessibleIconButton

--- a/apps/desktop/src/ui/onboarding/DesktopOnboarding.tsx
+++ b/apps/desktop/src/ui/onboarding/DesktopOnboarding.tsx
@@ -1034,37 +1034,37 @@ export function DesktopOnboarding() {
   const workspaces = useAppStore((s) => s.workspaces);
   const providerConnected = useAppStore((s) => s.providerConnected);
   const providerStatusByName = useAppStore((s) => s.providerStatusByName);
-  const [dismissPending, setDismissPending] = useState(false);
   const dismissPendingRef = useRef(false);
 
   const requestDismiss = useCallback(async () => {
     if (dismissPendingRef.current) return;
     dismissPendingRef.current = true;
-    setDismissPending(true);
-    const hasConnectedProvider =
-      providerConnected.length > 0 ||
-      Object.values(providerStatusByName).some(
-        (status) => status?.authorized === true || status?.verified === true,
-      );
-    const incompleteSetup = workspaces.length === 0 || !hasConnectedProvider;
-    if (incompleteSetup) {
-      const confirmed = await confirmAction({
-        title: "Skip setup?",
-        message: "You have not finished connecting a provider or adding a workspace yet.",
-        detail:
-          "You can reopen setup later from Settings, but Cowork may feel incomplete until then.",
-        confirmLabel: "Skip for now",
-        cancelLabel: "Continue setup",
-        kind: "warning",
-        defaultAction: "cancel",
-      });
-      if (!confirmed) {
-        dismissPendingRef.current = false;
-        setDismissPending(false);
-        return;
+    try {
+      const hasConnectedProvider =
+        providerConnected.length > 0 ||
+        Object.values(providerStatusByName).some(
+          (status) => status?.authorized === true || status?.verified === true,
+        );
+      const incompleteSetup = workspaces.length === 0 || !hasConnectedProvider;
+      if (incompleteSetup) {
+        const confirmed = await confirmAction({
+          title: "Skip setup?",
+          message: "You have not finished connecting a provider or adding a workspace yet.",
+          detail:
+            "You can reopen setup later from Settings, but Cowork may feel incomplete until then.",
+          confirmLabel: "Skip for now",
+          cancelLabel: "Continue setup",
+          kind: "warning",
+          defaultAction: "cancel",
+        });
+        if (!confirmed) return;
       }
+      dismiss();
+    } catch {
+      // Keep onboarding open when the native confirmation cannot be shown.
+    } finally {
+      dismissPendingRef.current = false;
     }
-    dismiss();
   }, [dismiss, providerConnected.length, providerStatusByName, workspaces.length]);
   const complete = useAppStore((s) => s.completeOnboarding);
   const newThread = useAppStore((s) => s.newThread);
@@ -1073,7 +1073,6 @@ export function DesktopOnboarding() {
   useEffect(() => {
     if (visible) return;
     dismissPendingRef.current = false;
-    setDismissPending(false);
   }, [visible]);
 
   const goTo = useCallback((next: OnboardingStep) => setStep(next), [setStep]);
@@ -1110,7 +1109,7 @@ export function DesktopOnboarding() {
 
   return (
     <Dialog
-      open={!dismissPending}
+      open
       onOpenChange={(open) => {
         if (!open) void requestDismiss();
       }}

--- a/apps/desktop/src/ui/research/NewResearchComposer.tsx
+++ b/apps/desktop/src/ui/research/NewResearchComposer.tsx
@@ -179,6 +179,7 @@ export function NewResearchComposer({ onSubmitted }: { onSubmitted?: () => void 
           onFiles: async (files) => {
             try {
               await addResearchCreationAttachments(files);
+              return true;
             } catch (error) {
               setResearchCreationError(
                 draft.revision,

--- a/apps/desktop/src/ui/research/ResearchFollowUpComposer.tsx
+++ b/apps/desktop/src/ui/research/ResearchFollowUpComposer.tsx
@@ -80,6 +80,7 @@ export function ResearchFollowUpComposer({
           disabled: disabled || submitting,
           onFiles: async (files) => {
             addFiles(files);
+            return true;
           },
         }}
       >

--- a/apps/desktop/test/accessibility-review-fixes.test.ts
+++ b/apps/desktop/test/accessibility-review-fixes.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+
+async function readDesktopSource(path: string): Promise<string> {
+  return readFile(new URL(`../src/${path}`, import.meta.url), "utf8");
+}
+
+describe("accessibility review fixes", () => {
+  test("citation popovers allow focus entry and handle source navigation inside the content", async () => {
+    const source = await readDesktopSource("ui/markdown/DesktopMarkdown.tsx");
+    expect(source).not.toContain("onOpenAutoFocus={(event) => event.preventDefault()}");
+    expect(source).toMatch(/<PopoverContent[\s\S]*onKeyDown=[\s\S]*ArrowLeft[\s\S]*ArrowRight/);
+  });
+
+  test("onboarding stays mounted while dismissal confirmation runs or fails", async () => {
+    const source = await readDesktopSource("ui/onboarding/DesktopOnboarding.tsx");
+    expect(source).toContain("<Dialog\n      open");
+    expect(source).toContain("finally {\n      dismissPendingRef.current = false;");
+  });
+
+  test("response completion waits for the thread to stop being busy", async () => {
+    const source = await readDesktopSource("ui/chat/ChatFeed.tsx");
+    expect(source).toContain("if (busy || !pendingStreamingAssistantMessageIdRef.current) return;");
+    expect(source).toContain("busy={busy}");
+  });
+
+  test("chat attachment ingestion reports rejected and accepted outcomes", async () => {
+    const sources = await Promise.all([
+      readDesktopSource("ui/ChatView.tsx"),
+      readDesktopSource("ui/chat/NewChatLanding.tsx"),
+    ]);
+    for (const source of sources) {
+      expect(source).toContain("return false;");
+      expect(source).toContain("return true;");
+    }
+  });
+});

--- a/apps/desktop/test/ime-safe-submit.test.ts
+++ b/apps/desktop/test/ime-safe-submit.test.ts
@@ -54,4 +54,12 @@ describe("IME-safe submit shortcuts", () => {
     expect(sources[1]).toContain("isPlainEnterWithoutIme(event)");
     expect(sources[2]).toContain("isEnterWithoutIme(e)");
   });
+
+  test("lets the spreadsheet IME handle composing Enter", async () => {
+    const source = await readFile(
+      new URL("../src/ui/UniverSpreadsheetCanvas.tsx", import.meta.url),
+      "utf8",
+    );
+    expect(source).not.toContain('event.key === "Enter" && isImeComposing');
+  });
 });

--- a/apps/desktop/test/message-composer.test.tsx
+++ b/apps/desktop/test/message-composer.test.tsx
@@ -124,7 +124,7 @@ describe("message composer", () => {
 
   test("preserves drag-and-drop file ingestion", async () => {
     const harness = setupJsdom();
-    const onFiles = mock(async (_files: File[]) => {});
+    const onFiles = mock(async (_files: File[]) => true);
 
     try {
       const container = harness.dom.window.document.getElementById("root");
@@ -219,6 +219,47 @@ describe("message composer", () => {
       expect(container.querySelector('[role="alert"]')?.textContent).toContain(
         "Could not attach 1 file. Unsupported file",
       );
+      await act(async () => root.unmount());
+    } finally {
+      harness.restore();
+    }
+  });
+
+  test("does not announce attachment success when ingestion rejects the files", async () => {
+    const harness = setupJsdom();
+    const onFiles = mock(async (_files: File[]) => false);
+
+    try {
+      const container = harness.dom.window.document.getElementById("root");
+      if (!container) throw new Error("missing root");
+      const root = createRoot(container);
+      await act(async () => {
+        root.render(
+          createElement(
+            MessageComposerRoot,
+            { fileDrop: { onFiles } },
+            createElement(MessageComposerTextarea, { "aria-label": "Draft" }),
+          ),
+        );
+      });
+
+      const composer = container.querySelector(
+        '[data-slot="message-composer"]',
+      ) as HTMLFieldSetElement | null;
+      if (!composer) throw new Error("missing composer");
+      const file = new harness.dom.window.File(["bad"], "bad.bin");
+      const drop = new harness.dom.window.Event("drop", { bubbles: true });
+      Object.defineProperty(drop, "dataTransfer", {
+        value: { files: [file], types: ["Files"], dropEffect: "none" },
+      });
+      await act(async () => {
+        composer.dispatchEvent(drop);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(container.querySelector('[role="status"]')?.textContent).toContain("No file attached");
+      expect(container.textContent).not.toContain("1 file attached");
       await act(async () => root.unmount());
     } finally {
       harness.restore();


### PR DESCRIPTION
## What and why

Follow up on the actionable review comments left on #278 after its rebase and merge.

- keep citation popover actions keyboard reachable and support arrow navigation inside the popover
- report file-drop success only when attachment ingestion actually succeeds
- keep onboarding visible when skip confirmation is cancelled or fails
- announce response completion only after the thread is no longer busy
- let IME Enter commit spreadsheet prompt candidates instead of cancelling the key event
- add focused regression coverage for each review cluster

## How to test

- `bun run check`
- `bun run lint`
- `bun run typecheck`
- `bun run docs:check`
- `bun test apps/desktop/test/message-composer.test.tsx apps/desktop/test/ime-safe-submit.test.ts apps/desktop/test/accessibility-review-fixes.test.ts`
- `bun test --max-concurrency 1` (local run still shows the existing mobile subprocess, filesystem watcher, and WebSocket invalidation timing flakes; exact-head CI is authoritative)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and accessibility behavior only; no auth, data, or server changes. Risk is limited to announcement timing and drag-drop messaging edge cases.
> 
> **Overview**
> Addresses follow-up accessibility review items across chat, onboarding, citations, and spreadsheet UI.
> 
> **Citation popovers** no longer block focus on open; **ArrowLeft** / **ArrowRight** navigate sources inside the popover content (in addition to existing chip-level handling).
> 
> **File drop** ingestion now returns a **boolean** so `MessageComposer` only announces success when attachments actually attach; rejected validation or upload failures surface as “No file(s) attached.” Chat and new-chat composers pass the async handler through directly.
> 
> **“Cowork response complete”** screen-reader announcement waits until the thread is **not busy** and streaming has ended, avoiding premature completion toasts while work continues.
> 
> **Onboarding** keeps the dialog **open** during skip confirmation (no unmount while `confirmAction` runs); cancel, confirm failure, or native dialog errors leave setup visible.
> 
> **Spreadsheet agent prompt** drops the Enter + IME `preventDefault`, so composing users can commit IME candidates instead of having Enter swallowed.
> 
> Regression tests cover these clusters in `accessibility-review-fixes.test.ts`, `message-composer.test.tsx`, and `ime-safe-submit.test.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e6b3437817e3861b28b4e80e59a15c08ea3a724. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->