### PR TITLE
fix(desktop): make transcript copy and attachment-only turns semantic

### DIFF
--- a/apps/desktop/src/ui/chat/FeedRow.tsx
+++ b/apps/desktop/src/ui/chat/FeedRow.tsx
@@ -1,4 +1,5 @@
 import {
+  AlertCircleIcon,
   CheckIcon,
   CopyIcon,
   FileAudioIcon,
@@ -26,6 +27,7 @@ import { Button } from "../../components/ui/button";
 import { Card, CardContent } from "../../components/ui/card";
 import { Marker, MarkerContent } from "../../components/ui/marker";
 import { Message, MessageContent } from "../../components/ui/message";
+import { copyText as writeClipboardText } from "../../lib/desktopCommands";
 import {
   encodeDesktopMediaUrl,
   isAbsoluteDesktopPath,
@@ -33,21 +35,97 @@ import {
 } from "../../lib/mediaProtocol";
 import { openExternalSource } from "../../lib/openExternalSource";
 import { cn } from "../../lib/utils";
-import { DesktopMarkdown } from "../markdown";
+import { DesktopMarkdown, rewriteDesktopImageUrl } from "../markdown";
 import { recordDesktopRenderMetric } from "../renderDiagnostics";
 import { useChatViewContext } from "./ChatViewContext";
 import { CitationSourcesCarousel } from "./CitationSourcesCarousel";
 import type { MentionCatalog } from "./composerMentions";
 import {
+  buildVisibleUserMessage,
   type CanvasRequest,
-  parseCanvasRequest,
-  parseUserMessageAttachments,
+  canvasFallbackName,
+  type VisibleUserAttachment,
 } from "./feedMessageParsing";
 import { MentionText } from "./MentionText";
 import { ToolCard } from "./toolCards/ToolCard";
 
-function MessageCopyAction(props: { text: string; className?: string }) {
-  const [copied, setCopied] = useState(false);
+type CopyStatus = "idle" | "copied" | "failed";
+
+function copyStatusLabel(status: CopyStatus, idleLabel: string): string {
+  switch (status) {
+    case "idle":
+      return idleLabel;
+    case "copied":
+      return "Copied";
+    case "failed":
+      return "Copy failed. Retry.";
+    default: {
+      const _exhaustive: never = status;
+      return _exhaustive;
+    }
+  }
+}
+
+function copyButtonCaption(status: CopyStatus): string {
+  switch (status) {
+    case "idle":
+      return "Copy";
+    case "copied":
+      return "Copied";
+    case "failed":
+      return "Retry";
+    default: {
+      const _exhaustive: never = status;
+      return _exhaustive;
+    }
+  }
+}
+
+function copyStatusSrOnly(status: CopyStatus): string {
+  switch (status) {
+    case "idle":
+      return "Copy";
+    case "copied":
+      return "Copied";
+    case "failed":
+      return "Copy failed. Retry.";
+    default: {
+      const _exhaustive: never = status;
+      return _exhaustive;
+    }
+  }
+}
+function copyLiveAnnouncement(status: CopyStatus): string {
+  switch (status) {
+    case "idle":
+      return "";
+    case "copied":
+      return "Copied";
+    case "failed":
+      return "Couldn't copy message. Try again.";
+    default: {
+      const _exhaustive: never = status;
+      return _exhaustive;
+    }
+  }
+}
+function CopyStatusIcon(props: { status: CopyStatus }) {
+  switch (props.status) {
+    case "copied":
+      return <CheckIcon data-icon="inline-start" className="text-success" />;
+    case "failed":
+      return <AlertCircleIcon data-icon="inline-start" className="text-destructive" />;
+    case "idle":
+      return <CopyIcon data-icon="inline-start" />;
+    default: {
+      const _exhaustive: never = props.status;
+      return _exhaustive;
+    }
+  }
+}
+
+function useClipboardCopy() {
+  const [status, setStatus] = useState<CopyStatus>("idle");
   const copyTimeoutRef = useRef<number | null>(null);
 
   useEffect(() => {
@@ -58,65 +136,59 @@ function MessageCopyAction(props: { text: string; className?: string }) {
     };
   }, []);
 
-  const handleCopy = async () => {
+  const copy = async (text: string) => {
     try {
-      await navigator.clipboard.writeText(props.text);
-      setCopied(true);
+      await writeClipboardText(text);
+      setStatus("copied");
       if (copyTimeoutRef.current !== null) {
         window.clearTimeout(copyTimeoutRef.current);
       }
-      copyTimeoutRef.current = window.setTimeout(() => setCopied(false), 1500);
+      copyTimeoutRef.current = window.setTimeout(() => setStatus("idle"), 1500);
     } catch {
-      // Clipboard may be unavailable (permissions, non-secure context). Fail silently.
+      if (copyTimeoutRef.current !== null) {
+        window.clearTimeout(copyTimeoutRef.current);
+        copyTimeoutRef.current = null;
+      }
+      setStatus("failed");
     }
   };
+
+  return { status, copy };
+}
+
+function MessageCopyAction(props: { text: string; className?: string }) {
+  const { status, copy } = useClipboardCopy();
+  const label = copyStatusLabel(status, "Copy message");
+
   return (
     <Button
       type="button"
       variant="ghost"
       size="icon-xs"
-      onClick={handleCopy}
-      aria-label={copied ? "Copied" : "Copy message"}
+      onClick={() => {
+        void copy(props.text);
+      }}
+      aria-label={label}
+      title={label}
       className={cn(
         "opacity-0 transition-opacity duration-150 focus-visible:opacity-100 group-hover/message:opacity-100 group-focus-within/message:opacity-100",
+        status !== "idle" && "opacity-100",
         props.className,
       )}
     >
-      {copied ? (
-        <CheckIcon data-icon="inline-start" className="text-success" />
-      ) : (
-        <CopyIcon data-icon="inline-start" />
-      )}
-      <span className="sr-only">{copied ? "Copied" : "Copy"}</span>
+      <CopyStatusIcon status={status} />
+      <span className="sr-only">{copyStatusSrOnly(status)}</span>
+      <span className="sr-only" role="status" aria-live="polite" aria-atomic="true">
+        {copyLiveAnnouncement(status)}
+      </span>
     </Button>
   );
 }
 
 function ErrorFeedRow(props: { message: string }) {
-  const [copied, setCopied] = useState(false);
+  const { status, copy } = useClipboardCopy();
   const [expanded, setExpanded] = useState(false);
-  const copyTimeoutRef = useRef<number | null>(null);
-
-  useEffect(() => {
-    return () => {
-      if (copyTimeoutRef.current !== null) {
-        window.clearTimeout(copyTimeoutRef.current);
-      }
-    };
-  }, []);
-
-  const handleCopy = async () => {
-    try {
-      await navigator.clipboard.writeText(props.message);
-      setCopied(true);
-      if (copyTimeoutRef.current !== null) {
-        window.clearTimeout(copyTimeoutRef.current);
-      }
-      copyTimeoutRef.current = window.setTimeout(() => setCopied(false), 1500);
-    } catch {
-      // Clipboard unavailable — fail silently.
-    }
-  };
+  const copyLabel = copyStatusLabel(status, "Copy error");
   return (
     <Card
       role="alert"
@@ -130,16 +202,21 @@ function ErrorFeedRow(props: { message: string }) {
           <div className="flex items-center gap-1">
             <button
               type="button"
-              onClick={handleCopy}
-              aria-label={copied ? "Copied" : "Copy error"}
+              onClick={() => {
+                void copy(props.message);
+              }}
+              aria-label={copyLabel}
+              title={copyLabel}
               className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             >
-              {copied ? (
+              {status === "copied" ? (
                 <CheckIcon className="size-3 text-success" />
+              ) : status === "failed" ? (
+                <AlertCircleIcon className="size-3 text-destructive" />
               ) : (
                 <CopyIcon className="size-3" />
               )}
-              {copied ? "Copied" : "Copy"}
+              {copyButtonCaption(status)}
             </button>
             <button
               type="button"
@@ -168,14 +245,14 @@ function ErrorFeedRow(props: { message: string }) {
 export function CanvasRequestBody(props: { request: CanvasRequest; catalog: MentionCatalog }) {
   const { request, catalog } = props;
   const FileGlyph = request.surface === "spreadsheet" ? FileSpreadsheetIcon : FileTextIcon;
-  const fallbackName = request.surface === "spreadsheet" ? "Spreadsheet" : "Document";
+  const fallbackName = canvasFallbackName(request.surface);
 
   return (
     <div className="flex flex-col gap-2">
       <div className="flex flex-wrap items-center gap-1.5 select-none">
         <span className="inline-flex min-w-0 items-center gap-1 rounded-md border border-primary/25 bg-primary/10 px-1.5 py-0.5 text-xs font-medium text-foreground/90">
           <FileGlyph className="size-3 shrink-0 text-primary/80" />
-          <span className="max-w-[200px] truncate" title={request.fileName ?? undefined}>
+          <span className="max-w-[200px] truncate" title={request.fileName ?? fallbackName}>
             {request.fileName ?? fallbackName}
           </span>
         </span>
@@ -210,7 +287,7 @@ export function CanvasRequestBody(props: { request: CanvasRequest; catalog: Ment
 
 function attachmentIconForFilename(fileName: string) {
   if (/\.(mp3|wav|ogg|m4a|aac|flac)$/i.test(fileName)) return FileAudioIcon;
-  if (/\.(png|jpe?g|gif|webp|svg)$/i.test(fileName)) return FileImageIcon;
+  if (/\.(png|jpe?g|gif|webp|svg|bmp|ico|avif)$/i.test(fileName)) return FileImageIcon;
   if (/\.(mp4|mov|avi|mkv|webm)$/i.test(fileName)) return FileVideoIcon;
   if (/\.pdf$/i.test(fileName)) return FileTextIcon;
   return FileIcon;
@@ -221,11 +298,42 @@ function attachmentTypeForFilename(fileName: string): string {
   return extension && extension !== fileName ? extension.toUpperCase() : "FILE";
 }
 
-function attachmentPreviewSrc(fileName: string): string | null {
-  if (!isAbsoluteDesktopPath(fileName) || !isDesktopMediaImagePath(fileName)) {
+const WORKSPACE_UPLOADS_DIR = "User Uploads";
+const URL_SCHEME_RE = /^[a-zA-Z][a-zA-Z0-9+.-]*:/;
+
+function hasUnsafeAttachmentPreviewScheme(fileName: string): boolean {
+  const trimmed = fileName.trim();
+  if (!trimmed) return true;
+  return URL_SCHEME_RE.test(trimmed) && !isAbsoluteDesktopPath(trimmed);
+}
+
+function isSafeAttachmentPreviewSrc(src: string): boolean {
+  return src.startsWith("cowork-media:");
+}
+
+export function resolveUserAttachmentPreviewSrc(
+  fileName: string,
+  desktopBasePath?: string | null,
+): string | null {
+  if (!isDesktopMediaImagePath(fileName) || hasUnsafeAttachmentPreviewScheme(fileName)) {
     return null;
   }
-  return encodeDesktopMediaUrl(fileName);
+
+  const absolute = encodeDesktopMediaUrl(fileName);
+  if (absolute && isSafeAttachmentPreviewSrc(absolute)) return absolute;
+  if (!desktopBasePath) return null;
+
+  const normalized = fileName.replace(/\\/g, "/");
+  const candidates =
+    normalized.includes("/") || normalized.includes(":")
+      ? [normalized]
+      : [`${WORKSPACE_UPLOADS_DIR}/${normalized}`, normalized];
+
+  for (const candidate of candidates) {
+    const rewritten = rewriteDesktopImageUrl(candidate, desktopBasePath);
+    if (rewritten && isSafeAttachmentPreviewSrc(rewritten)) return rewritten;
+  }
+  return null;
 }
 
 function keyedAttachmentFileNames(fileNames: readonly string[]) {
@@ -237,13 +345,19 @@ function keyedAttachmentFileNames(fileNames: readonly string[]) {
   });
 }
 
-function UserAttachmentGroup(props: { fileNames: readonly string[] }) {
-  if (props.fileNames.length === 0) return null;
+function UserAttachmentGroup(props: {
+  attachments: readonly VisibleUserAttachment[];
+  desktopBasePath?: string | null;
+}) {
+  if (props.attachments.length === 0) return null;
+  const fileNames = props.attachments.map((attachment) => attachment.fileName);
   return (
-    <AttachmentGroup className="max-w-full">
-      {keyedAttachmentFileNames(props.fileNames).map(({ fileName, key }) => {
-        const previewSrc = attachmentPreviewSrc(fileName);
-        const IconComponent = attachmentIconForFilename(fileName);
+    <AttachmentGroup className="max-w-full" aria-label="Attached files">
+      {keyedAttachmentFileNames(fileNames).map(({ fileName, key }, index) => {
+        const attachment = props.attachments[index];
+        const displayName = attachment?.displayName ?? fileName;
+        const previewSrc = resolveUserAttachmentPreviewSrc(fileName, props.desktopBasePath);
+        const IconComponent = attachmentIconForFilename(displayName);
         return (
           <Attachment key={key} size="sm">
             <AttachmentMedia variant={previewSrc ? "image" : "icon"}>
@@ -254,25 +368,16 @@ function UserAttachmentGroup(props: { fileNames: readonly string[] }) {
               )}
             </AttachmentMedia>
             <AttachmentContent>
-              <AttachmentTitle title={fileName}>{fileName}</AttachmentTitle>
-              <AttachmentDescription>{attachmentTypeForFilename(fileName)}</AttachmentDescription>
+              <AttachmentTitle title={displayName}>{displayName}</AttachmentTitle>
+              <AttachmentDescription>
+                {attachmentTypeForFilename(displayName)}
+              </AttachmentDescription>
             </AttachmentContent>
           </Attachment>
         );
       })}
     </AttachmentGroup>
   );
-}
-
-function resolveUserCopyText(opts: {
-  canvasRequest: CanvasRequest | null;
-  cleanText: string;
-  rawText: string;
-}): string {
-  if (opts.canvasRequest) {
-    return opts.canvasRequest.userRequest || opts.cleanText || opts.rawText;
-  }
-  return opts.cleanText || opts.rawText;
 }
 
 export const FeedRow = memo(function FeedRow(props: {
@@ -296,16 +401,8 @@ export const FeedRow = memo(function FeedRow(props: {
       // action special rendering removed (feature fully stripped)
     }
 
-    const userMessage = item.role === "user" ? parseUserMessageAttachments(item.text) : null;
-    const canvasRequest = userMessage ? parseCanvasRequest(userMessage.cleanText) : null;
-    const copyText =
-      item.role === "user" && userMessage
-        ? resolveUserCopyText({
-            canvasRequest,
-            cleanText: userMessage.cleanText,
-            rawText: item.text,
-          })
-        : item.text;
+    const visibleUserMessage = item.role === "user" ? buildVisibleUserMessage(item.text) : null;
+    const copyText = visibleUserMessage?.copyText ?? item.text;
     const isStreamingAssistant = item.role === "assistant" && props.isStreaming === true;
     if (isStreamingAssistant) {
       recordDesktopRenderMetric("streaming-markdown", item.id);
@@ -348,13 +445,19 @@ export const FeedRow = memo(function FeedRow(props: {
             >
               <BubbleContent className="cursor-text select-text rounded-2xl rounded-br-md px-3.5 py-2.5 text-[15px] leading-relaxed whitespace-pre-wrap selection:bg-primary/20">
                 <div className="flex flex-col gap-2">
-                  {canvasRequest ? (
-                    <CanvasRequestBody request={canvasRequest} catalog={mentionCatalog} />
-                  ) : userMessage?.cleanText ? (
-                    <MentionText text={userMessage.cleanText} catalog={mentionCatalog} />
+                  {visibleUserMessage?.canvas ? (
+                    <CanvasRequestBody
+                      request={visibleUserMessage.canvas}
+                      catalog={mentionCatalog}
+                    />
+                  ) : visibleUserMessage?.bodyText ? (
+                    <MentionText text={visibleUserMessage.bodyText} catalog={mentionCatalog} />
                   ) : null}
-                  {userMessage && userMessage.fileNames.length > 0 ? (
-                    <UserAttachmentGroup fileNames={userMessage.fileNames} />
+                  {visibleUserMessage && visibleUserMessage.attachments.length > 0 ? (
+                    <UserAttachmentGroup
+                      attachments={visibleUserMessage.attachments}
+                      desktopBasePath={props.desktopBasePath}
+                    />
                   ) : null}
                 </div>
               </BubbleContent>
@@ -368,17 +471,19 @@ export const FeedRow = memo(function FeedRow(props: {
             />
           ) : null}
 
-          <div
-            className={cn(
-              "pointer-events-none -mt-2 flex h-6 items-center",
-              item.role === "user" ? "justify-end" : "justify-start",
-            )}
-            data-slot="message-actions"
-          >
-            <div className="pointer-events-auto">
-              <MessageCopyAction text={copyText} />
+          {copyText ? (
+            <div
+              className={cn(
+                "pointer-events-none -mt-2 flex h-6 items-center",
+                item.role === "user" ? "justify-end" : "justify-start",
+              )}
+              data-slot="message-actions"
+            >
+              <div className="pointer-events-auto">
+                <MessageCopyAction text={copyText} />
+              </div>
             </div>
-          </div>
+          ) : null}
         </MessageContent>
       </Message>
     );

--- a/apps/desktop/src/ui/chat/feedMessageParsing.ts
+++ b/apps/desktop/src/ui/chat/feedMessageParsing.ts
@@ -1,3 +1,5 @@
+import { getFilePreviewKind } from "../../lib/filePreviewKind";
+
 export type CanvasRequestSurface = "spreadsheet" | "document";
 
 export type CanvasRequest = {
@@ -114,28 +116,186 @@ export function parseCanvasRequest(text: string): CanvasRequest | null {
   return null;
 }
 
+function looksLikeCanvasEnvelope(text: string): boolean {
+  const trimmed = text.trim();
+  return (
+    trimmed.startsWith("<spreadsheet_canvas_request") ||
+    trimmed.startsWith("<canvas_request") ||
+    trimmed.startsWith("[Canvas Collaborative Edit]")
+  );
+}
+
+function inferCanvasSurface(text: string): CanvasRequestSurface {
+  return text.trim().startsWith("<spreadsheet_canvas_request") ? "spreadsheet" : "document";
+}
+
+/**
+ * Recover a compact canvas model from a stored envelope, including malformed
+ * or partial payloads. Never returns null for a recognized envelope — the
+ * transcript can always show a readable chip instead of raw serialization.
+ */
+export function interpretCanvasRequest(text: string): CanvasRequest | null {
+  const trimmed = text.trim();
+  if (!looksLikeCanvasEnvelope(trimmed)) return null;
+
+  const parsed = parseCanvasRequest(trimmed);
+  if (parsed) return parsed;
+
+  const userRequest = firstCapture(trimmed, /<user_request>([\s\S]*?)<\/user_request>/) ?? "";
+  const fileName =
+    firstCapture(trimmed, /<workbook\b[^>]*?\sfile_name="([^"]*)"/) ??
+    firstCapture(trimmed, /<file\b[^>]*?\sname="([^"]*)"/) ??
+    trimmed.match(/edit the file `([^`]+)`/)?.[1]?.trim() ??
+    null;
+
+  return {
+    surface: inferCanvasSurface(trimmed),
+    fileName,
+    fileKind: firstCapture(trimmed, /\skind="([^"]*)"/),
+    sheet: firstCapture(trimmed, /<active_sheet>([\s\S]*?)<\/active_sheet>/),
+    region: firstCapture(trimmed, /\srange="([^"]*)"/),
+    selectionText:
+      firstCapture(trimmed, /<selection\b[^>]*>\s*<value>([\s\S]*?)<\/value>/) ??
+      firstCapture(trimmed, /<selection>([\s\S]*?)<\/selection>/),
+    userRequest,
+  };
+}
+
+function parseAttachmentNameList(raw: string): string[] {
+  const unwrapped = raw
+    .trim()
+    .replace(/^\[[\s\u00A0]*/, "")
+    .replace(/[\s\u00A0]*\]$/, "");
+  if (!unwrapped) return [];
+  return unwrapped
+    .split(/,\s+/)
+    .map((name) => name.trim())
+    .filter(Boolean);
+}
+
 export function parseUserMessageAttachments(text: string): {
   cleanText: string;
   fileNames: string[];
 } {
-  const attachedMatch = text.match(/\n\nAttached:\s+\[(.*?)\]$/);
+  const attachedMatch = text.match(/\n\nAttached:\s+\[(.*?)\]\s*$/);
   if (attachedMatch) {
-    const fileNames = attachedMatch[1]
-      .split(/,\s+/)
-      .map((f) => f.trim())
-      .filter(Boolean);
-    const cleanText = text.substring(0, attachedMatch.index).trim();
-    return { cleanText, fileNames };
+    return {
+      cleanText: text.substring(0, attachedMatch.index).trim(),
+      fileNames: parseAttachmentNameList(attachedMatch[1]),
+    };
   }
 
-  const onlyAttachmentsMatch = text.match(/^\[(.*?)\]$/);
+  const attachedLooseMatch = text.match(/\n\nAttached:\s*(\S[\s\S]*)$/);
+  if (attachedLooseMatch) {
+    return {
+      cleanText: text.substring(0, attachedLooseMatch.index).trim(),
+      fileNames: parseAttachmentNameList(attachedLooseMatch[1]),
+    };
+  }
+
+  const onlyAttachmentsMatch = text.match(/^\[(.*?)\]\s*$/);
   if (onlyAttachmentsMatch) {
-    const fileNames = onlyAttachmentsMatch[1]
-      .split(/,\s+/)
-      .map((f) => f.trim())
-      .filter(Boolean);
-    return { cleanText: "", fileNames };
+    return {
+      cleanText: "",
+      fileNames: parseAttachmentNameList(onlyAttachmentsMatch[1]),
+    };
   }
 
   return { cleanText: text, fileNames: [] };
+}
+
+export type VisibleUserAttachment = {
+  fileName: string;
+  displayName: string;
+  isImage: boolean;
+};
+
+export type VisibleUserMessage = {
+  bodyText: string;
+  attachments: VisibleUserAttachment[];
+  canvas: CanvasRequest | null;
+  copyText: string;
+};
+
+function attachmentDisplayName(fileName: string): string {
+  const normalized = fileName.replace(/\\/g, "/").trim();
+  const base = normalized.split("/").pop()?.trim();
+  if (!base || base === "." || base === "..") return fileName.trim();
+  return base;
+}
+
+export function canvasFallbackName(surface: CanvasRequestSurface): string {
+  return surface === "spreadsheet" ? "Spreadsheet" : "Document";
+}
+
+function formatCanvasCopyText(request: CanvasRequest): string {
+  const header = [
+    request.fileName ?? canvasFallbackName(request.surface),
+    request.sheet,
+    request.region,
+  ]
+    .filter((part): part is string => Boolean(part?.trim()))
+    .join(" · ");
+  const lines: string[] = [];
+  if (header) lines.push(header);
+  if (request.selectionText) lines.push(`\u201C${request.selectionText}\u201D`);
+  if (request.userRequest) lines.push(request.userRequest);
+  return lines.join("\n");
+}
+
+function formatAttachmentCopyText(attachments: readonly VisibleUserAttachment[]): string {
+  const names = attachments.map((attachment) => attachment.displayName).filter(Boolean);
+  if (names.length === 0) return "";
+  if (names.length === 1) return names[0];
+  return `Attached: ${names.join(", ")}`;
+}
+
+function formatVisibleUserCopyText(opts: {
+  bodyText: string;
+  attachments: readonly VisibleUserAttachment[];
+  canvas: CanvasRequest | null;
+}): string {
+  if (opts.canvas) {
+    const canvasText = formatCanvasCopyText(opts.canvas);
+    const attached = formatAttachmentCopyText(opts.attachments);
+    if (canvasText && attached) return `${canvasText}\n\n${attached}`;
+    return canvasText || attached;
+  }
+  const attached = formatAttachmentCopyText(opts.attachments);
+  const body = opts.bodyText.trim();
+  if (body && attached) return `${body}\n\n${attached}`;
+  return body || attached;
+}
+
+function isImageAttachmentName(fileName: string): boolean {
+  return (
+    getFilePreviewKind(fileName) === "image" ||
+    getFilePreviewKind(attachmentDisplayName(fileName)) === "image"
+  );
+}
+
+/**
+ * One semantic view of a persisted user turn: visible body, attachments, canvas
+ * context, and the clipboard string. Callers must not copy or render `rawText`
+ * once this model exists — that string can contain attachment/Canvas markup.
+ */
+export function buildVisibleUserMessage(rawText: string): VisibleUserMessage {
+  const parsed = parseUserMessageAttachments(rawText);
+  const canvas = interpretCanvasRequest(parsed.cleanText);
+  const attachments = parsed.fileNames.map((fileName) => ({
+    fileName,
+    displayName: attachmentDisplayName(fileName),
+    isImage: isImageAttachmentName(fileName),
+  }));
+  const bodyText = canvas ? canvas.userRequest : parsed.cleanText;
+  return {
+    bodyText,
+    attachments,
+    canvas,
+    copyText: formatVisibleUserCopyText({
+      bodyText: canvas ? canvas.userRequest : parsed.cleanText,
+      attachments,
+      canvas,
+    }),
+  };
 }

--- a/apps/desktop/test/feed-message-parsing.test.ts
+++ b/apps/desktop/test/feed-message-parsing.test.ts
@@ -7,7 +7,11 @@ import {
   selectionContextFromWorkbook,
   spreadsheetSnapshotToUniverData,
 } from "../src/lib/univerSpreadsheet";
-import { parseCanvasRequest } from "../src/ui/chat/feedMessageParsing";
+import {
+  buildVisibleUserMessage,
+  interpretCanvasRequest,
+  parseCanvasRequest,
+} from "../src/ui/chat/feedMessageParsing";
 
 const WORKBOOK: SpreadsheetWorkbookSnapshot = {
   kind: "xlsx",
@@ -151,5 +155,137 @@ describe("parseCanvasRequest", () => {
   test("returns null for ordinary user messages", () => {
     expect(parseCanvasRequest("just a normal question")).toBeNull();
     expect(parseCanvasRequest("<not_a_canvas>hi</not_a_canvas>")).toBeNull();
+  });
+});
+
+describe("buildVisibleUserMessage", () => {
+  test("copies text-only turns as the visible body", () => {
+    const visible = buildVisibleUserMessage("Please summarize this thread.");
+    expect(visible.bodyText).toBe("Please summarize this thread.");
+    expect(visible.attachments).toEqual([]);
+    expect(visible.canvas).toBeNull();
+    expect(visible.copyText).toBe("Please summarize this thread.");
+  });
+
+  test("copies attachment-only turns as human-visible names, not bracket serialization", () => {
+    const visible = buildVisibleUserMessage("[diagram.png]");
+    expect(visible.bodyText).toBe("");
+    expect(visible.attachments).toEqual([
+      { fileName: "diagram.png", displayName: "diagram.png", isImage: true },
+    ]);
+    expect(visible.copyText).toBe("diagram.png");
+    expect(visible.copyText).not.toContain("[");
+  });
+
+  test("copies mixed file turns as visible text plus attachment names", () => {
+    const visible = buildVisibleUserMessage(
+      "Please review these.\n\nAttached: [diagram.png, findings.pdf]",
+    );
+    expect(visible.bodyText).toBe("Please review these.");
+    expect(visible.attachments.map((attachment) => attachment.displayName)).toEqual([
+      "diagram.png",
+      "findings.pdf",
+    ]);
+    expect(visible.attachments[0]?.isImage).toBe(true);
+    expect(visible.attachments[1]?.isImage).toBe(false);
+    expect(visible.copyText).toBe("Please review these.\n\nAttached: diagram.png, findings.pdf");
+    expect(visible.copyText).not.toContain("[diagram.png");
+  });
+
+  test("uses basenames for copied image paths and marks them as images", () => {
+    const visible = buildVisibleUserMessage("[/Users/test/User Uploads/chart.webp]");
+    expect(visible.attachments).toEqual([
+      {
+        fileName: "/Users/test/User Uploads/chart.webp",
+        displayName: "chart.webp",
+        isImage: true,
+      },
+    ]);
+    expect(visible.copyText).toBe("chart.webp");
+  });
+
+  test("copies canvas requests as the visible file, region, and user text", () => {
+    const prompt = buildCanvasDocumentPrompt({
+      path: "/w/spec.md",
+      fileName: "spec.md",
+      kind: "markdown",
+      selection: "The legacy intro section",
+      request: "rewrite this to be concise",
+    });
+    const visible = buildVisibleUserMessage(prompt);
+    expect(visible.canvas?.fileName).toBe("spec.md");
+    expect(visible.copyText).toBe(
+      ["spec.md", "\u201CThe legacy intro section\u201D", "rewrite this to be concise"].join("\n"),
+    );
+    expect(visible.copyText).not.toContain("canvas_request");
+    expect(visible.copyText).not.toContain("assistant_instructions");
+  });
+
+  test("never copies raw canvas XML when the user request is empty", () => {
+    const prompt = [
+      '<spreadsheet_canvas_request version="2" source="univer">',
+      '  <workbook file_name="Budget.xlsx" kind="xlsx">',
+      "    <active_sheet>Q1</active_sheet>",
+      '    <selection range="B2:B4" active_cell="B2">',
+      "      <value></value>",
+      "    </selection>",
+      "  </workbook>",
+      "  <user_request></user_request>",
+      "</spreadsheet_canvas_request>",
+    ].join("\n");
+    const visible = buildVisibleUserMessage(prompt);
+    expect(visible.canvas?.fileName).toBe("Budget.xlsx");
+    expect(visible.copyText).toBe("Budget.xlsx · Q1 · B2:B4");
+    expect(visible.copyText).not.toContain("spreadsheet_canvas_request");
+  });
+
+  test("degrades malformed canvas envelopes to a readable chip instead of raw markup", () => {
+    const malformed = '<canvas_request version="1" source="document">broken';
+    expect(parseCanvasRequest(malformed)).toBeNull();
+    expect(interpretCanvasRequest(malformed)?.surface).toBe("document");
+    const visible = buildVisibleUserMessage(malformed);
+    expect(visible.canvas).not.toBeNull();
+    expect(visible.copyText).toBe("Document");
+    expect(visible.copyText).not.toContain("<canvas_request");
+    expect(visible.bodyText).toBe("");
+  });
+
+  test("recovers a partial user request from a malformed canvas envelope", () => {
+    const malformed = [
+      '<canvas_request version="1">',
+      "  <user_request>please tighten the intro</user_request>",
+      "</canvas_request",
+    ].join("\n");
+    const visible = buildVisibleUserMessage(malformed);
+    expect(visible.canvas?.userRequest).toBe("please tighten the intro");
+    expect(visible.copyText).toContain("please tighten the intro");
+    expect(visible.copyText).not.toContain("<user_request>");
+  });
+
+  test("parses malformed Attached suffixes without copying persistence markup", () => {
+    const visible = buildVisibleUserMessage("Look at this\n\nAttached: [notes.txt");
+    expect(visible.bodyText).toBe("Look at this");
+    expect(visible.attachments.map((attachment) => attachment.displayName)).toEqual(["notes.txt"]);
+    expect(visible.copyText).toBe("Look at this\n\nnotes.txt");
+    expect(visible.copyText).not.toContain("Attached: [");
+  });
+
+  test("parses legacy canvas markdown through the same visible model", () => {
+    const legacy = [
+      "[Canvas Collaborative Edit]",
+      "Please edit the file `plan.md` (located at `/w/plan.md`) based on my instructions below.",
+      "",
+      "**Instructions:**",
+      "make the tone friendlier",
+      "",
+      "**Target Section / Selection:**",
+      "> Welcome to the project.",
+    ].join("\n");
+    const visible = buildVisibleUserMessage(legacy);
+    expect(visible.canvas?.fileName).toBe("plan.md");
+    expect(visible.copyText).toContain("plan.md");
+    expect(visible.copyText).toContain("make the tone friendlier");
+    expect(visible.copyText).not.toContain("[Canvas Collaborative Edit]");
+    expect(visible.copyText).not.toContain("**Instructions:**");
   });
 });

--- a/apps/desktop/test/feed-row-visible-message.test.tsx
+++ b/apps/desktop/test/feed-row-visible-message.test.tsx
@@ -1,0 +1,273 @@
+import { describe, expect, mock, test } from "bun:test";
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import type { SessionFeedItem } from "../../../src/shared/sessionSnapshot";
+import { buildCanvasDocumentPrompt } from "../src/lib/canvasRequest";
+import { ChatViewContext } from "../src/ui/chat/ChatViewContext";
+import type { MentionCatalog } from "../src/ui/chat/composerMentions";
+import { createDesktopCommandsMock } from "./helpers/mockDesktopCommands";
+import { setupJsdom } from "./jsdomHarness";
+
+const copyTextMock = mock(async (_text: string) => {});
+
+mock.module("../src/lib/desktopCommands", () =>
+  createDesktopCommandsMock({
+    copyText: copyTextMock,
+  }),
+);
+
+const { FeedRow, resolveUserAttachmentPreviewSrc } = await import("../src/ui/chat/FeedRow");
+
+const EMPTY_MENTION_CATALOG: MentionCatalog = {
+  items: [],
+  names: [],
+  kindByName: new Map(),
+};
+
+function userMessage(id: string, text: string): SessionFeedItem {
+  return {
+    id,
+    kind: "message",
+    role: "user",
+    ts: "2026-07-09T13:00:00.000Z",
+    text,
+  };
+}
+
+function renderFeedRow(
+  item: SessionFeedItem,
+  props: {
+    desktopBasePath?: string | null;
+  } = {},
+) {
+  return createElement(
+    ChatViewContext.Provider,
+    {
+      value: {
+        developerMode: false,
+        mentionCatalog: EMPTY_MENTION_CATALOG,
+      },
+    },
+    createElement(FeedRow, {
+      item,
+      ...props,
+    }),
+  );
+}
+
+function htmlFor(item: SessionFeedItem, desktopBasePath?: string | null): string {
+  return renderToStaticMarkup(renderFeedRow(item, { desktopBasePath }));
+}
+
+async function renderInteractive(item: SessionFeedItem) {
+  const harness = setupJsdom();
+  const container = harness.dom.window.document.getElementById("root");
+  if (!container) throw new Error("missing root");
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(renderFeedRow(item));
+  });
+  return { harness, container, root };
+}
+
+describe("FeedRow visible user messages", () => {
+  test("labels text-only, attachment-only, mixed, and canvas turns as authored by you", () => {
+    const cases = [
+      userMessage("text-only", "Please summarize this thread."),
+      userMessage("attachment-only", "[diagram.png]"),
+      userMessage("mixed", "Please review these.\n\nAttached: [diagram.png, findings.pdf]"),
+      userMessage(
+        "canvas",
+        buildCanvasDocumentPrompt({
+          path: "/w/spec.md",
+          fileName: "spec.md",
+          kind: "markdown",
+          selection: "Intro",
+          request: "tighten this",
+        }),
+      ),
+    ];
+
+    for (const item of cases) {
+      const html = htmlFor(item);
+      expect(html).toContain('role="article"');
+      expect(html).toContain('aria-label="Message from you"');
+      expect(html).toContain('data-slot="message" data-align="end"');
+      expect(html).toContain('data-slot="bubble" data-variant="tinted" data-align="end"');
+    }
+  });
+
+  test("keeps attachment-only turns inside the user bubble with named files", () => {
+    const html = htmlFor(userMessage("attachment-only", "[notes.txt, photo.png]"));
+    expect(html).toContain('data-slot="bubble-content"');
+    expect(html).toContain('data-slot="attachment-group"');
+    expect(html).toContain('aria-label="Attached files"');
+    expect(html).toContain("notes.txt");
+    expect(html).toContain("photo.png");
+    expect(html).not.toContain("[notes.txt, photo.png]");
+  });
+
+  test("renders image previews through cowork-media and never remote URLs", () => {
+    const html = htmlFor(userMessage("images", "[diagram.png, findings.pdf]"), "/Users/test/ws");
+    expect(html).toContain(
+      `src="cowork-media://media?path=${encodeURIComponent("/Users/test/ws/User Uploads/diagram.png")}"`,
+    );
+    expect(html).toContain("findings.pdf");
+    expect(html).not.toContain("https://");
+    expect(html.match(/data-slot="attachment"/g)).toHaveLength(2);
+  });
+
+  test("does not load unsafe remote image attachment names", () => {
+    const html = htmlFor(
+      userMessage("remote-image", "[https://evil.example/photo.png]"),
+      "/Users/test/ws",
+    );
+    expect(html).toContain("photo.png");
+    expect(html).not.toContain('src="https://evil.example/photo.png"');
+    expect(html).not.toContain("cowork-media:");
+  });
+
+  test("renders canvas requests without leaking the stored envelope", () => {
+    const html = htmlFor(
+      userMessage(
+        "canvas",
+        buildCanvasDocumentPrompt({
+          path: "/w/spec.md",
+          fileName: "spec.md",
+          kind: "markdown",
+          selection: "The legacy intro section",
+          request: "rewrite this to be concise",
+        }),
+      ),
+    );
+    expect(html).toContain("spec.md");
+    expect(html).toContain("rewrite this to be concise");
+    expect(html).not.toContain("canvas_request");
+    expect(html).not.toContain("assistant_instructions");
+  });
+
+  test("degrades malformed canvas payloads to a readable document chip", () => {
+    const html = htmlFor(userMessage("malformed-canvas", '<canvas_request version="1">broken'));
+    expect(html).toContain("Document");
+    expect(html).toContain('aria-label="Message from you"');
+    expect(html).not.toContain("&lt;canvas_request");
+    expect(html).not.toContain("<canvas_request version");
+  });
+});
+
+describe("resolveUserAttachmentPreviewSrc", () => {
+  test("encodes absolute local images and rejects remote schemes", () => {
+    expect(resolveUserAttachmentPreviewSrc("/Users/test/chart.png")).toBe(
+      "cowork-media://media?path=%2FUsers%2Ftest%2Fchart.png",
+    );
+    expect(
+      resolveUserAttachmentPreviewSrc("https://evil.example/photo.png", "/Users/test/ws"),
+    ).toBeNull();
+    expect(resolveUserAttachmentPreviewSrc("javascript:alert(1)", "/Users/test/ws")).toBeNull();
+    expect(resolveUserAttachmentPreviewSrc("../secret.png", "/Users/test/ws")).toBeNull();
+  });
+
+  test("resolves bare image filenames against the workspace uploads folder", () => {
+    expect(resolveUserAttachmentPreviewSrc("diagram.png", "/Users/test/ws")).toBe(
+      `cowork-media://media?path=${encodeURIComponent("/Users/test/ws/User Uploads/diagram.png")}`,
+    );
+  });
+});
+
+describe("FeedRow message copy", () => {
+  test("copies the visible mixed-message text instead of persistence markup", async () => {
+    copyTextMock.mockClear();
+    copyTextMock.mockImplementation(async () => {});
+    const { harness, container, root } = await renderInteractive(
+      userMessage("mixed-copy", "Please review these.\n\nAttached: [diagram.png, findings.pdf]"),
+    );
+    try {
+      const button = container.querySelector<HTMLButtonElement>(
+        'button[aria-label="Copy message"]',
+      );
+      if (!button) throw new Error("missing copy button");
+      await act(async () => {
+        button.click();
+        await Promise.resolve();
+      });
+      expect(copyTextMock).toHaveBeenCalledTimes(1);
+      expect(copyTextMock.mock.calls[0]?.[0]).toBe(
+        "Please review these.\n\nAttached: diagram.png, findings.pdf",
+      );
+      expect(copyTextMock.mock.calls[0]?.[0]).not.toContain("Attached: [");
+      expect(button.getAttribute("aria-label")).toBe("Copied");
+    } finally {
+      await act(async () => root.unmount());
+      harness.restore();
+    }
+  });
+
+  test("copies canvas-visible content instead of the stored XML envelope", async () => {
+    copyTextMock.mockClear();
+    copyTextMock.mockImplementation(async () => {});
+    const prompt = buildCanvasDocumentPrompt({
+      path: "/w/spec.md",
+      fileName: "spec.md",
+      kind: "markdown",
+      selection: "Intro",
+      request: "tighten this",
+    });
+    const { harness, container, root } = await renderInteractive(
+      userMessage("canvas-copy", prompt),
+    );
+    try {
+      const button = container.querySelector<HTMLButtonElement>(
+        'button[aria-label="Copy message"]',
+      );
+      if (!button) throw new Error("missing copy button");
+      await act(async () => {
+        button.click();
+        await Promise.resolve();
+      });
+      const copied = String(copyTextMock.mock.calls[0]?.[0] ?? "");
+      expect(copied).toContain("spec.md");
+      expect(copied).toContain("tighten this");
+      expect(copied).not.toContain("canvas_request");
+      expect(copied).not.toContain(prompt);
+    } finally {
+      await act(async () => root.unmount());
+      harness.restore();
+    }
+  });
+
+  test("surfaces clipboard failure and keeps copy retryable", async () => {
+    copyTextMock.mockClear();
+    copyTextMock.mockImplementation(async () => {
+      throw new Error("clipboard unavailable");
+    });
+    const { harness, container, root } = await renderInteractive(
+      userMessage("copy-fail", "Just the text"),
+    );
+    try {
+      const button = container.querySelector<HTMLButtonElement>(
+        'button[aria-label="Copy message"]',
+      );
+      if (!button) throw new Error("missing copy button");
+      await act(async () => {
+        button.click();
+        await Promise.resolve();
+      });
+      expect(button.getAttribute("aria-label")).toBe("Copy failed. Retry.");
+      expect(button.className).toContain("opacity-100");
+      expect(container.textContent).toContain("Couldn't copy message. Try again.");
+
+      copyTextMock.mockImplementation(async () => {});
+      await act(async () => {
+        button.click();
+        await Promise.resolve();
+      });
+      expect(copyTextMock).toHaveBeenCalledTimes(2);
+      expect(button.getAttribute("aria-label")).toBe("Copied");
+    } finally {
+      await act(async () => root.unmount());
+      harness.restore();
+    }
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes mweinbach/agent-coworker#247.

User turns now share one visible-message model for rendering, clipboard, and screen-reader authorship. Attachment-only and Canvas-request turns keep a normal user bubble, Copy matches what is on screen, and clipboard failure stays visible and retryable.

## What changed

- Parse persisted user text into a semantic model (`bodyText`, attachments, canvas, `copyText`) instead of copying raw storage markup.
- Always render user authorship (`role="article"` / `aria-label="Message from you"`) for text-only, attachment-only, mixed, and Canvas turns, including malformed/legacy envelopes.
- Copy the human-visible body, attachment names, and Canvas chips — never `Attached: [...]` brackets or Canvas XML.
- Show clipboard failure on the copy control with a live announcement and keep the action retryable.
- Preview supported image attachments through `cowork-media:` (absolute paths or workspace `User Uploads/`), and refuse remote/`javascript:`/`..` sources.

## Tests

- Text-only, attachment-only, mixed files, images, and Canvas requests
- Raw/legacy/malformed stored payloads
- Clipboard success and failure (including retry)
- Accessible message labeling for authored user turns

Targeted desktop tests covering these cases pass. Full CI lane (`bun run test`, `typecheck`, `lint`, `docs:check`) is next.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c3ff552a-284c-4704-af80-645b7414c528?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c3ff552a-284c-4704-af80-645b7414c528&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

